### PR TITLE
Use built-in fetch API

### DIFF
--- a/searchConsole.js
+++ b/searchConsole.js
@@ -1,5 +1,4 @@
 // Usage: `node searchConsole.js`
-import fetch from 'node-fetch';
 
 export const sendSitemapToSearchConsole = async () => {
     try {


### PR DESCRIPTION
## Summary
- remove `node-fetch` import and rely on Node's built-in `fetch`

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684eecd9b4dc8332995d73df0e59e28a