### PR TITLE
Pin Node 18 usage

### DIFF
--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -16,7 +16,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 18.x
+                  node-version: 18.20.0
                   cache: yarn
             - name: Install dependencies
               run: |

--- a/.github/workflows/pre-deploy.yml
+++ b/.github/workflows/pre-deploy.yml
@@ -27,7 +27,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 18.x
+                  node-version: 18.20.0
                   cache: yarn
             - name: Install dependencies
               run: |
@@ -50,7 +50,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 18.x
+                  node-version: 18.20.0
                   cache: yarn
             - name: Install dependencies
               run: |
@@ -111,7 +111,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 18.x
+                  node-version: 18.20.0
                   cache: yarn
             - name: Install dependencies
               run: |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@
 
 ## Running Locally
 
-This application requires Node.js v18.20.0 or higher.
+This application requires **Node.js v18.20.0** (see `.nvmrc`).
+Until the Next.js 15 migration is complete, other versions are not supported.
 Yarn (Berry) is the official package manager for this project.
 
 ```bash
@@ -49,7 +50,8 @@ yarn dev
 
 ### Node.js Version
 
-This project uses Node.js v18.20.0. If you have `nvm` installed, you can use:
+This project is pinned to Node.js v18.20.0 until the Next.js 15 migration is complete.
+If you have `nvm` installed, you can use:
 
 ```bash
 nvm use


### PR DESCRIPTION
## Summary
- document Node 18 usage until Next.js 15 migration
- pin Node 18.20.0 in GitHub workflows

## Testing
- `yarn lint`
- `yarn test`
- `yarn dev` *(logged output then stopped)*

------
https://chatgpt.com/codex/tasks/task_e_684eecca915c8332a4cc9f3067d503bf