### PR TITLE
chore(security): silence dev-only install audit noise (all 23 are dev-only)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,11 @@
+; Skip the automatic audit that npm runs at the end of `npm install`. It reports
+; dev-only transitive vulnerabilities from build/test tooling (lighthouse's
+; @sentry/node -> @opentelemetry/core, and storybook's crypto-browserify -> elliptic)
+; that never ship to production and cannot be fixed without breaking those tools
+; (see specs/008-dev-audit-vulnerabilities.md).
+;
+; This does NOT weaken security: the real gate is the production-scoped
+; `npm audit --omit=dev --audit-level=high` step in .github/workflows/pre-deploy.yml,
+; which the explicit `npm audit` command still runs regardless of this flag, plus
+; Dependabot alerts. `npm audit --omit=dev` reports 0 vulnerabilities.
+audit=false

--- a/specs/008-dev-audit-vulnerabilities.md
+++ b/specs/008-dev-audit-vulnerabilities.md
@@ -1,0 +1,67 @@
+# SDD-008: npm audit vulnerabilities (all dev-only)
+
+- **Status**: Resolved 2026-07-17 by silencing the install-time audit noise + documenting.
+  No production code/dependency is affected.
+- **Trigger**: the Vercel install log shows `23 vulnerabilities (6 low, 17 moderate)`.
+
+## The one fact that matters
+
+`npm audit --omit=dev` reports **0 vulnerabilities**. Every flagged package is a
+**dev-only transitive dependency** of build/test tooling. None ship in the deployed
+bundle; the site and its users are not exposed. The `23` in Vercel's log is the default
+install-time audit, which scans devDependencies too — it is informational, not a build
+failure.
+
+## The two clusters (and why neither is safely fixable)
+
+### 1. OpenTelemetry / Sentry — 17 moderate
+
+Path: `lighthouse` (devDep, used by `npm run lighthouse-report`) → `@sentry/node@9` →
+`@opentelemetry/core@1.30.1`. Advisory GHSA-8988-4f7v-96qf ("unbounded memory allocation
+in W3C Baggage propagation") is fixed in `@opentelemetry/core >= 2.8.0` — a **major** bump.
+
+- `@sentry/node@9` requires `@opentelemetry/core@^1.x`. Even the **latest** `lighthouse`
+  (13.4.0) still uses `@sentry/node@9`, so upgrading lighthouse does not help.
+- **Tested**: forcing `@opentelemetry/core@^2.8.0` via an npm override installs, and
+  `jest` + `lighthouse --version` still load — but `import('@sentry/node')` then throws
+  `Cannot read properties of undefined (reading 'AlwaysOn')`. otel 2.x moved the sampler
+  API that Sentry 9 depends on. So the override **breaks @sentry/node**. Reverted.
+- Not exploitable here: it concerns parsing untrusted W3C Baggage headers, which a local
+  CLI performance tool never does.
+
+### 2. elliptic — 6 low
+
+Path: `@storybook/nextjs` (devDep) → `node-polyfill-webpack-plugin` → `crypto-browserify`
+→ `browserify-sign` / `create-ecdh` → `elliptic`. Advisory GHSA-848j-6mx2-7j84 affects
+`elliptic <= 6.6.1`, and **6.6.1 is the latest** — there is no patched version. It is a
+browser crypto polyfill pulled in by Storybook's Next.js preset. (Already dismissed once
+in Dependabot.)
+
+`npm audit fix` (non-breaking) fixes none of these. `npm audit fix --force` would make
+breaking major changes to storybook/lighthouse.
+
+## Decision
+
+- **Silence the install-time audit** via `.npmrc` (`audit=false`). This removes the noisy
+  Vercel line. It does **not** weaken anything: the production gate
+  `npm audit --omit=dev --audit-level=high` in `pre-deploy.yml` still runs (verified the
+  explicit `npm audit` ignores the flag), and Dependabot still tracks alerts.
+- **Dismiss** the corresponding Dependabot alerts as tolerable dev-only risk with no safe fix.
+- Do **not** force overrides (they break the tools) and do **not** run `audit fix --force`.
+
+## Real remediation paths (owner decision, out of scope here)
+
+- **Drop the otel cluster (17)**: stop depending on `lighthouse` as an npm package — rewrite
+  `lighthouse/assets/lighthouse.js` to shell out to the `lighthouse` CLI in the
+  `post-deploy` workflow instead of importing it. Then lighthouse (and its sentry/otel) leave
+  the tree.
+- **Drop the elliptic cluster (6)**: remove Storybook (its build is already broken under
+  React 19 — [[storybook-build-broken]]) or wait for `@storybook/nextjs` to drop the
+  crypto polyfill.
+- **Upstream waits**: Sentry adopting otel 2.x, or elliptic shipping a patch.
+
+## Acceptance criteria
+
+- `npm audit --omit=dev` = 0 (already true).
+- Vercel install log no longer prints the vulnerability count.
+- CI production-audit gate still runs and passes.

--- a/specs/README.md
+++ b/specs/README.md
@@ -14,6 +14,7 @@ live-site inspection (browser + prod API probes), and code audit of this repo.
 | [004](004-knowledge-panel-entity.md)      | "Xabier Lameiro" Google entity / Knowledge Panel             | On-site part done; off-site program open (owner)           |
 | [005](005-nextjs16-upgrade-decision.md)   | Next.js 16 upgrade go/no-go                                  | **Decided: NO-GO for now**                                 |
 | [006](006-trending-content-radar.md)      | Trending content radar (weekly briefs for the content phase) | **Implemented** — weekly issue via GitHub Action           |
+| [008](008-dev-audit-vulnerabilities.md)   | npm audit vulnerabilities (all dev-only)                     | **Resolved** — install audit silenced, prod audit clean    |
 
 All code lives on branch `fix/sdd-001-header-widgets` (specs + implementation).
 


### PR DESCRIPTION
## The one fact that matters

`npm audit --omit=dev` = **0 vulnerabilities**. All 23 findings are **dev-only transitive deps** of build/test tooling — none ship to production, so the deployed site and its users are not exposed. The `23 vulnerabilities` line in Vercel is the default install-time audit (it scans devDependencies too); it is informational, not a build failure.

## The two clusters — and why neither is safely fixable

**1. OpenTelemetry / Sentry (17 moderate)** — `lighthouse` → `@sentry/node@9` → `@opentelemetry/core@1.30.1`. The advisory is fixed in `@opentelemetry/core >= 2.8.0` (a **major** bump). `@sentry/node@9` needs otel `^1.x`, and even the latest lighthouse (13.4.0) still uses sentry 9. I **tested** forcing otel `^2.8.0` via an override: install + jest + `lighthouse --version` pass, but `import('@sentry/node')` then throws `Cannot read properties of undefined (reading 'AlwaysOn')` — otel 2.x moved a sampler API sentry 9 depends on. So the override **breaks @sentry/node**. Reverted.

**2. elliptic (6 low)** — `@storybook/nextjs` → `node-polyfill-webpack-plugin` → `crypto-browserify` → `elliptic`. The advisory affects `elliptic <= 6.6.1` and **6.6.1 is the latest** — no patched version exists.

`npm audit fix` (non-breaking) fixes none. `npm audit fix --force` would make breaking major changes to storybook/lighthouse.

## What this PR does

- **`.npmrc` → `audit=false`**: skips the automatic audit at the end of `npm install`, removing the noisy Vercel line. This does **not** weaken security:
  - The production gate `npm audit --omit=dev --audit-level=high` in `pre-deploy.yml` still runs — verified the explicit `npm audit` command ignores the flag and still reports (0 for `--omit=dev`).
  - Dependabot still tracks alerts.
- **`specs/008-dev-audit-vulnerabilities.md`**: the full analysis, the proof that the otel override breaks sentry, and the real remediation options.

## Real remediation (owner decision, out of scope)

- Drop the 17 otel findings by rewriting the `lighthouse-report` script to shell out to the `lighthouse` CLI instead of importing it as a package.
- Drop the 6 elliptic findings by removing Storybook (its build is already broken under React 19) or waiting for its Next.js preset to drop the crypto polyfill.

## Verification

`npm audit --omit=dev --audit-level=high` = 0 with `.npmrc` present (CI gate intact). 100/100 tests unaffected (config-only change).
