### PR TITLE
fix: runtime 500s on non-ASCII slugs, harden heating API, Node 22 in CI

### DIFF
--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -14,7 +14,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 18.20.0
+                  node-version: 22
                   cache: npm
             - name: Install dependencies
               run: |

--- a/.github/workflows/pre-deploy.yml
+++ b/.github/workflows/pre-deploy.yml
@@ -22,7 +22,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 18.20.0
+                  node-version: 22
                   cache: npm
             - name: Install dependencies
               run: |
@@ -43,7 +43,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 18.20.0
+                  node-version: 22
                   cache: npm
             - name: Install dependencies
               run: |
@@ -108,7 +108,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 18.20.0
+                  node-version: 22
                   cache: npm
             - name: Install dependencies
               run: |

--- a/package.json
+++ b/package.json
@@ -95,8 +95,8 @@
         "storybook-react-intl": "^1.1.1"
     },
     "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": ">=20.0.0",
+        "npm": ">=10.0.0"
     },
     "overrides": {
         "@storybook/addon-actions": {

--- a/src/helpers/fileReader.ts
+++ b/src/helpers/fileReader.ts
@@ -49,17 +49,21 @@ const findPostBySlug = (slug: string | { params: { slug: string } }) => {
     if (!slug || typeof slug !== 'string' || slug.includes('..') || slug.includes('/') || slug.includes('\\')) {
         throw new Error('Invalid slug parameter');
     }
-    
+
+    // Slugs with non-ASCII characters (e.g. "compoñentes") may arrive NFD-decomposed
+    // from some clients/crawlers while the frontmatter stores them NFC-composed
+    const normalizedSlug = slug.normalize('NFC');
+
     const [route] = paths.filter((filePath) => {
         // Ensure the file path is within the POST_PATH directory
         if (!filePath.startsWith(POST_PATH)) {
             return false;
         }
-        
+
         const document = fs.readFileSync(filePath, 'utf8');
         const { data } = matter(document);
         const fileName = filePath.split('/').pop();
-        if (data.slug === slug || fileName === `${slug}.mdx`) {
+        if (data.slug?.normalize('NFC') === normalizedSlug || fileName?.normalize('NFC') === `${normalizedSlug}.mdx`) {
             return true;
         }
     });

--- a/src/helpers/fileReader.ts
+++ b/src/helpers/fileReader.ts
@@ -63,9 +63,7 @@ const findPostBySlug = (slug: string | { params: { slug: string } }) => {
         const document = fs.readFileSync(filePath, 'utf8');
         const { data } = matter(document);
         const fileName = filePath.split('/').pop();
-        if (data.slug?.normalize('NFC') === normalizedSlug || fileName?.normalize('NFC') === `${normalizedSlug}.mdx`) {
-            return true;
-        }
+        return data.slug?.normalize('NFC') === normalizedSlug || fileName?.normalize('NFC') === `${normalizedSlug}.mdx`;
     });
     
     if (!route) {

--- a/src/pages/api/heating.ts
+++ b/src/pages/api/heating.ts
@@ -38,8 +38,12 @@ export default allowCors(async function handler(
         })
             .then(async (response) => {
                 const cookies = response.headers.get('set-cookie');
-                const token = cookies?.split('ar.loggedUser=')[1].split(';')[0];
-                const appCookie = cookies?.split('.AspNet.ApplicationCookie=')[1].split(';')[0];
+                const token = cookies?.split('ar.loggedUser=')[1]?.split(';')[0];
+                const appCookie = cookies?.split('.AspNet.ApplicationCookie=')[1]?.split(';')[0];
+
+                if (!token || !appCookie) {
+                    throw new Error(`Ariston login failed (status ${response.status}): session cookies missing`);
+                }
 
                 const data = await fetch(
                     'https://www.ariston-net.remotethermo.com/R2/PlantHome/GetData/A8032A1A96D4?umsys=si',
@@ -53,7 +57,10 @@ export default allowCors(async function handler(
                 );
 
                 return await data.json().then((res) => {
-                    const terms: Array<{ id: string; value: number }> = res['data']['items'];
+                    const terms: Array<{ id: string; value: number }> | undefined = res?.data?.items;
+                    if (!terms) {
+                        throw new Error('Ariston response missing data.items');
+                    }
                     const outsideTemp = terms.find((item) => item.id === 'OutsideTemp')?.value;
                     const zoneMeasuredTemp = terms.find((item) => item.id === 'ZoneMeasuredTemp')?.value;
 

--- a/src/pages/blog/[category]/[slug].tsx
+++ b/src/pages/blog/[category]/[slug].tsx
@@ -147,7 +147,16 @@ export const getStaticProps = async (data: {
         params: { category },
         locale,
     } = data;
-    const post = await getPostBySlug(data);
+    // Unknown slugs must 404, not crash the render with a 500
+    let post;
+    try {
+        post = await getPostBySlug(data);
+    } catch {
+        return {
+            notFound: true as const,
+            revalidate: 10,
+        };
+    }
 
     // Tag-based paths duplicate the canonical category URL — consolidate with a 301
     const canonicalCategory = post.meta.category.toLowerCase();

--- a/src/pages/blog/[category]/[slug].tsx
+++ b/src/pages/blog/[category]/[slug].tsx
@@ -150,7 +150,7 @@ export const getStaticProps = async (data: {
     // Unknown slugs must 404, not crash the render with a 500
     let post;
     try {
-        post = await getPostBySlug(data);
+        post = getPostBySlug(data);
     } catch {
         return {
             notFound: true as const,


### PR DESCRIPTION
## Contexto

Revisión post-merge del [PR #117](https://github.com/xabierlameiro/the-last-dance/pull/117) usando los clusters de errores runtime de Vercel (últimos 7 días) y la configuración del proyecto.

## Errores encontrados en producción y corregidos

### 1. 500 en el post gallego con `ñ` (24 errores, 6 usuarios afectados)
`/gl/blog/react/documentar-os-meus-compoñentes-de-react` devolvía **500** cuando el slug llegaba con la `ñ` descompuesta en Unicode NFD (`n` + tilde combinante), como envían algunos clientes y crawlers: el lookup comparaba contra el slug NFC del frontmatter y nunca coincidía, `getPostBySlug` lanzaba `Error: Post not found` y el render moría (esto generaba además los errores secundarios `ENOENT /gl/500.html` y `/en/500.html`).

- `findPostBySlug` normaliza ahora ambos lados a NFC.
- `getStaticProps` devuelve `notFound: true` (404) para slugs genuinamente desconocidos en lugar de propagar la excepción (500).

Verificado en local: slug NFD → 200, slug NFC → 200, slug inexistente → 404.

### 2. `/api/heating`: TypeError "reading 'items'" (35 errores hoy)
Cuando el login de Ariston falla, `res.data` llega `undefined` y el handler moría con un TypeError opaco. Ahora se validan las cookies de sesión y la forma de la respuesta con errores explícitos (`Ariston login failed (status N)` / `Ariston response missing data.items`), lo que permitirá distinguir en los logs si el problema es de credenciales (`HEATING_CREDENTIALS` en Vercel) o del servicio de Ariston.

### 3. Node 18 (EOL) en CI vs Node 22 en producción
Vercel compila el proyecto con **Node 22.x**, pero los workflows de CI testeaban con **18.20.0** (EOL desde abril de 2025). Workflows a Node 22 y `engines` a `>=20`.

## Estado de la build de producción

La build del último deploy (`23bcafb`) está limpia: `Build Completed in /vercel/output [2m]`, sin errores.

## Verificación

- `next build` ✓ (65 páginas), 45 suites / 81 tests ✓
- Reproducido y verificado el fix de slugs NFD/NFC/404 contra `next start` local

## Relacionado

- [PR #114](https://github.com/xabierlameiro/the-last-dance/pull/114): diagnosticado y comentado — sus 10 bumps ya están cubiertos en master y su build fallaba por el breaking change de next-mdx-remote v6 que master ya resolvió; se ha pedido a dependabot que lo recree (se autocerrará al no quedar nada pendiente).
- Sitemap reenviado a Search Console tras el merge (42 URLs canónicas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)