### PR TITLE
Update headers in Next config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 import { remarkCodeHike } from '@code-hike/mdx';
-import theme from 'shiki/themes/one-dark-pro.json' assert { type: 'json' };
+import theme from 'shiki/themes/one-dark-pro.json' with { type: 'json' };
 import nextMDX from '@next/mdx';
 
 const withMDX = nextMDX({
@@ -38,7 +38,6 @@ export default withMDX({
     },
     pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx'],
     experimental: {
-        appDir: false,
         largePageDataBytes: 800 * 1000,
     },
     images: {
@@ -55,13 +54,17 @@ export default withMDX({
         defaultLocale: 'en',
         localeDetection: false,
     },
-    headers: {
-        source: '/:path*',
-        headers: [
-            { key: "Access-Control-Allow-Credentials", value: "true" },
-            { key: "Access-Control-Allow-Origin", value: "*" },
-            { key: "Access-Control-Allow-Methods", value: "GET,OPTIONS,PATCH,DELETE,POST,PUT" },
-            { key: "Access-Control-Allow-Headers", value: "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version" },
-        ],
+    async headers() {
+        return [
+            {
+                source: '/:path*',
+                headers: [
+                    { key: 'Access-Control-Allow-Credentials', value: 'true' },
+                    { key: 'Access-Control-Allow-Origin', value: '*' },
+                    { key: 'Access-Control-Allow-Methods', value: 'GET,OPTIONS,PATCH,DELETE,POST,PUT' },
+                    { key: 'Access-Control-Allow-Headers', value: 'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version' },
+                ],
+            },
+        ];
     },
 });


### PR DESCRIPTION
## Summary
- provide JSON import 'with' syntax for shiki theme
- clean up obsolete appDir option
- export async `headers()` in Next config

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_684ed2b6036c83328f563001e82c88f9