### PR TITLE
feat: update home bio to Software Architect and refresh experience/tech years

### DIFF
--- a/data/home/desktop.en.mdx
+++ b/data/home/desktop.en.mdx
@@ -13,7 +13,7 @@ const App = ({ name = 'Xabier Lameiro' }: Props) => {
         <main className={`${styles.experience} ${styles.education}`}>
             <h1>👋, my name is {name}!</h1>
             <p>
-                I&apos;m Frontend developer. I have worked in the banking and retail
+                I&apos;m a Software Architect. I have worked in the banking and retail
                 sector for companies like CaixaBank, Openbak and Inditex. I like web 
                 development, applications, automations and the IOT.
             </p>
@@ -26,17 +26,17 @@ export { App, App as default };
 
 ```css knowledge.module.css
 :root {
-    --html-css : 6 years;
-    --javascript : 6 years;
-    --typescript : 4.5 years;
-    --react : 4.5 years;
+    --html-css : 8.4 years;
+    --javascript : 8.4 years;
+    --typescript : 6.9 years;
+    --react : 6.9 years;
     --redux : 3 years;
-    --nextjs : 3.5 years;
+    --nextjs : 5.9 years;
     --gatsby : 1.5 years;
 }
 
 .experience {
-    Hiberus : 1 year !important;
+    Hiberus : 3.4 years !important;
     Plexus Tech : 2 years;
     Orienteed : 1.5 years;
     Viewnext  : 1.5 years;

--- a/data/home/desktop.es.mdx
+++ b/data/home/desktop.es.mdx
@@ -13,7 +13,7 @@ const App = ({ name = 'Xabier Lameiro' }: Props) => {
         <main className={`${styles.experience} ${styles.education}`}>
             <h1>👋, me llamo {name}!</h1>
             <p>
-                Soy desarrollador Frontend. He trabajado y trabajo en el sector
+                Soy Software Architect. He trabajado y trabajo en el sector
                 bancario y retail para empresas como CaixaBank, Openbak e Inditex.
                 Me gusta el desarrollo aplicaciones, automatizaciones y el IoT.
             </p>
@@ -26,17 +26,17 @@ export { App, App as default };
 
 ```css knowledge.module.css
 :root {
-    --html-css : 6 años;
-    --javascript : 6 años;
-    --typescript : 4.5 años;
-    --react : 4.5 años;
+    --html-css : 8.4 años;
+    --javascript : 8.4 años;
+    --typescript : 6.9 años;
+    --react : 6.9 años;
     --redux : 3 años;
-    --nextjs : 3.5 años;
+    --nextjs : 5.9 años;
     --gatsby : 1.5 años;
 }
 
 .experience {
-    Hiberus : 1 año !important;
+    Hiberus : 3.4 años !important;
     Plexus Tech : 2 años;
     Orienteed : 1.5 años;
     Viewnext  : 1.5 años;

--- a/data/home/desktop.gl.mdx
+++ b/data/home/desktop.gl.mdx
@@ -13,7 +13,7 @@ const App = ({ name = 'Xabier Lameiro' }: Props) => {
         <main className={`${styles.experience} ${styles.education}`}>
             <h1>👋, chámome {name}!</h1>
             <p>
-                Son desarrollador Frontend. Traballei e traballo no sector bancario
+                Son Software Architect. Traballei e traballo no sector bancario
                 e retail para empresas como CaixaBank, Openbak e Inditex. Gústame 
                 o desenvolvemento de aplicacións, as automatizacións e o IoT.
             </p>
@@ -26,17 +26,17 @@ export { App, App as default };
 
 ```css knowledge.module.css
 :root {
-    --html-css : 6 anos;
-    --javascript : 6 anos;
-    --typescript : 4.5 anos;
-    --react : 4.5 anos;
+    --html-css : 8.4 anos;
+    --javascript : 8.4 anos;
+    --typescript : 6.9 anos;
+    --react : 6.9 anos;
     --redux : 3 anos;
-    --nextjs : 3.5 anos;
+    --nextjs : 5.9 anos;
     --gatsby : 1.5 anos;
 }
 
 .experience {
-    Hiberus : 1 ano !important;
+    Hiberus : 3.4 anos !important;
     Plexus Tech : 2 anos;
     Orienteed : 1.5 anos;
     Viewnext  : 1.5 anos;

--- a/data/home/mobile.en.mdx
+++ b/data/home/mobile.en.mdx
@@ -16,7 +16,7 @@ const App = ({ name = name }: Props) => {
    <h1>👋, my name is {name}!</h1>
 
    <p className={`${styles.education}`}>
-     I&apos;m Frontend developer. 
+     I&apos;m a Software Architect. 
      I have worked in the banking and 
      retail sector for companies like CaixaBank, 
      Openbak and Inditex. I like
@@ -32,17 +32,17 @@ export { App, App as default };
 
 ```css knowledge.module.css
 :root {
-  --html-css : 6 years;
-  --javascript : 6 years;
-  --typescript : 4.5 years;
-  --react : 4.5 years;
+  --html-css : 8.4 years;
+  --javascript : 8.4 years;
+  --typescript : 6.9 years;
+  --react : 6.9 years;
   --redux : 3 years;
-  --nextjs : 3.5 years;
+  --nextjs : 5.9 years;
   --gatsby : 1.5 years;
 }
 
 .experience {
-  Hiberus / Spain : 1 year !important;
+  Hiberus / Spain : 3.4 years !important;
   Plexus Tech / Spain : 2 years;
   Orienteed / Spain : 1.5 years;
   Viewnext / Spain  : 1.5 years;

--- a/data/home/mobile.es.mdx
+++ b/data/home/mobile.es.mdx
@@ -16,7 +16,7 @@ const App = ({ name = name }: Props) => {
    <h1>👋, me llamo {name}!</h1>
 
    <p className={`${styles.education}`}>
-     Soy desarrollador Frontend. 
+     Soy Software Architect. 
      Nací y crecí en Galicia pero
      actualmente vivo en Irlanda, 
      intentando mejorar mi inglés. 
@@ -32,17 +32,17 @@ export { App, App as default };
 
 ```css knowledge.module.css
 :root {
-  --html-css : 6 años;
-  --javascript : 6 años;
-  --typescript : 4.5 años;
-  --react : 4.5 años;
+  --html-css : 8.4 años;
+  --javascript : 8.4 años;
+  --typescript : 6.9 años;
+  --react : 6.9 años;
   --redux : 3 años;
-  --nextjs : 3.5 años;
+  --nextjs : 5.9 años;
   --gatsby : 1.5 años;
 }
 
 .experience {
-  Hiberus : 1 año !important;
+  Hiberus : 3.4 años !important;
   Plexus Tech : 2 años;
   Orienteed : 1.5 años;
   Viewnext  : 1.5 años;

--- a/data/home/mobile.gl.mdx
+++ b/data/home/mobile.gl.mdx
@@ -16,7 +16,7 @@ const App = ({ name = name }: Props) => {
    <h1>👋, chámome {name}!</h1>
 
    <p className={`${styles.education}`}>
-      Son un programador frontend.
+      Son Software Architect.
       Nacín e criei en Galiza pero
       actualmente vivo en Irlanda,
       intentando mellorar o meu inglés.
@@ -32,17 +32,17 @@ export { App, App as default };
 
 ```css knowledge.module.css
 :root {
-  --html-css : 6 anos;
-  --javascript : 6 anos;
-  --typescript : 4.5 anos;
-  --react : 4.5 anos;
+  --html-css : 8.4 anos;
+  --javascript : 8.4 anos;
+  --typescript : 6.9 anos;
+  --react : 6.9 anos;
   --redux : 3 anos;
-  --nextjs : 3.5 anos;
+  --nextjs : 5.9 anos;
   --gatsby : 1.5 anos;
 }
 
 .experience {
-  Hiberus : 1 ano !important;
+  Hiberus : 3.4 anos !important;
   Plexus Tech : 2 anos;
   Orienteed : 1.5 anos;
   Viewnext : 1.5 anos;

--- a/e2e/landing-page.test.ts
+++ b/e2e/landing-page.test.ts
@@ -14,7 +14,7 @@ test.afterAll(async () => {
 test.describe('Landing page', () => {
     test('should navigate to landing page', async () => {
         await page.goto('/');
-        await expect(page).toHaveTitle(/Front end developer, microcomputing and networks Technician/);
+        await expect(page).toHaveTitle(/Software Architect, microcomputing and networks Technician/);
     });
     test('should check if the header, main and footer are visible', async () => {
         await page.getByTestId('header').isVisible();

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
                 "gray-matter": "^4.0.3",
                 "next": "^15.5.9",
                 "next-env": "^1.1.1",
-                "next-mdx-remote": "^5.0.0",
+                "next-mdx-remote": "^6.0.0",
                 "nodemailer": "^7.0.11",
                 "octokit": "^3.1.2",
                 "react": "^19.1.0",
@@ -128,7 +128,6 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
             "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.27.1",
@@ -4056,7 +4055,6 @@
             "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-2.3.0.tgz",
             "integrity": "sha512-zQH//gdOmuu7nt2oJR29vFhDv88oGPmVw6BggmrHeMI+xgEkp1B2dX9/bMBSYtK0dyLX/aOmesKS09g222K1/g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/mdx": "^2.0.0",
                 "@types/react": ">=16"
@@ -4491,7 +4489,6 @@
             "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
             "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@octokit/auth-token": "^4.0.0",
                 "@octokit/graphql": "^7.1.0",
@@ -4744,9 +4741,8 @@
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
             "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -4770,7 +4766,6 @@
             "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=14"
             },
@@ -4784,7 +4779,6 @@
             "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@opentelemetry/semantic-conventions": "1.28.0"
             },
@@ -4811,7 +4805,6 @@
             "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@opentelemetry/api-logs": "0.57.2",
                 "@types/shimmer": "^1.2.0",
@@ -5242,7 +5235,6 @@
             "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@opentelemetry/core": "1.30.1",
                 "@opentelemetry/semantic-conventions": "1.28.0"
@@ -5270,7 +5262,6 @@
             "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@opentelemetry/core": "1.30.1",
                 "@opentelemetry/resources": "1.30.1",
@@ -5299,7 +5290,6 @@
             "integrity": "sha512-TtxJSRD8Ohxp6bKkhrm27JRHAxPczQA7idtcTOMYI+wQRRrfgqxHv1cFbCApcSnNjtXkmzFozn6jQtFrOmbjPQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=14"
             }
@@ -5335,9 +5325,8 @@
             "version": "1.57.0",
             "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
             "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "playwright": "1.57.0"
             },
@@ -5935,7 +5924,6 @@
             "integrity": "sha512-p3DqQi+8QRL5k7jXhXmJZLsE/GqHqyY6PcoA1oNTJr0try48uhTGUOYkgzmqtDaa/qPFO5LP+xCPzZXckGtquQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@storybook/api": "6.5.16",
                 "@storybook/channels": "6.5.16",
@@ -5964,7 +5952,6 @@
             "integrity": "sha512-HOsuT8iomqeTMQJrRx5U8nsC7lJTwRr1DhdD0SzlqL4c80S/7uuCy4IZvOt4sYQjOzW5fOo/kamcoBXyLproTA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@storybook/channels": "6.5.16",
                 "@storybook/client-logger": "6.5.16",
@@ -6103,7 +6090,6 @@
             "integrity": "sha512-HNR2mC5I4Z5ek8kTrVZlIY/B8gJGs5b3XdZPBPBopTIN6U/YHXiDyOjY3JlaS4fSG1fVhp/Qp1TpMn1w/9m1pw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/storybook"
@@ -6150,7 +6136,6 @@
             "integrity": "sha512-qMZQwmvzpH5F2uwNUllTPg6eZXr2OaYZQRRN8VZJiuorZzDNdAFmiVWMWdkThwmyLEJuQKXxqCL8lMj/7PPM+g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "core-js": "^3.8.2"
             },
@@ -6800,7 +6785,6 @@
             "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
@@ -6883,7 +6867,6 @@
             "integrity": "sha512-hNLctkjaYLRdk1+xYTkC1mg4dYz2wSv6SqbLpcKMbkPHTE0ElhddGPHQqB362md/w9emYXNkt1LSMD8Xk9JzVQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@storybook/client-logger": "6.5.16",
                 "core-js": "^3.8.2",
@@ -6914,7 +6897,6 @@
             "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
@@ -7445,7 +7427,6 @@
             "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/linkify-it": "^5",
                 "@types/mdurl": "^2"
@@ -7518,7 +7499,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.5.tgz",
             "integrity": "sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -7643,7 +7623,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
             "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "csstype": "^3.0.2"
             }
@@ -7653,7 +7632,6 @@
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
             "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@types/react": "^19.0.0"
             }
@@ -7876,7 +7854,6 @@
             "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.38.0",
                 "@typescript-eslint/types": "8.38.0",
@@ -8632,7 +8609,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -8737,7 +8713,6 @@
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -9777,7 +9752,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001726",
                 "electron-to-chromium": "^1.5.173",
@@ -11093,8 +11067,7 @@
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1464554.tgz",
             "integrity": "sha512-CAoP3lYfwAGQTaAXYvA6JZR0fjGUb7qec1qf4mToyoH2TZgUFeIqYcjh6f9jNuhHfuZiEdH+PONHYrLhRQX6aw==",
             "dev": true,
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/diff": {
             "version": "5.2.0",
@@ -11753,7 +11726,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -11849,7 +11821,6 @@
             "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -12037,7 +12008,6 @@
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.9",
@@ -20747,7 +20717,6 @@
             "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
             "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@next/env": "15.5.9",
                 "@swc/helpers": "0.5.15",
@@ -20805,15 +20774,16 @@
             }
         },
         "node_modules/next-mdx-remote": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/next-mdx-remote/-/next-mdx-remote-5.0.0.tgz",
-            "integrity": "sha512-RNNbqRpK9/dcIFZs/esQhuLA8jANqlH694yqoDBK8hkVdJUndzzGmnPHa2nyi90N4Z9VmzuSWNRpr5ItT3M7xQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/next-mdx-remote/-/next-mdx-remote-6.0.0.tgz",
+            "integrity": "sha512-cJEpEZlgD6xGjB4jL8BnI8FaYdN9BzZM4NwadPe1YQr7pqoWjg9EBCMv3nXBkuHqMRfv2y33SzUsuyNh9LFAQQ==",
             "license": "MPL-2.0",
             "dependencies": {
                 "@babel/code-frame": "^7.23.5",
                 "@mdx-js/mdx": "^3.0.1",
                 "@mdx-js/react": "^3.0.1",
-                "unist-util-remove": "^3.1.0",
+                "unist-util-remove": "^4.0.0",
+                "unist-util-visit": "^5.1.0",
                 "vfile": "^6.0.1",
                 "vfile-matter": "^5.0.0"
             },
@@ -21612,9 +21582,9 @@
             }
         },
         "node_modules/next-mdx-remote/node_modules/unist-util-visit": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
-            "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+            "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",
@@ -23030,7 +23000,7 @@
             "version": "1.57.0",
             "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
             "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "playwright-core": "1.57.0"
@@ -23049,7 +23019,7 @@
             "version": "1.57.0",
             "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
             "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "playwright-core": "cli.js"
@@ -23062,6 +23032,7 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -23128,7 +23099,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -23313,7 +23283,6 @@
             "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "prettier": "bin-prettier.js"
             },
