### PR TITLE
Add missing tests for hooks and components

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -20,7 +20,7 @@ const customJestConfig = {
     coverageDirectory: 'public/coverage',
     testEnvironment: 'jest-environment-jsdom',
     coverageReporters: ['html'],
-    collectCoverageFrom: ['src/components/**/*.tsx'],
+    collectCoverageFrom: ['src/components/**/*.tsx', 'src/hooks/**/*.ts'],
     moduleNameMapper: {
         '^@/helpers(.*)$': '<rootDir>/src/helpers/$1',
         '^@/layout(.*)$': '<rootDir>src/components/Layout/index.tsx$1',

--- a/src/components/DeploymentStatus/__test__/deploymentstatus.test.tsx
+++ b/src/components/DeploymentStatus/__test__/deploymentstatus.test.tsx
@@ -1,0 +1,26 @@
+import DeploymentStatus from '..';
+import { render, screen } from '@/test';
+import useSWR from 'swr';
+
+jest.mock('swr');
+
+const mockData = {
+    status: 'ready',
+    username: 'test',
+    environment: 'prod',
+    createdAt: new Date().toISOString(),
+};
+
+describe('DeploymentStatus component', () => {
+    it('renders status indicator', () => {
+        (useSWR as jest.Mock).mockReturnValue({ data: mockData, error: false });
+        const { container } = render(<DeploymentStatus />);
+        expect(container.querySelector('.status')).toBeInTheDocument();
+    });
+
+    it('renders error state', () => {
+        (useSWR as jest.Mock).mockReturnValue({ data: undefined, error: true });
+        render(<DeploymentStatus />);
+        expect(screen.getByTestId('error')).toBeInTheDocument();
+    });
+});

--- a/src/components/ErrorBoundary/__test__/errorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/__test__/errorBoundary.test.tsx
@@ -1,0 +1,17 @@
+import ErrorBoundary from '..';
+import { render, screen } from '@/test';
+
+const ProblemChild = () => {
+    throw new Error('boom');
+};
+
+describe('ErrorBoundary component', () => {
+    it('catches errors and renders fallback UI', () => {
+        render(
+            <ErrorBoundary>
+                <ProblemChild />
+            </ErrorBoundary>
+        );
+        expect(screen.getByText(/boom/)).toBeInTheDocument();
+    });
+});

--- a/src/hooks/__test__/useAnalytics.test.tsx
+++ b/src/hooks/__test__/useAnalytics.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@/test';
+import useAnalytics from '../useAnalytics';
+import useSWR from 'swr';
+
+jest.mock('swr');
+
+const TestComponent = () => {
+    const { data } = useAnalytics();
+    return <span data-testid="page-views">{data.pageViews}</span>;
+};
+
+describe('useAnalytics hook', () => {
+    it('returns analytics data', () => {
+        const mockData = { pageViews: 5, newUsers: 2 };
+        (useSWR as jest.Mock).mockReturnValue({ data: mockData, error: false, isLoading: false });
+        const expectedUrl = new URL('https://xabierlameiro.com/api/analytics');
+        expectedUrl.searchParams.set('slug', '/undefined');
+        render(<TestComponent />);
+        expect(useSWR).toHaveBeenCalledWith(expectedUrl, expect.any(Function), expect.any(Object));
+        expect(screen.getByTestId('page-views').textContent).toBe('5');
+    });
+});

--- a/src/hooks/__test__/useGithubStars.test.tsx
+++ b/src/hooks/__test__/useGithubStars.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@/test';
+import useGithubStars from '../useGithubStars';
+import useSWR from 'swr';
+
+jest.mock('swr');
+
+const TestComponent = () => {
+    const { data } = useGithubStars();
+    return <span data-testid="stars">{data}</span>;
+};
+
+describe('useGithubStars hook', () => {
+    it('returns stars count', () => {
+        (useSWR as jest.Mock).mockReturnValue({ data: 42, error: false, isLoading: false });
+        const expectedUrl = new URL('https://xabierlameiro.com/api/github-stars');
+        render(<TestComponent />);
+        expect(useSWR).toHaveBeenCalledWith(expectedUrl, expect.any(Function), expect.any(Object));
+        expect(screen.getByTestId('stars').textContent).toBe('42');
+    });
+});

--- a/src/hooks/__test__/useHeating.test.tsx
+++ b/src/hooks/__test__/useHeating.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@/test';
+import useHeating from '../useHeating';
+import useSWR from 'swr';
+
+jest.mock('swr');
+
+const TestComponent = () => {
+    const { data } = useHeating();
+    return <span data-testid="temp">{data.outsideTemp}</span>;
+};
+
+describe('useHeating hook', () => {
+    it('returns heating data', () => {
+        (useSWR as jest.Mock).mockReturnValue({ data: { outsideTemp: 10 }, error: false, isLoading: false });
+        const expectedUrl = new URL('https://xabierlameiro.com/api/heating');
+        render(<TestComponent />);
+        expect(useSWR).toHaveBeenCalledWith(expectedUrl, expect.any(Function), expect.any(Object));
+        expect(screen.getByTestId('temp').textContent).toBe('10');
+    });
+});

--- a/src/hooks/__test__/useIndexedPages.test.tsx
+++ b/src/hooks/__test__/useIndexedPages.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@/test';
+import useIndexedPages from '../useIndexedPages';
+import useSWR from 'swr';
+
+jest.mock('swr');
+
+const TestComponent = () => {
+    const { data } = useIndexedPages();
+    return <span data-testid="num">{data.num}</span>;
+};
+
+describe('useIndexedPages hook', () => {
+    it('returns indexed pages count', () => {
+        (useSWR as jest.Mock).mockReturnValue({ data: { num: 1 }, error: false, isLoading: false });
+        const expectedUrl = new URL('https://xabierlameiro.com/api/indexed-pages');
+        render(<TestComponent />);
+        expect(useSWR).toHaveBeenCalledWith(expectedUrl, expect.any(Function), expect.any(Object));
+        expect(screen.getByTestId('num').textContent).toBe('1');
+    });
+});

--- a/src/hooks/__test__/useWeather.test.tsx
+++ b/src/hooks/__test__/useWeather.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@/test';
+import useWeather from '../useWeather';
+import useSWR from 'swr';
+
+jest.mock('swr');
+
+const TestComponent = () => {
+    const { data } = useWeather(['london', 'paris']);
+    return <span data-testid="city">{data[0].city}</span>;
+};
+
+describe('useWeather hook', () => {
+    it('returns weather data for cities', () => {
+        const mockData = [{ city: 'london' }];
+        (useSWR as jest.Mock).mockReturnValue({ data: mockData, error: false, isLoading: false });
+        const expectedUrl = new URL('https://xabierlameiro.com/api/weather');
+        expectedUrl.searchParams.append('cities', 'london,paris');
+        render(<TestComponent />);
+        expect(useSWR).toHaveBeenCalledWith(expectedUrl, expect.any(Function), expect.any(Object));
+        expect(screen.getByTestId('city').textContent).toBe('london');
+    });
+});


### PR DESCRIPTION
## Summary
- add unit tests for DeploymentStatus and ErrorBoundary
- add unit tests for several custom hooks
- include hooks folder in coverage collection

## Testing
- `npx jest --silent`

------
https://chatgpt.com/codex/tasks/task_e_684eecd6b95883329d3b6ca829e11972