### PR TITLE
Fix Jest path mapping

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -22,8 +22,7 @@ const customJestConfig = {
     coverageReporters: ['html'],
     collectCoverageFrom: ['src/components/**/*.tsx'],
     moduleNameMapper: {
-        '^@/helpers(.*)$': '<rootDir>src/helpers/index.ts$1',
-        '^@/helpers(.*)$': '<rootDir>src/helpers/$1',
+        '^@/helpers(.*)$': '<rootDir>/src/helpers/$1',
         '^@/layout(.*)$': '<rootDir>src/components/Layout/index.tsx$1',
         '^@/test$': '<rootDir>/jest.setup.js',
         '^@/components(.*)$': '<rootDir>src/components/$1',


### PR DESCRIPTION
## Summary
- deduplicate mapping for `@/helpers`
- ensure tests still pass after config change

## Testing
- `npx jest src/helpers/__test__/helpers.test.tsx`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_684ed2dc97b88332a5506a088375a9a7