@@ -23741,7 +23710,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
             "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -23827,7 +23795,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
             "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "scheduler": "^0.26.0"
             },
@@ -23893,7 +23860,6 @@
             "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -24827,7 +24793,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -25365,7 +25330,6 @@
             "integrity": "sha512-Ob7DMlwWx8s7dMvcQ3xPc02TvUeralb+xX3oaPRk9wY9Hc6M1IBC/7cEoITkSmRS2v38DHubC+mtEKNc1u2gQg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@storybook/core": "8.6.15"
             },
@@ -26178,7 +26142,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -26457,7 +26420,6 @@
             "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
-            "peer": true,
             "engines": {
                 "node": ">=12.20"
             },
@@ -26555,7 +26517,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
             "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -26734,14 +26695,14 @@
             "license": "MIT"
         },
         "node_modules/unist-util-remove": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-3.1.1.tgz",
-            "integrity": "sha512-kfCqZK5YVY5yEa89tvpl7KnBBHu2c6CzMkqHUrlOqaRgGOMp0sMvwWOVrbAtj03KhovQB7i96Gda72v/EFE0vw==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-4.0.0.tgz",
+            "integrity": "sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==",
             "license": "MIT",
             "dependencies": {
-                "@types/unist": "^2.0.0",
-                "unist-util-is": "^5.0.0",
-                "unist-util-visit-parents": "^5.0.0"
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0",
+                "unist-util-visit-parents": "^6.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -26756,6 +26717,39 @@
             "dependencies": {
                 "@types/unist": "^2.0.0",
                 "unist-util-visit": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-remove/node_modules/@types/unist": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+            "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+            "license": "MIT"
+        },
+        "node_modules/unist-util-remove/node_modules/unist-util-is": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+            "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-remove/node_modules/unist-util-visit-parents": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+            "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -27192,7 +27186,6 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.100.2.tgz",
             "integrity": "sha512-QaNKAvGCDRh3wW1dsDjeMdDXwZm2vqq3zn6Pvq4rHOEOGSaUMgOOjG2Y9ZbIGzpfkJk9ZYTHpDqgDfeBDcnLaw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -27271,7 +27264,6 @@
             "integrity": "sha512-khZGfAeJx6I8K9zKohEWWYN6KDlVw2DHownoe+6Vtwj1LP9WFgegXnVMSkZ/dBEBtXFwrkkydsaPFlB7f8wU2A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-html-community": "0.0.8",
                 "html-entities": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "gray-matter": "^4.0.3",
         "next": "^15.5.9",
         "next-env": "^1.1.1",
-        "next-mdx-remote": "^5.0.0",
+        "next-mdx-remote": "^6.0.0",
         "nodemailer": "^7.0.11",
         "octokit": "^3.1.2",
         "react": "^19.1.0",

--- a/src/helpers/mdx.ts
+++ b/src/helpers/mdx.ts
@@ -20,6 +20,12 @@ export const serializePath = (route: string, fileName: string) => {
     const mdx = fs.readFileSync(filePath, 'utf8');
 
     return sz(mdx, {
+        // MDX content is first-party (authored in this repo), so JS expressions
+        // are trusted. next-mdx-remote v6 blocks them by default, which breaks
+        // Code Hike's compiled output; re-enable JS while keeping the guard
+        // against dangerous globals (eval/Function/require/...).
+        blockJS: false,
+        blockDangerousJS: true,
         mdxOptions: {
             remarkPlugins: [[remarkCodeHike, { autoImport: false, theme }]],
             useDynamicImport: true,
@@ -39,6 +45,10 @@ export const serializePath = (route: string, fileName: string) => {
  */
 export const serialize = (mdx: string) =>
     sz(mdx, {
+        // See serializePath: trusted first-party MDX, so allow JS expressions
+        // (required by Code Hike) while blocking dangerous globals.
+        blockJS: false,
+        blockDangerousJS: true,
         mdxOptions: {
             remarkPlugins: [[remarkCodeHike, { autoImport: false, theme }]],
             useDynamicImport: true,

--- a/src/intl/translations.ts
+++ b/src/intl/translations.ts
@@ -8,14 +8,14 @@ export const messages = {
         'blog.tags': 'Tags',
         language: 'English',
         'home.breadcrumb': 'Code',
-        'home.seo.title': 'Front end developer, microcomputing and networks Technician',
+        'home.seo.title': 'Software Architect, microcomputing and networks Technician',
         'home.seo.description':
-            "I'm a developer with more than 5 years of experience working in the online banking sector, currently specialized in Nextjs and React. Passionate about technology and programming, I like to learn new things and share knowledge with the community.",
+            "I'm a Software Architect with more than 8 years of experience working in the online banking sector, currently specialized in Nextjs and React. Passionate about technology and programming, I like to learn new things and share knowledge with the community.",
         'settings.seo.title': 'Customized language, theme and region preferences for a web application',
         'settings.seo.description':
             'Web page for user preferences settings for your experience on the web, allows you to change the language, theme and region',
         'settings.title': 'System Preferences',
-        'settings.desc': 'Web application developer, microcomputing and networks',
+        'settings.desc': 'Software Architect, web applications, microcomputing and networks',
         'settings.lang': 'Language & Region',
         'settings.langAlt': 'Language & Region Icon',
         'settings.lang.preferred': 'Preferred languages:',
@@ -84,16 +84,16 @@ export const messages = {
         'blog.readHits': '{hits} visitas',
         'blog.breadcrumb': 'Notas',
         language: 'Español',
-        'home.seo.title': 'Desarrollador front end, técnico en microinformática y redes',
+        'home.seo.title': 'Software Architect, técnico en microinformática y redes',
         'home.seo.description':
-            'Programador con más de 5 años de experencia trabajando en el sector de la banca online, actualmente especializado en Nextjs y React. Apasionado de la tecnología y la programación, me gusta aprender cosas nuevas y compartir conocimientos con la comunidad. ',
+            'Software Architect con más de 8 años de experiencia trabajando en el sector de la banca online, actualmente especializado en Nextjs y React. Apasionado de la tecnología y la programación, me gusta aprender cosas nuevas y compartir conocimientos con la comunidad. ',
         'home.breadcrumb': 'Código',
         'settings.seo.title':
             'Configuración de preferencias de idioma, tema y región personalizada para una aplicación web',
         'settings.seo.description':
             'Pagina web de configuración de preferencias de usuario para su experiencia en la web, permite cambiar el idioma, el tema y la región',
         'settings.title': 'Preferencias del sistema',
-        'settings.desc': 'Desarrollador de aplicaciones web, microinformática y redes',
+        'settings.desc': 'Software Architect, aplicaciones web, microinformática y redes',
         'settings.lang': 'Idioma y Región',
         'settings.langAlt': 'Icono de Idioma y Región',
         'settings.lang.preferred': 'Idiomas preferidos:',
@@ -162,16 +162,16 @@ export const messages = {
         'blog.readHits': '{hits} visitas',
         'blog.breadcrumb': 'Notas',
         language: 'Galego',
-        'home.seo.title': 'Desenvolvedor front end, técnico en microinformática e redes',
+        'home.seo.title': 'Software Architect, técnico en microinformática e redes',
         'home.breadcrumb': 'Código',
         'home.seo.description':
-            'Programador con máis de 5 anos de experiencia traballando no sector da banca online, actualmente especializado en Nextjs e React. Apasionado da tecnoloxía e a programación, gustame aprender cousas novas e compartir coñecemento coa comunidade. ',
+            'Software Architect con máis de 8 anos de experiencia traballando no sector da banca online, actualmente especializado en Nextjs e React. Apasionado da tecnoloxía e a programación, gustame aprender cousas novas e compartir coñecemento coa comunidade. ',
         'settings.seo.title':
             'Configuración de preferencias de idioma, tema e rexión personalizada para unha aplicación web',
         'settings.seo.description':
             'Páxina web de configuración de preferencias de usuario para a súa experiencia na web, permite cambiar o idioma, o tema e a rexión',
         'settings.title': 'Preferencias do sistema',
-        'settings.desc': 'Desenvolvedor de aplicacións web, microinformática e redes',
+        'settings.desc': 'Software Architect, aplicacións web, microinformática e redes',
         'settings.lang': 'Idioma e Rexión',
         'settings.langAlt': 'Icono de Idioma e Rexión',
         'settings.lang.preferred': 'Idiomas preferidos:',

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -46,7 +46,7 @@ const Document = (props: Props) => {
                             sameAs: socialNetworks,
                             email: 'mailto:xabier.lameiro@gmail.com',
                             image: '/profile.png',
-                            jobTitle: 'Front-end Developer',
+                            jobTitle: 'Software Architect',
                             address: {
                                 '@type': 'PostalAddress',
                                 addressLocality: 'As Cortiñas, Moraña',


### PR DESCRIPTION
## Summary

Updates the home page content (stale since the last content refresh in March 2024) and, along the way, resolves a Vercel deploy blocker caused by a security advisory on `next-mdx-remote@5`.

## Content changes

- **Bio / role**: `Frontend developer` → `Software Architect` across all home files (desktop + mobile, `en`/`es`/`gl`).
- **Work experience**: added the elapsed time to the Hiberus tenure (`1 year` → `3.4 years`), the current role.
- **Technologies**: added ~2.4 years to the actively used stack — `html/css`, `javascript`, `typescript`, `react`, `nextjs`. `redux` and `gatsby` left unchanged.
- **SEO / metadata**: updated `home.seo.title`, `home.seo.description` ("more than 5 years" → "more than 8 years"), and `settings.desc` in `translations.ts`, plus the JSON-LD `jobTitle` in `_document.tsx`.
- **Tests**: updated the landing-page e2e title assertion to match the new SEO title.

## Dependency fix (unblocks Vercel deploy)

Vercel rejected the preview deploy with `VULNERABLE_NEXTMDXREMOTE_VERSION` (CVE-2026-0969) — it blocks any deployment using `next-mdx-remote@5.0.0`. There is no patched 5.x, so this bumps to `^6.0.0`.

v6 introduces `blockJS`/`blockDangerousJS` serialize options that default to `true` (the CVE fix), which strips the JS expressions Code Hike's compiled output relies on and crashed blog/home prerendering (`Cannot read properties of undefined (reading 'length')`). Since all MDX is first-party content authored in this repo, `serialize`/`serializePath` now pass `blockJS: false` while keeping `blockDangerousJS: true` for defense-in-depth.

Verified locally: `npm run build` generates all 104 pages, `npm run lint` clean, and the full Jest suite (81 tests) passes.

## Files touched

- `data/home/{desktop,mobile}.{en,es,gl}.mdx`
- `src/intl/translations.ts`
- `src/pages/_document.tsx`
- `e2e/landing-page.test.ts`
- `src/helpers/mdx.ts`
- `package.json`, `package-lock.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gw96rxTmKB7qER8C1ZnC7q