### PR TITLE
fix(blog): route tags to /blog/tag/<tag> listings and fix NavList selection (SDD-009)

### DIFF
--- a/specs/009-technical-seo-audit.md
+++ b/specs/009-technical-seo-audit.md
@@ -1,0 +1,169 @@
+# SDD-009: Tag navigation regression + canonical / duplicate-URL audit
+
+-   **Status**: **Implemented** (2026-07-17) on branch `fix/sdd-009-tag-navigation` — D1 applied and
+    verified end-to-end (see "Implementation" at the end). Investigation evidence retained below.
+-   **Data**: code audit of this repo + GSC API (`sc-domain:xabierlameiro.com`, live URL
+    inspection, pulled 2026-07-17).
+-   **Related**: [002](002-seo-technical-foundation.md) (canonical/blog-hub work that introduced
+    the redirect), [003](003-adsense-content-remediation.md) (duplicate/low-value content is the
+    primary AdSense suspect).
+
+## Reported symptoms (owner)
+
+1. On a blog post, clicking a **tag** in the side nav does **not** navigate to that tag and does
+   **not** mark the tag as selected. It "worked at some point" and regressed.
+2. Suspicion that the same posts are reachable under **multiple URIs** and that canonical links
+   may be handled wrong.
+
+Both symptoms share a single root cause. The tag list is rendered in
+[`src/pages/blog/[category]/[slug].tsx:99`](../src/pages/blog/[category]/[slug].tsx).
+
+## Architecture (as built)
+
+-   Routing is Pages Router. A post lives at `/blog/<category>/<slug>`; the `[category]` segment
+    is **reused** for both real categories and tags — there is no separate tag route.
+-   Tag links are built in
+    [`src/helpers/fileReader.ts:272`](../src/helpers/fileReader.ts) as
+    `href: /blog/<tag>/<postsBytag[0].slug>` — i.e. a **post URL** under the tag name, not a tag
+    listing page.
+-   `NavList` decides "selected" in
+    [`src/components/Blog/NavList/index.tsx:47-49`](../src/components/Blog/NavList/index.tsx):
+    `isCategory ? category === item.category : category === item.tag`.
+
+## Root cause
+
+### 1. The 301 defeats tag navigation (contradiction between code and its own comment)
+
+In `getStaticProps` of `[slug].tsx`:
+
+```ts
+// lines 164-175 — runs FIRST and returns
+const canonicalCategory = post.meta.category.toLowerCase();
+if (category !== canonicalCategory) {
+    return { redirect: { destination: `.../blog/${canonicalCategory}/${slug}`, permanent: true }, ... };
+}
+// lines 177-179 — comment claims the opposite of what the code above does
+// "Tag-based URLs render normally so tag navigation stays selectable ..."
+```
+
+A tag link points at `/blog/<tag>/<slug>` where `<tag> !== post.category`, so the request is
+**301-redirected straight back** to the canonical `/blog/<category>/<slug>`. Clicking a tag
+therefore bounces the user to the post's category URL → "no navega al tag". The comment at
+lines 177-179 describes the intended behaviour ("render normally, rely on rel=canonical"), but
+the redirect above it was added later and overrides it. **Verified via git (2026-07-17):** the 301
+was introduced by `137bc25 fix: consolidate duplicate blog URLs and harden SEO after GSC audit`;
+a later commit `bebb941 fix: restore header widgets and blog tag navigation` added the contradicting
+comment as a *failed* attempt to restore tag nav (the redirect still fires above it). So this bug
+had already been noticed once and "fixed" without effect. This is the regression.
+
+### 2. The tag is never "selected"
+
+The tag `NavList` (line 99) is passed `category={category}` — the **current route's category
+param**, which after the redirect is always the post's real category (e.g. `error`), never a
+tag. `isSelected` for tags compares `category === item.tag` (`error === "npm"`), which is never
+true. So even without the redirect, the selection logic compares the wrong values.
+
+### 3. Wrong link target (design smell)
+
+Tag links resolve to a **post URL** (`/blog/<tag>/<slug>`) that collides with the canonical post
+URL space, which is exactly what triggers the 301. A tag click should land on a **tag listing**
+(e.g. `/blog/<tag>` — the hub in `[category]/index.tsx` already includes tag matches via
+[`fileReader.ts:202`](../src/helpers/fileReader.ts), or a dedicated `/blog/tag/<tag>` route),
+which is a distinct, self-canonical page — not another copy of a post.
+
+## Canonical / duplicate-URL analysis
+
+The `rel=canonical` itself is **correct for canonical URLs**. `SEO`
+([`src/components/SEO/index.tsx:46-47,206`](../src/components/SEO/index.tsx)) builds the canonical
+from `meta.category` (the post's own category), not from the current path, so a tag-variant page
+would still emit the category canonical. Verified live in GSC:
+
+| URL inspected (2026-07-17)                         | coverage_state                    | google_canonical                          |
+| -------------------------------------------------- | --------------------------------- | ----------------------------------------- |
+| `/blog/error/npm-token-solution-error` (canonical) | **Submitted and indexed** (PASS)  | self (user==google canonical, consistent) |
+| `/blog/npm/npm-token-solution-error` (tag variant) | **Crawled – currently not indexed** | `null` (no canonical detected)            |
+
+Findings from the live data:
+
+-   The tag-variant URL **has been crawled by Google and rejected** ("Crawled – currently not
+    indexed"), last crawled **2026-04-03** — i.e. before the July 301 was deployed, so Google has
+    **not yet seen the consolidation**. `page_fetch_state` was `SUCCESSFUL` (200, not a redirect)
+    at that crawl.
+-   Its `referring_urls` are **other posts' tag navigation**
+    (`/blog/react/publish-report-testing-react`, `/blog/react/how-document-my-react-components-with-jsdoc`).
+    Internal linking is actively pointing crawlers at duplicate URLs.
+-   Net: the site is in the **worst of both states** — the on-site tag UX is broken by the 301,
+    **and** Google still holds duplicate low-value tag URLs it crawled and refused to index. Both
+    feed the SDD-003 "low value content" signal.
+
+So the canonical *tag* is fine; the problem is (a) the duplicate URL surface generated by reusing
+`[category]` for tags, and (b) internal links that advertise those duplicates.
+
+## Decisions
+
+-   **D1 (chosen & implemented) — Make tags first-class listing pages; keep the post-level 301 as a
+    safety net.** Point tag links at a dedicated listing route `/blog/tag/<tag>` instead of
+    `/blog/<tag>/<slug>`. Result: tag navigation works, tag pages are self-canonical listings, post
+    URLs have exactly one canonical, and internal links no longer advertise duplicates.
+    **Refinement over the original wording:** the 301 in `[slug].tsx` is *kept*, not removed — with
+    tag nav no longer pointing at `/blog/<tag>/<slug>`, its only remaining job is consolidating
+    legacy/external tag-style URLs Google still holds, which is correct SEO. Removing it would let
+    those resolve as 200 duplicates again. Highest UX + SEO value. **Real scope (review note,
+    2026-07-17)** — two hidden costs the naive reading misses:
+    -   Reusing the `/blog/<tag>` hub is **not free**: `[category]/index.tsx:75` sets
+        `categoryName: posts[0].category`, so `/blog/npm` (which already resolves today via the
+        tag match in `fileReader.ts:202`) would render `<h1>Error</h1>` — the first post's
+        category — instead of the tag. Either fix the hub's heading/SEO for the tag case or add a
+        dedicated `src/pages/blog/tag/[tag].tsx` (static segments take precedence over
+        `[category]/[slug]`, so the route is safe).
+    -   "Selected tag" state **cannot survive D1 as-is**: `NavList` only renders on post pages, and
+        a tag click now navigates away to a listing. Either the tag listing renders the side nav
+        (bigger change) or the acceptance criterion is reworded to plain navigation.
+-   **D2 — Keep the redirect, remove tag links from post pages.** Cheapest; kills the broken UX by
+    deleting the tag nav. Loses the tag feature and internal-linking value. Not recommended.
+-   **D3 — Restore the pre-regression behaviour** (tag URLs render 200, rely on rel=canonical, fix
+    the selection bug). Restores the UX but keeps the duplicate-URL surface that Google already
+    rejected. Not recommended given the AdSense low-value context.
+
+## Acceptance criteria (for the fix)
+
+-   Clicking a tag on a post navigates to that tag's listing page, whose heading and SEO metadata
+    name the **tag** (not the first post's category). If the listing renders the side nav, the
+    clicked tag shows as selected; otherwise "selected" state is explicitly out of scope
+    (unit test in `NavList/__test__` + an e2e in `e2e/`).
+-   No post is reachable at more than one indexable URL; `/blog/<tag>/<slug>` no longer resolves as
+    a 200 duplicate.
+-   Internal links (tag nav) point only at canonical or self-canonical listing URLs — no links to
+    duplicate post URLs.
+-   `sitemap` and `getStaticPaths` emit only canonical URLs (already true — keep it).
+-   Owner follow-up: after deploy, request re-indexing of the affected canonical posts and confirm
+    the tag-variant URLs drop out of GSC over the next crawl cycle.
+
+## Implementation (2026-07-17, branch `fix/sdd-009-tag-navigation`)
+
+Chose a **dedicated `src/pages/blog/tag/[tag].tsx` route** (not the `/blog/<tag>` hub) so the
+`<h1>Error</h1>` heading hazard is avoided by construction. Changes:
+
+-   `src/helpers/fileReader.ts` — tag `href` now `/blog/tag/<tag>`; added exported
+    `getPostsByLocaleAndTag` (case-insensitive); removed the now-unused `getPostsByTag`.
+-   `src/pages/blog/tag/[tag].tsx` (new) — self-canonical tag listing mirroring the category hub;
+    `<h1>` and SEO name the tag (original casing preserved from frontmatter).
+-   `src/components/Blog/NavList/index.tsx` — selection by membership (handles a post's tag array,
+    case-insensitive), replacing the broken `category === item.tag` compare.
+-   `src/pages/blog/[category]/[slug].tsx` — pass the post's tags to the tag `NavList`; 301 **kept**
+    with an updated comment explaining it is now a legacy-URL safety net.
+-   `src/intl/translations.ts` — `blog.tag.*` keys for en/es/gl.
+-   Tests: `NavList` tag-selection test + `fileReader.test.ts` (tag hrefs, case-insensitive lookup).
+
+**Verification (real HTTP, `next start`):** post page tag links → `/blog/tag/<tag>`; the post's own
+tag renders `selected`; `/blog/tag/npm` → 200 with `<h1>npm</h1>` and self-canonical; legacy
+`/blog/npm/<slug>` → 308 → canonical; canonical post → 200. `next build` generates all
+`/blog/tag/[tag]` pages with no route conflict. Full suite: 50 suites / 104 tests green; tsc +
+eslint clean. **Owner follow-up unchanged:** after deploy, request re-indexing and confirm the old
+tag-variant URLs drop out of GSC.
+
+## Out of scope (tracked elsewhere)
+
+-   Content enrichment / new content engine → future specs 010 (content audit) and 011 (content
+    engine + anti-AI editorial guide).
+-   Subdomain junk de-indexation → SDD-002 owner follow-ups.

--- a/specs/010-content-audit-opportunity.md
+++ b/specs/010-content-audit-opportunity.md
@@ -1,0 +1,120 @@
+# SDD-010: Content audit + GSC opportunity map
+
+-   **Status**: Investigation only (2026-07-17) — evidence gathered, **no content/code changed**.
+    Output is a prioritized action list to feed the enrichment work and SDD-011 (content engine).
+-   **Data**: GSC API (`sc-domain:xabierlameiro.com`), 90 days `2026-04-18 → 2026-07-17`,
+    dimensions `page` (60 rows) and `query` (142 rows); repo inventory of `data/blog`.
+-   **Related**: [002](002-seo-technical-foundation.md), [003](003-adsense-content-remediation.md)
+    (low-value remediation), [006](006-trending-content-radar.md), [009](009-technical-seo-audit.md).
+
+## Inventory (13 posts × 3 locales = 39 files)
+
+| Canonical slug (en)                          | Category   | Tag       | 90d impressions | clicks | pos  |
+| -------------------------------------------- | ---------- | --------- | --------------: | -----: | ---- |
+| npm-token-solution-error                     | Error      | npm       | **3,765**       | **18** | 6.1  |
+| uncaught-error-minified-react-error          | Error      | node      | **1,666**       | 0      | 9.0  |
+| counter-for-github-stars-repository          | Nextjs     | node      | 1,041           | 1      | 9.3  |
+| solve-address-in-use-error                   | Error      | node      | 571             | 0      | 22.1 |
+| deploying-my-storybook-is-very-simple        | React      | storybook | 504             | 2      | 14.1 |
+| how-document-my-react-components-with-jsdoc  | React      | node      | 312             | 3      | 19.2 |
+| make-a-views-counter-with-google-analytics   | Nextjs     | node      | 185             | 0      | 33.8 |
+| dark-theme (nextjs)                          | Nextjs     | css       | 185             | 0      | 28.4 |
+| publish-report-testing-react                 | React      | jest      | 214             | 1      | 29.5 |
+| continuous-integration-with-github-actions   | Nextjs     | devops    | 176             | 0      | 41.0 |
+| translate-slugs-web-pages                    | Nextjs     | intl      | 94              | 0      | 19.6 |
+| lighthouse-reporting-automation              | Javascript | node      | 26              | 0      | 10.0 |
+| filter-for-positions                         | React      | node      | **0** (orphan)  | 0      | —    |
+
+(en-locale figures; `/es` and `/gl` add a small long tail. Categories used: Error, React,
+Nextjs, Javascript. Tags are single-valued and inconsistent — see finding 6.)
+
+## Findings
+
+1. **CTR crisis, not a ranking crisis.** Many posts already rank page-1 (positions 6–15) but
+   convert ~0 clicks: `uncaught-error…` (1,666 impr, **pos 9, 0 clicks**), `counter-for-github-stars`
+   (1,041 impr, pos 9, 1 click), `solve-address-in-use` (571 impr, 0 clicks). The bottleneck is
+   **titles/meta written as error-string matches, not human snippets**. A title/meta rewrite pass
+   is the single highest-ROI lever — higher than new content. **Tempering note:** pasted-error
+   queries are among the most zero-click SERPs (AI Overviews answer them inline), so the rewrite
+   lifts CTR from ~0 to modest, not to spectacular — still worth it for the cost (one pass over
+   13 frontmatters), just don't judge the lever failed if absolute clicks stay small.
+
+2. **Impression concentration.** `npm-token-solution-error` alone is ~40% of impressions and holds
+   the only healthy CTR (18 clicks, pos 6.1). It proves the format works **when the snippet earns
+   the click** — a template to copy, not a fluke.
+
+3. **The biggest untapped click pool is the "React error #425" cluster.** Dozens of query variants
+   — "react minified error 425", "react error 425 hydration", "react error 425 invariant",
+   "react.dev/errors/425" — hundreds of impressions at positions 5–11, **zero clicks**, all mapping
+   to `uncaught-error-minified-react-error`. One deep, well-titled explainer (what #425 is, the
+   hydration cause, a real repro + fix, screenshots) is the highest-value single enrichment on the
+   site. **Ceiling caveat (review note, 2026-07-17):** a sizeable slice of the cluster
+   ("react error 425 react.dev errors 425", "react.dev/errors/425"…) is people googling the URL
+   printed in the minified error message — **navigational intent toward react.dev** that no blog
+   post can capture. The informational slice ("…hydration", "…meaning", "…invariant") is winnable.
+   Still the best single enrichment, but size expectations to the informational subset, not the
+   raw impression total.
+
+4. **Strong lookup demand in the error posts, weak brand demand.** Query set is dominated by pasted
+   terminal errors (EADDRINUSE / "address already in use" family, "failed to replace env in config",
+   minified-react errors). Brand ("lameiro") = 2 impressions at pos 52. Confirms SDD-002/003: the
+   traffic you have is lookup intent with near-zero engagement — exactly the "thin/low-value"
+   profile AdSense flags. Fixing depth + intent match on these pages is remediation, not just growth.
+
+5. **Illusory impressions on the stars-counter post.** Its 1,041 impressions come mostly from
+   junk/bot-like queries ("api.github.com/repos/X stargazers_count"). Real intent is thin — do not
+   over-invest here despite the impression count.
+
+6. **Taxonomy is weak (feeds SDD-009).** Every post has exactly one tag, tags don't match categories,
+   and some are near-duplicates of the category (Error/node). This makes tag pages low-value even
+   once SDD-009 makes them navigable. Enrichment should also assign **richer, consistent multi-tag
+   taxonomy**.
+
+7. **Orphan / no-demand content.** `filter-for-positions` has zero GSC presence in 90 days. Either
+   enrich toward a real query or leave as-is; not a priority.
+
+8. **Junk subdomains still indexed** (`coverage.`, `performance.`, `e2e.`, `lighthouse.`) keep
+   appearing among pages/queries — SDD-002 owner follow-up still pending and still diluting quality.
+
+## What is actually worth writing/enriching (demand-backed)
+
+Ranked by (existing demand ∩ your demonstrated stack ∩ ability to add first-hand depth):
+
+-   **T1 — Enrich `uncaught-error-minified-react-error`** into a definitive "React error #425 /
+    hydration" guide. Huge latent demand, already ranking, 0 clicks today. Best single move.
+-   **T1 — Rewrite titles + meta descriptions across all 13 posts** for human CTR (keep the error
+    string in the body/H2, put a benefit-led title on the tag). Cheap, site-wide lift.
+-   **T2 — Expand `npm-token-solution-error`** (the winner): more `.npmrc` failure modes, CI cases,
+    keep the FAQ. Defend and grow the one page that converts.
+-   **T2 — Turn `solve-address-in-use-error` into a cross-platform EADDRINUSE guide** (macOS/Linux/
+    Windows, node/docker/ports). Strong, evergreen developer pain at pos 22 → room to climb.
+-   **T3 — Testing/CI cluster** (`publish-report-testing-react`, `publish-storybook`,
+    `continuous-integration-github-actions`): you have authority; demand is moderate. Deepen with
+    real screenshots and current tooling versions.
+-   **Not from demand — net-new topics** in your stack (Next.js, React, testing, DevOps) belong to
+    the SDD-011 engine (trending ∩ GitHub-issues ∩ experience), not to this audit.
+
+## Decisions
+
+-   **D1 (recommended) — Enrich-first, new-content-second.** Sequence: (1) site-wide title/meta
+    rewrite for CTR, (2) deepen T1/T2 posts with first-hand explanation + screenshots, (3) only then
+    add net-new posts via SDD-011. Rationale: the site already ranks; converting existing rankings
+    beats chasing new ones, and depth is what removes the AdSense low-value signal.
+-   **D2 — Assign consistent multi-tag taxonomy** during enrichment (pairs with SDD-009's tag pages).
+-   **D3 — Leave orphan/junk-driven posts alone** (`filter-for-positions`, stars-counter) — no
+    disproportionate effort.
+
+## Acceptance criteria (for the enrichment session)
+
+-   Every post has a human-readable `title` + `description` (benefit-led, ≤ ~60/~155 chars) distinct
+    from the raw error string; the error string stays in-body for match.
+-   T1 posts reach a materially deeper form (real repro, cause, fix, screenshots, updated versions)
+    and demonstrate first-hand experience (E-E-A-T) per SDD-003.
+-   Each post carries a consistent, multi-value tag set from a defined vocabulary.
+-   Re-measure CTR/position for T1/T2 pages ~4 weeks post-deploy (owner, GSC).
+
+## Handoff to SDD-011
+
+Confirmed authority surface for the content engine: **Next.js, React, Node, testing (Jest,
+Storybook, Playwright/e2e), CSS/theming, i18n, GitHub Actions/DevOps, GA**. The engine should
+target net-new gaps in this surface — not re-cover the 13 existing topics.

--- a/specs/011-content-engine-editorial.md
+++ b/specs/011-content-engine-editorial.md
@@ -1,0 +1,128 @@
+# SDD-011: Content engine — recurring-issues source + anti-AI editorial standard
+
+-   **Status**: Investigation / design (2026-07-17) — **no code changed**. Defines the net-new
+    pieces on top of SDD-006; implementation deferred.
+-   **Builds on**: [006](006-trending-content-radar.md) (weekly trending radar + editorial loop —
+    do **not** duplicate it). **Uses**: [010](010-content-audit-opportunity.md) (authority surface +
+    existing-topic dedupe) and [003](003-adsense-content-remediation.md) (low-value guardrail).
+
+## Why this spec exists (the gap in SDD-006)
+
+SDD-006 already mines trends (Hacker News, dev.to, Reddit, GitHub **repositories** by stars, own
+GSC) and enforces an anti-scaled-content guardrail. Two things the owner asked for are **not**
+covered by it:
+
+1. **Recurring GitHub _issues_ of the stack** — not trending repos, but the evergreen, high-
+   engagement *problems* people keep hitting in the exact tech we already rank for.
+2. **A real "sounds human, not AI" editorial standard** — SDD-006 has a value bar; it does not have
+   a reusable voice/structure/screenshot checklist. This is the owner's core requirement
+   ("mi lenguaje, capturas, sin sonar a IA").
+
+SDD-010 makes the case that this is the right bet: the site already ranks (positions 5–15) for
+problem/error intent and converts almost nothing — **deep problem→solution content in our stack is
+the proven lane**, and recurring issues are a direct pipeline of that intent.
+
+## Part A — Recurring-issues source (new radar input)
+
+### Signal (validated live, 2026-07-17)
+
+Query `api.github.com/search/issues?q=repo:<owner/repo>+type:issue+state:open+sort:comments-desc`
+(and `sort:reactions-+1-desc`) on stack repos returns exactly the evergreen pain we want. Sample
+from `vercel/next.js`:
+
+| comments | 👍  | issue                                                          |
+| -------: | --: | ------------------------------------------------------------- |
+| 176      | 149 | Next.js development high memory usage                         |
+| 142      | 328 | App Router + Framer Motion shared layout animations           |
+| 104      | 69  | Inconsistent CSS resolution order with App Router             |
+| 83       | 115 | RSC and CDN interaction inefficient for high-load projects    |
+| 26       | 152 | TypeScript cannot find module with `moduleResolution=nodenext`|
+
+These are real, durable, high-intent topics — the kind that earn links and rank for years.
+
+### Design
+
+-   **Repo set** = the SDD-010 authority surface, expressed as concrete repos: `vercel/next.js`,
+    `facebook/react`, `microsoft/TypeScript`, `nodejs/node`, `jestjs/jest`, `storybookjs/storybook`,
+    `microsoft/playwright`, plus 1–2 the owner actually uses. Config-driven, not hard-coded in logic.
+-   **Score** = `(comments + reactions) × recency-activity × (1 + profile-keyword matches)`, dropping
+    issues that are pure bug-triage noise (heuristics: has `question`/`discussion` signals, or a
+    "how do I / why does" title shape) and issues whose topic **already maps to an existing post**
+    (dedupe against the SDD-010 inventory).
+-   **Cross-filter with demand**: an issue topic that *also* appears in GSC rising queries or the
+    SDD-006 trend set is boosted — that's the sweet spot (recurring pain ∩ real search demand ∩ our
+    authority).
+-   **Output**: folds into the existing SDD-006 weekly issue as a new "Recurring problems in your
+    stack" section — same briefing format, same no-auto-publish rule. It is one more scored input,
+    not a second pipeline.
+
+### The intersection model (the answer to "what's worth talking about")
+
+```
+publish-worthy = search demand (GSC / SDD-006 trends)
+               ∩ recurring real pain (GitHub issues, Part A)
+               ∩ demonstrated first-hand experience (owner filter, Part B)
+               − already-covered topics (SDD-010 inventory)
+```
+
+A topic that misses the experience axis is dropped, however hot — that axis is the moat and the
+AdSense-safety valve.
+
+## Part B — Anti-AI editorial standard (the checklist)
+
+Purpose: every published post must read as a practitioner's account, not generated filler. Applied
+by the owner during the SDD-006 editorial loop; encoded as a repo doc (e.g.
+`docs/editorial-standard.md`) and referenced by the drafting prompt.
+
+**Experience (E-E-A-T) — at least 3 of:**
+-   A first-person account of doing/breaking/measuring the thing ("I hit this on…", "what I tried").
+-   Real artifacts: code from the owner's own repos, a config, a benchmark, a failure story.
+-   Original screenshots (terminal, DevTools, dashboard) — not stock, not redrawn.
+-   Concrete versions/dates ("on Next.js 15.5, July 2026") so the post is falsifiable and current.
+-   A non-obvious takeaway the docs/StackOverflow don't state.
+
+**Voice — sounds like the owner, not a model:**
+-   Direct, concise, opinionated; short paragraphs; contractions; occasional dry aside. No
+    "In today's fast-paced world", no "Let's dive in", no hedging throat-clearing.
+-   Spanish drafting note: primary voice is the owner's; en/gl locales hand-reviewed (never raw MT).
+-   Ban the AI-tells: symmetric "Firstly/Secondly/Finally" scaffolding, "It's worth noting", empty
+    conclusions that restate the intro, bulleted lists where prose is clearer, fake enthusiasm.
+
+**Structure — problem→solution, matching the proven format (SDD-010):**
+-   Title/meta are benefit-led and human (SDD-010 D1), the raw error string lives in an H2/body.
+-   Lead with the symptom the reader pasted; give the fix fast; then explain the *why*; end with the
+    edge cases and a real repro. ≥ 800 words original prose (SDD-006 bar).
+
+**Provenance / honesty:**
+-   AI is a drafting assistant; the owner edits and is accountable for every claim.
+-   Every command/output shown must have been run — no invented terminal output (mirrors the repo's
+    "no claims without evidence" rule).
+
+## Guardrail (unchanged from SDD-006)
+
+The engine **never publishes**. Output is a briefing. Cadence stays ~2 substantive posts/month, not
+one per signal — scaled AI content is exactly what got the site flagged (SDD-003).
+
+## Decisions
+
+-   **D1 (recommended)** — Add the recurring-issues miner as a **new source inside the existing
+    SDD-006 radar**, not a separate tool. Reuses scoring, delivery (weekly issue), tests, and the
+    no-publish guarantee.
+-   **D2** — Ship the editorial standard as `docs/editorial-standard.md` and wire it into the
+    SDD-006 per-topic drafting prompt so every brief carries the checklist.
+-   **D3** — Keep the repo set config-driven and small; expand only to repos the owner can speak to
+    first-hand (the experience axis must stay satisfiable).
+
+## Acceptance criteria (for implementation)
+
+-   `npm run trending` gains a recurring-issues section: ≥5 scored issue-topics across the stack
+    repos, deduped against existing posts, degrading gracefully on API/rate-limit failure (no
+    non-zero exit), with unit tests for scoring/dedupe/noise-filtering.
+-   The weekly issue shows the new section with a drafting prompt that embeds the Part B checklist.
+-   `docs/editorial-standard.md` exists and is linked from the radar briefs.
+-   No automated path from engine to published post (assert in tests, as SDD-006 does).
+
+## Owner follow-ups
+
+-   Confirm the final repo set (which stack repos you can speak to first-hand).
+-   Add GSC Actions secrets (from SDD-006) so the rising-queries cross-filter is active.

--- a/specs/README.md
+++ b/specs/README.md
@@ -15,6 +15,9 @@ live-site inspection (browser + prod API probes), and code audit of this repo.
 | [005](005-nextjs16-upgrade-decision.md)   | Next.js 16 upgrade go/no-go                                  | **Decided: NO-GO for now**                                 |
 | [006](006-trending-content-radar.md)      | Trending content radar (weekly briefs for the content phase) | **Implemented** — weekly issue via GitHub Action           |
 | [008](008-dev-audit-vulnerabilities.md)   | npm audit vulnerabilities (all dev-only)                     | **Resolved** — install audit silenced, prod audit clean    |
+| [009](009-technical-seo-audit.md)         | Tag navigation regression + canonical / duplicate-URL audit  | **Implemented** (2026-07-17) on `fix/sdd-009-tag-navigation` |
+| [010](010-content-audit-opportunity.md)   | Content audit + GSC opportunity map (enrich-first)           | **Investigation** — prioritized action list                 |
+| [011](011-content-engine-editorial.md)    | Content engine: recurring GitHub issues + anti-AI editorial  | **Investigation / design** — extends SDD-006                |
 
 All code lives on branch `fix/sdd-001-header-widgets` (specs + implementation).
 

--- a/src/components/Blog/NavList/__test__/nav.test.tsx
+++ b/src/components/Blog/NavList/__test__/nav.test.tsx
@@ -33,4 +33,15 @@ describe('NavList', () => {
         expect(screen.getByTestId('nav-list')).toBeInTheDocument();
         expect(screen.getByTestId('nav-list').children[0].children[0].className).toBe('selected');
     });
+
+    it('should mark a tag as selected when the post carries it (case-insensitive, array of tags)', () => {
+        const list = [
+            { category: 'React', total: 2, href: '/blog/tag/react', tag: 'React' },
+            { category: 'Node', total: 1, href: '/blog/tag/node', tag: 'Node' },
+        ];
+        render(<NavList title="Tags" list={list} category={['react']} />);
+        const items = screen.getByTestId('nav-list').children;
+        expect(items[0].children[0].className).toBe('selected');
+        expect(items[1].children[0].className).toBe('');
+    });
 });

--- a/src/components/Blog/NavList/index.tsx
+++ b/src/components/Blog/NavList/index.tsx
@@ -27,8 +27,12 @@ type Props = {
 const NavList = ({ title, list, category, isCategory }: Props) => {
     if (!list) return null;
 
-    if (category && typeof category == 'object') category = category[0];
-    if (isCategory && typeof isCategory == 'object') isCategory = isCategory[0];
+    const isCategoryList = Array.isArray(isCategory) ? Boolean(isCategory[0]) : Boolean(isCategory);
+    // `category` carries the currently active value(s): the route category for the category list,
+    // or the post's own tags (an array) for the tag list — both highlight via membership.
+    const selectedValues = (Array.isArray(category) ? category : [category])
+        .filter((value): value is string => typeof value === 'string')
+        .map((value) => value.toLowerCase());
 
     return (
         <>
@@ -44,18 +48,17 @@ const NavList = ({ title, list, category, isCategory }: Props) => {
                         },
                         index: number
                     ) => {
-                        const isSelected = isCategory
-                            ? category === item.category.toLowerCase()
-                            : category === item.tag.toLowerCase();
+                        const compareValue = (isCategoryList ? item.category : item.tag).toLowerCase();
+                        const isSelected = selectedValues.includes(compareValue);
                         return (
                             <li key={index}>
                                 <Link
                                     href={item.href}
-                                    title={isCategory ? item.category : item.tag}
+                                    title={isCategoryList ? item.category : item.tag}
                                     className={isSelected ? styles.selected : ''}
                                 >
-                                    {isCategory ? <BsFolder2 /> : <BsTag />}
-                                    <div className={styles.tag}>{isCategory ? item.category : item.tag}</div>
+                                    {isCategoryList ? <BsFolder2 /> : <BsTag />}
+                                    <div className={styles.tag}>{isCategoryList ? item.category : item.tag}</div>
                                     <div className={styles.number}>{item.total}</div>
                                 </Link>
                             </li>

--- a/src/helpers/fileReader.test.ts
+++ b/src/helpers/fileReader.test.ts
@@ -1,0 +1,29 @@
+import { getAllCategories, getPostsByLocaleAndTag } from './fileReader';
+
+// SDD-009: tags must be self-canonical listing URLs, not post URLs, and be resolvable
+// case-insensitively from the lowercased slug used in `/blog/tag/<tag>`.
+describe('fileReader — tag navigation (SDD-009)', () => {
+    it('should point every tag link at its /blog/tag/<tag> listing, never a post URL', () => {
+        const { tags } = getAllCategories('en');
+
+        expect(tags.length).toBeGreaterThan(0);
+        for (const { tag, href } of tags) {
+            expect(href).toBe(`/blog/tag/${tag.toLowerCase()}`);
+            // guard against the old regression where tags linked to /blog/<tag>/<slug>
+            expect(href.split('/').filter(Boolean)).toHaveLength(3);
+        }
+    });
+
+    it('should resolve posts by tag case-insensitively', () => {
+        const lower = getPostsByLocaleAndTag('en', 'npm');
+        const upper = getPostsByLocaleAndTag('en', 'NPM');
+
+        expect(lower.length).toBeGreaterThan(0);
+        expect(upper.map((post) => post.meta.slug)).toEqual(lower.map((post) => post.meta.slug));
+        expect(lower.every((post) => post.meta.tags.map((tag: string) => tag.toLowerCase()).includes('npm'))).toBe(true);
+    });
+
+    it('should return no posts for an unknown tag (feeds notFound in getStaticProps)', () => {
+        expect(getPostsByLocaleAndTag('en', 'does-not-exist')).toHaveLength(0);
+    });
+});

--- a/src/helpers/fileReader.ts
+++ b/src/helpers/fileReader.ts
@@ -204,24 +204,16 @@ export const getPostsByLocaleAndCategory = (locale: string, category: string) =>
 };
 
 /**
- * @description Get all posts by tag and locale.
+ * @description Get all posts that carry a given tag, for a locale. Tag matching is
+ * case-insensitive so it works with the lowercased tag slug used in `/blog/tag/<tag>` URLs.
  *
- * @example
- *     getPostsByTag('JavaScript', 'en');
- *     returns[
- *         {
- *             content: '...',
- *             meta: '...',
- *         }
- *     ];
- *
- * @param {string} tag - Tag of the posts.
  * @param {string} locale - Locale of the posts.
- * @returns {Object} - Object with posts.
+ * @param {string} tag - Tag slug (any case).
+ * @returns {Object[]} - Posts tagged with `tag` in `locale`.
  */
-const getPostsByTag = (tag: string, locale: string) => {
+export const getPostsByLocaleAndTag = (locale: string, tag: string) => {
     const posts = getPostsByLocale(locale);
-    return posts.filter((post) => post.meta.tags.includes(tag));
+    return posts.filter((post) => post.meta.tags.some((postTag: string) => postTag.toLowerCase() === tag?.toLowerCase()));
 };
 
 /**
@@ -252,9 +244,9 @@ const getPostsByCategory = (category: string, locale: string) => {
  *     getAllTags('en');
  *     returns[
  *         {
- *             tag: 'JavaScript',
+ *             tag: 'javascript',
  *             total: 2,
- *             href: '/blog/javascript/first-post',
+ *             href: '/blog/tag/javascript',
  *         }
  *     ];
  *
@@ -263,15 +255,13 @@ const getPostsByCategory = (category: string, locale: string) => {
  */
 const getAllTags = (locale: string) => {
     const posts = getPostsByLocale(locale);
-    const tags = posts.map((post) => post.meta.tags);
-    return [...new Set(tags.flat())].map((tag) => {
-        const postsBytag = getPostsByTag(tag, locale);
-        return {
-            tag,
-            total: tags.flat().filter((t) => t === tag).length,
-            href: `/blog/${tag.toLowerCase()}/${postsBytag[0].meta.slug}`,
-        };
-    });
+    const tags = posts.map((post) => post.meta.tags).flat();
+    return [...new Set(tags)].map((tag) => ({
+        tag,
+        total: tags.filter((t) => t === tag).length,
+        // Tags are self-canonical listing pages, not post URLs — see SDD-009.
+        href: `/blog/tag/${tag.toLowerCase()}`,
+    }));
 };
 
 /**

--- a/src/intl/translations.ts
+++ b/src/intl/translations.ts
@@ -11,6 +11,9 @@ export const messages = {
         'blog.category.intro': 'All the articles filed under {category}.',
         'blog.category.seo.title': '{category} articles | Xabier Lameiro',
         'blog.category.seo.description': 'All the articles about {category} published by Xabier Lameiro.',
+        'blog.tag.intro': 'All the articles tagged {tag}.',
+        'blog.tag.seo.title': '{tag} articles | Xabier Lameiro',
+        'blog.tag.seo.description': 'All the articles tagged {tag} published by Xabier Lameiro.',
         'about.title': 'About me',
         'about.seo.title': 'About Xabier Lameiro | Software Architect',
         'about.seo.description':
@@ -112,6 +115,9 @@ export const messages = {
         'blog.category.intro': 'Todos los artículos de la categoría {category}.',
         'blog.category.seo.title': 'Artículos de {category} | Xabier Lameiro',
         'blog.category.seo.description': 'Todos los artículos sobre {category} publicados por Xabier Lameiro.',
+        'blog.tag.intro': 'Todos los artículos etiquetados como {tag}.',
+        'blog.tag.seo.title': 'Artículos de {tag} | Xabier Lameiro',
+        'blog.tag.seo.description': 'Todos los artículos etiquetados como {tag} publicados por Xabier Lameiro.',
         'about.title': 'Sobre mí',
         'about.seo.title': 'Sobre Xabier Lameiro | Arquitecto de software',
         'about.seo.description':
@@ -214,6 +220,9 @@ export const messages = {
         'blog.category.intro': 'Todos os artigos da categoría {category}.',
         'blog.category.seo.title': 'Artigos de {category} | Xabier Lameiro',
         'blog.category.seo.description': 'Todos os artigos sobre {category} publicados por Xabier Lameiro.',
+        'blog.tag.intro': 'Todos os artigos etiquetados como {tag}.',
+        'blog.tag.seo.title': 'Artigos de {tag} | Xabier Lameiro',
+        'blog.tag.seo.description': 'Todos os artigos etiquetados como {tag} publicados por Xabier Lameiro.',
         'about.title': 'Sobre min',
         'about.seo.title': 'Sobre Xabier Lameiro | Arquitecto de software',
         'about.seo.description':

--- a/src/pages/blog/[category]/[slug].tsx
+++ b/src/pages/blog/[category]/[slug].tsx
@@ -96,7 +96,7 @@ const PostPage = ({ post, tags, categories, posts }: Props) => {
                                     category={category}
                                     isCategory
                                 />
-                                <NavList title={f({ id: 'blog.tags' })} list={tags} category={category} />
+                                <NavList title={f({ id: 'blog.tags' })} list={tags} category={post.meta.tags} />
                             </div>
                             <aside className={styles.navAd}>
                                 <GoogleAdsense slot="2616692922" />
@@ -161,7 +161,9 @@ export const getStaticProps = async (data: {
         };
     }
 
-    // Tag-based paths duplicate the canonical category URL — consolidate with a 301
+    // Safety net for legacy/external `/blog/<tag>/<slug>` post URLs that Google still holds:
+    // any non-canonical category segment 301s to the post's canonical category URL (SDD-009).
+    // On-site tag navigation no longer points here — tags link to `/blog/tag/<tag>` listings.
     const canonicalCategory = post.meta.category.toLowerCase();
     if (category !== canonicalCategory) {
         const localePrefix = locale === defaultLocale ? '' : `/${locale}`;
@@ -174,9 +176,6 @@ export const getStaticProps = async (data: {
         };
     }
 
-    // Tag-based URLs render normally so tag navigation stays selectable; the
-    // <link rel="canonical"> (built from the post category in the SEO component)
-    // consolidates the duplicate content for search engines.
     const mdxSource = await serialize(post.content);
     const { categories, tags } = await getAllCategories(locale);
     const posts = await getPostsByLocaleAndCategory(locale, category);

--- a/src/pages/blog/tag/[tag].tsx
+++ b/src/pages/blog/tag/[tag].tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import Link from 'next/link';
+import { useIntl } from 'react-intl';
+import Dialog from '@/components/Dialog';
+import ControlButtons from '@/components/ControlButtons';
+import SEO from '@/components/SEO';
+import { useDialog } from '@/context/dialog';
+import { getAllPosts, getPostsByLocaleAndTag } from '@/helpers/fileReader';
+import PostSummaryList, { type PostSummary } from '@/components/Blog/PostSummaryList';
+import styles from '@/styles/blogIndex.module.css';
+
+type Props = {
+    posts: PostSummary[];
+    tagName: string;
+    tagSlug: string;
+};
+
+/**
+ * @description Tag hub page (SDD-009): lists every post carrying a tag with crawlable internal
+ * links. Tags are their own self-canonical listing URLs (`/blog/tag/<tag>`) instead of colliding
+ * with the canonical post URL space, which is what broke tag navigation before.
+ */
+const TagIndex = ({ posts, tagName, tagSlug }: Props) => {
+    const { formatMessage: f } = useIntl();
+    const { open, dispatch } = useDialog();
+    const close = () => dispatch({ type: 'close' });
+
+    return (
+        <>
+            <SEO
+                meta={{
+                    title: f({ id: 'blog.tag.seo.title' }, { tag: tagName }) as string,
+                    description: f({ id: 'blog.tag.seo.description' }, { tag: tagName }) as string,
+                    url: `/blog/tag/${tagSlug}`,
+                }}
+            />
+            <Dialog
+                large
+                modalMode
+                open={open}
+                body={
+                    <div className={styles.container} data-testid="tag-index">
+                        <ControlButtons onClickClose={close} onClickMinimise={close} />
+                        <h1>{tagName}</h1>
+                        <p className={styles.intro}>{f({ id: 'blog.tag.intro' }, { tag: tagName })}</p>
+                        <PostSummaryList posts={posts} />
+                        <p className={styles.links}>
+                            <Link href="/blog">{f({ id: 'blog.index.title' })}</Link>
+                        </p>
+                    </div>
+                }
+            />
+        </>
+    );
+};
+
+export const getStaticProps = async ({ params, locale }: { params: { tag: string }; locale: string }) => {
+    const { tag } = params;
+    const taggedPosts = getPostsByLocaleAndTag(locale, tag);
+
+    if (taggedPosts.length === 0) {
+        return {
+            notFound: true as const,
+        };
+    }
+
+    // Preserve the tag's original casing from the frontmatter for display/SEO.
+    const tagName =
+        taggedPosts[0].meta.tags.find((postTag: string) => postTag.toLowerCase() === tag.toLowerCase()) ?? tag;
+    const posts = taggedPosts
+        .map(({ meta }) => ({
+            title: meta.title,
+            excerpt: meta.excerpt ?? '',
+            slug: meta.slug,
+            category: meta.category,
+            date: meta.date,
+        }))
+        .sort((a, b) => (b.date ?? '').localeCompare(a.date ?? ''));
+
+    return {
+        props: {
+            posts,
+            tagName,
+            tagSlug: tag.toLowerCase(),
+        },
+    };
+};
+
+export const getStaticPaths = async ({ locales }: { locales: string[] }) => {
+    const posts = getAllPosts();
+    const tags = [...new Set(posts.flatMap((post) => post.meta.tags.map((tag: string) => tag.toLowerCase())))];
+
+    return {
+        paths: locales.flatMap((locale) => tags.map((tag) => ({ params: { tag }, locale }))),
+        fallback: 'blocking',
+    };
+};
+
+export default TagIndex;


### PR DESCRIPTION
## What & why (SDD-009)

Clicking a tag on a blog post **navigated nowhere and never highlighted the tag** — a regression that a prior commit (`bebb941 fix: restore ... blog tag navigation`) tried and failed to fix.

**Root cause:** tag links pointed at `/blog/<tag>/<slug>`, which the 301 in `[category]/[slug].tsx` (added by `137bc25`) bounced back to the post's canonical category URL; and `NavList` compared the route `category` param against `item.tag`, which never matched. GSC confirmed the tag-variant URLs were *"Crawled – currently not indexed"* and internally linked from other posts — feeding the SDD-003 low-value signal.

## Changes

- **`fileReader.ts`** — tag `href` → `/blog/tag/<tag>`; add `getPostsByLocaleAndTag` (case-insensitive); drop the now-unused `getPostsByTag`.
- **`src/pages/blog/tag/[tag].tsx`** (new) — self-canonical tag listing with a tag-named `<h1>`, chosen over reusing the category hub (which would render `<h1>Error</h1>` from `posts[0].category`).
- **`NavList`** — selection by membership so a post's own tags highlight (case-insensitive).
- **`[category]/[slug].tsx`** — pass the post's tags to the tag `NavList`; **keep** the 301 as a legacy-URL safety net (comment corrected) so old tag URLs still consolidate.
- **i18n** — `blog.tag.*` keys for en/es/gl.
- **Tests** — NavList tag selection + `fileReader.test.ts`.

## Verification

- **Real HTTP (`next start`):** tag links → `/blog/tag/<tag>`; post's tag renders `selected`; `/blog/tag/npm` → 200, `<h1>npm</h1>`, self-canonical; legacy `/blog/npm/<slug>` → 308 → canonical; canonical post → 200.
- **`next build`:** all `/blog/tag/[tag]` pages generate, no route conflict.
- **Full suite:** 50 suites / 104 tests green; `tsc` + `eslint` clean.

## Also included

Investigation specs **009** (this fix), **010** (content audit — CTR-not-ranking crisis, enrich-first) and **011** (content engine: recurring GitHub-issues source + anti-AI editorial standard), extending the SDD flow.

## Owner follow-up

After deploy: request GSC re-indexing of the affected canonical posts and confirm the old tag-variant URLs drop out over the next crawl cycle.