### PR TITLE
Add utility, hook, and page tests

### DIFF
--- a/src/helpers/__test__/helpers.test.tsx
+++ b/src/helpers/__test__/helpers.test.tsx
@@ -29,3 +29,43 @@ describe('clx', () => {
         expect(clx('a', true ? 'b' : '', false ? 'c' : '', undefined)).toBe('a b');
     });
 });
+
+describe('other helper utilities', () => {
+    const { isNotEng, cleanTrailingSlash, removeTrailingSlash, getLang } = require('..');
+
+    it('isNotEng should check default locale', () => {
+        expect(isNotEng('es')).toBe(true);
+        expect(isNotEng('en')).toBe(false);
+        expect(isNotEng(undefined)).toBe(true);
+    });
+
+    it('cleanTrailingSlash should remove only root slash', () => {
+        expect(cleanTrailingSlash('/')).toBe('');
+        expect(cleanTrailingSlash('/es')).toBe('/es');
+    });
+
+    it('removeTrailingSlash should trim slash at end', () => {
+        expect(removeTrailingSlash('path/')).toBe('path');
+        expect(removeTrailingSlash('path')).toBe('path');
+    });
+
+    it('getLang should prefix lang when not english', () => {
+        expect(getLang('es')).toBe('/es');
+        expect(getLang('en')).toBe('');
+    });
+
+    it('fetcher should resolve json or throw', async () => {
+        const { fetcher } = require('..');
+        (global.fetch as jest.Mock).mockResolvedValueOnce({
+            ok: true,
+            json: () => Promise.resolve({ a: 1 }),
+        });
+        await expect(fetcher('url')).resolves.toEqual({ a: 1 });
+
+        (global.fetch as jest.Mock).mockResolvedValueOnce({
+            ok: false,
+            statusText: 'Bad',
+        });
+        await expect(fetcher('url')).rejects.toThrow('Bad');
+    });
+});

--- a/src/hooks/__test__/useDarkMode.test.tsx
+++ b/src/hooks/__test__/useDarkMode.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen, fireEvent } from '@/test';
+import useDarkMode from '../useDarkMode';
+
+const TestComponent = () => {
+    const { theme, toggleTheme } = useDarkMode();
+    return (
+        <div>
+            <span data-testid="theme">{theme}</span>
+            <button onClick={toggleTheme}>toggle</button>
+        </div>
+    );
+};
+
+describe('useDarkMode hook', () => {
+    it('toggles theme values', () => {
+        render(<TestComponent />);
+        expect(screen.getByTestId('theme').textContent).toBe('');
+        fireEvent.click(screen.getByText('toggle'));
+        expect(screen.getByTestId('theme').textContent).toBe('dark');
+        fireEvent.click(screen.getByText('toggle'));
+        expect(screen.getByTestId('theme').textContent).toBe('light');
+    });
+});

--- a/src/pages/__test__/404.test.tsx
+++ b/src/pages/__test__/404.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@/test';
+import Custom404 from '../404';
+import { DialogProvider } from '@/context/dialog';
+
+describe('404 page', () => {
+    it('renders not found message', () => {
+        render(
+            <DialogProvider>
+                <Custom404 />
+            </DialogProvider>
+        );
+        expect(screen.getByText(/doesn\'t exist/i)).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Summary
- extend helper tests to cover more utilities
- add a component test for the 404 page
- add a test for the `useDarkMode` hook

## Testing
- `yarn coverage`

------
https://chatgpt.com/codex/tasks/task_e_684ed2d557f88332a760bb7b39c6134d