### PR TITLE
docs(blog): enrich npm-token + testing/CI cluster (SDD-010 T2+T3)

### DIFF
--- a/data/blog/github-workflows/github-workflows.en.mdx
+++ b/data/blog/github-workflows/github-workflows.en.mdx
@@ -3,7 +3,7 @@ title: 'Continuous Integration with Github Actions workflow'
 slug: 'continuous-integration-with-github-actions-workflow'
 author: 'Xabier Lameiro'
 category: 'Nextjs'
-tags: ['devops']
+tags: ['github-actions', 'ci', 'nextjs', 'devops']
 locale: 'en'
 excerpt: 'Continuous integration and continuous deployment with using the github workflow actions in a nextjs project and deploying to vercel'
 description: 'Set up CI/CD for a Next.js project with GitHub Actions: lint, test and build on every push, then deploy to Vercel. The workflow YAML explained step by step.'
@@ -13,6 +13,11 @@ alternate:
         { lang: 'es', url: 'integracion-continua-con-github-actions-workflow' },
         { lang: 'gl', url: 'integracion-continua-con-github-actions-workflow' },
     ]
+faq:
+    - question: 'How do I run lint, test and build on every push with GitHub Actions?'
+      answer: 'Add a .github/workflows/*.yml file that triggers on push, checks out the code, sets up Node, installs dependencies and runs your lint/test/build scripts as steps. Split it into parallel jobs so a failure is easy to locate.'
+    - question: 'Why split into pre-deploy and post-deploy workflows?'
+      answer: 'Pre-deploy runs the fast gates (lint, test, build) before anything ships. Post-deploy runs the slow checks that only make sense against the live site, like a Lighthouse performance report, so they never block the deploy.'
 ---
 
 # Continuous Integration with Github Actions workflow
@@ -21,17 +26,17 @@ alternate:
 
 <GoogleAdsense />
 
-Each project is different and so are its priorities, but what they have in common is that they all need to be deployed and tested. This part can always be done manually, but it ends up being repetitive and tedious. That's why it's convenient to automate it, and that's why continuous integration and continuous deployment tools exist.
+Every project is different and so are its priorities, but they all have one thing in common: they need to be tested and deployed. You can do that by hand, but it gets repetitive and tedious fast — which is exactly what continuous integration and continuous deployment exist to remove.
 
-In this case we are going to use [Github Actions](https://docs.github.com/en/actions/using-workflows 'Link to github Actions') to automate the deployment of this project in [Vercel](https://vercel.com/ 'Link to vercel'), but also to do a series of previous tasks such as testing, code formatting and documentation generation.
+Here I use [GitHub Actions](https://docs.github.com/en/actions/using-workflows 'Link to github Actions') to automate deploying this project to [Vercel](https://vercel.com/ 'Link to vercel'), plus the checks that run before it: testing, linting, type-checking and documentation generation.
 
 ## Design
 
-The most time-consuming thing is to plan what your pipeline is going to look like, i.e. what tasks you are going to execute and in what order. In my case I started to draw in escalidraw how my task flow could look like and after several attempts one was the one that convinced me the most. Once you have this part more or less thought what you have to do is to go to your project and create a folder in the following route .github/workflows once inside you can create the file with the name you want with the format .yml in my case I have two pre-deploy.yml and post-deploy.yml, here I am not going to go into detail of how the format .yml works, but I am going to explain what does each of the jobs that I have in each of the workflows.
+The part that takes the most thought is the pipeline itself — which tasks run, and in what order. I sketched the flow in Excalidraw and iterated until one shape stuck. Then it is mechanical: create a `.github/workflows/` folder and drop your `.yml` files in it. I keep two, `pre-deploy.yml` and `post-deploy.yml`, and instead of explaining YAML syntax I will explain what each job does.
 
-First I run the cancel redundancy, code checking, testing and documentation jobs in parallel and if everything goes well, versioning and deployment in pre-production. After checking that everything went well and was deployed correctly in pre-production, I do my manual tests on the featuring developed or on the bugfixing and after checking that everything is correct and there is no problem, I can make the decision to deploy or not in production. For this it would only be necessary to create a pull request to merge the develop branch in master and merge it but, in my workflow the jobs don't end here. After all this and once merged in production a last performance test is executed using lighthouse and generating a page by page report that I publish once the job is finished.
+`pre-deploy` runs four jobs in parallel — cancel-redundant-runs, linting, testing and docs — and only if they all pass does it version and deploy to pre-production. I then test the feature or bugfix manually against that preview. If it holds up, deploying to production is just a pull request from `dev` to `master`. But the pipeline does not end at the merge: once it is live, `post-deploy` runs a Lighthouse pass and publishes a page-by-page performance report. Splitting it this way keeps the fast gates blocking (nothing ships broken) and the slow, live-site checks out of the critical path.
 
-Here you can see it in a more graphical way:
+Here it is graphically:
 
 <Image
     src="/continuos-integration.svg"
@@ -42,7 +47,7 @@ Here you can see it in a more graphical way:
     style={{ margin: '20px 0 20px 0' }}
 />
 
-This is a snippet of what my pre-deploy workflow looks like:
+This is a snippet of what the pre-deploy workflow looks like (Node 22, npm — update the versions to match your project, this is the kind of thing that goes stale):
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
@@ -57,36 +62,42 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Cancel previous redundant workflow runs
-              uses: styfle/cancel-workflow-action@0.11.0
+              uses: styfle/cancel-workflow-action@0.12.1
               with:
                   access_token: ${{ secrets.TOKEN_GITHUB }}
     code_checking:
         name: Linting
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
               with:
-                  node-version: 18
-                  cache: yarn
+                  node-version: 22
+                  cache: npm
             - name: Install dependencies
+              env:
+                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
               run: |
-                  echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+                  echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
                   echo "@xabierlameiro:registry=https://npm.pkg.github.com/" >> ~/.npmrc
-                  yarn install --frozen-lockfile
+                  npm install --legacy-peer-deps
             - name: Linter
-              run: yarn run lint
+              run: npm run lint
 ```
 
 </CH.Code>
 
-Workflow complete [in my github](https://github.com/xabierlameiro/the-last-dance/actions/workflows/pre-deploy.yml 'in my github')
+Full workflow [in my github](https://github.com/xabierlameiro/the-last-dance/actions/workflows/pre-deploy.yml 'in my github')
+
+## Three things worth doing from day one
+
+- **Cache the install.** `actions/setup-node` with `cache: npm` restores `node_modules`-worth of downloads between runs and cuts minutes off every job. Point it at your real lockfile.
+- **Cancel redundant runs.** Pushing three times in a row should not run three full pipelines. The cancel step above (or the built-in `concurrency:` key) kills superseded runs.
+- **Keep secrets in secrets.** The registry token comes from `${{ secrets.NPM_TOKEN }}`, never from the file. If a token ever lands in a committed `.npmrc`, rotate it — the runner reads it from the environment, not the repo.
 
 ## Results
 
-Each of these reports has its own repository on github and that's where the results of each of the tests are published.
-
-Here I can see the results of my jobs every time I make changes to my project:
+Each report has its own repository on GitHub, and that is where the output of every run is published:
 
 -   [Unit test report](https://coverage.xabierlameiro.com/ 'Link to Unit test report')
 -   [End to end testing report](https://e2e.xabierlameiro.com/ 'Link to End to end testing report')
@@ -96,6 +107,6 @@ Here I can see the results of my jobs every time I make changes to my project:
 
 ## Conclusions
 
-Every time I develop a new component in React, or create a new page with Nextjs I'm assured that a battery of tests thoroughly checks that what I've added to my project hasn't broken any of the previous work. This is partly because you are the one who has to create the tests in the most delicate and critical parts of your application.
+Every time I add a component in React or a page in Next.js, a battery of tests checks that I have not broken the work already there — which only works because you are the one who has to write the tests for the delicate, critical parts. The pipeline does not invent coverage; it enforces the coverage you decided to have.
 
-> You can find all this code in my github repository and if you liked this content you can help me with a [⭐️](https://github.com/xabierlameiro/the-last-dance 'Link to my github') Thanks !
+> You can find all this code in my github repository, and if you liked it you can help me with a [⭐️](https://github.com/xabierlameiro/the-last-dance 'Link to my github'). Thanks!

--- a/data/blog/github-workflows/github-workflows.es.mdx
+++ b/data/blog/github-workflows/github-workflows.es.mdx
@@ -3,7 +3,7 @@ title: 'Integración continua con Github Actions workflow'
 slug: 'integracion-continua-con-github-actions-workflow'
 author: 'Xabier Lameiro'
 category: 'Nextjs'
-tags: ['devops']
+tags: ['github-actions', 'ci', 'nextjs', 'devops']
 locale: 'es'
 excerpt: 'Integración continua y despliegue continuo con usando las github workflow actions en un proyecto de nextjs y desplegando en vercel'
 description: 'Configura CI/CD para un proyecto Next.js con GitHub Actions: lint, tests y build en cada push, y despliegue en Vercel. El YAML del workflow explicado paso a paso.'
@@ -13,6 +13,11 @@ alternate:
         { lang: 'en', url: 'continuous-integration-with-github-actions-workflow' },
         { lang: 'gl', url: 'integracion-continua-con-github-actions-workflow' },
     ]
+faq:
+    - question: '¿Cómo ejecuto lint, tests y build en cada push con GitHub Actions?'
+      answer: 'Añade un fichero .github/workflows/*.yml que se dispare en push, haga checkout del código, configure Node, instale dependencias y ejecute tus scripts de lint/test/build como pasos. Divídelo en jobs paralelos para localizar un fallo rápido.'
+    - question: '¿Por qué separar en pre-deploy y post-deploy?'
+      answer: 'El pre-deploy corre las verificaciones rápidas (lint, tests, build) antes de que se despliegue nada. El post-deploy corre las lentas que solo tienen sentido contra el sitio en vivo, como un informe de rendimiento con Lighthouse, para que nunca bloqueen el despliegue.'
 ---
 
 # Integración continua con Github Actions workflow para este Proyecto
@@ -21,17 +26,17 @@ alternate:
 
 <GoogleAdsense />
 
-Cada un proyecto es un mundo y sus prioridades también lo son, pero lo que tienen en común es que todos necesitan ser desplegados y probados. Esta parte siempre se puede hacer de forma manual, pero acaba siendo algo repetitivo y tedioso. Por eso es conveniente automatizarlo, y para eso existen las herramientas de integración continua y despliegue continuo.
+Cada proyecto es un mundo y sus prioridades también, pero todos tienen algo en común: hay que probarlos y desplegarlos. Puedes hacerlo a mano, pero acaba siendo repetitivo y tedioso — que es justo lo que la integración y el despliegue continuos existen para quitar.
 
-En este caso vamos a usar las [Github Actions](https://docs.github.com/en/actions/using-workflows 'Enlace a documentacion de github Actions') para automatizar el despliegue de este proyecto en [Vercel](https://vercel.com/ 'Enlace a vercel'), pero también hacer una serie de tareas previas como son los testing, el formateo del código y la generación de la documentación.
+Aquí uso las [Github Actions](https://docs.github.com/en/actions/using-workflows 'Enlace a documentación de github Actions') para automatizar el despliegue de este proyecto en [Vercel](https://vercel.com/ 'Enlace a vercel'), más las verificaciones previas: testing, linting, type-checking y generación de documentación.
 
 ## Diseño
 
-Lo que más tiempo puede llevar es, planificar como va ser tu pipeline, osea que tareas vas a ejecutar y en que orden. En mi caso me puse a dibujar en escalidraw como podría ser mi flujo de tareas y tras varios intentos uno fue el que más me convenció. Una vez tienes esta parte mas o menos pensada lo que tienes que hacer es ir a tu proyecto y crear una carpeta en la siguiente ruta .github/workflows una vez dentro puedes crear el archivo con el nombre que desees con el formato .yml en mi caso tengo dos pre-deploy.yml y post-deploy.yml, aquí no voy a entrar en detalle de como funciona el formato .yml, pero si que voy a explicar que hace cada uno de los jobs que tengo en cada uno de los workflows.
+La parte que más se piensa es el propio pipeline: qué tareas corren y en qué orden. Dibujé el flujo en Excalidraw y fui iterando hasta que una forma me convenció. A partir de ahí es mecánico: creas una carpeta `.github/workflows/` y sueltas tus ficheros `.yml`. Yo tengo dos, `pre-deploy.yml` y `post-deploy.yml`, y en vez de explicar la sintaxis del YAML voy a explicar qué hace cada job.
 
-Primero ejecuto los jobs de cancel redundacy, code checking, testing y documentation en paralelo y si todo va bien, versionado y despliegue en pre-producción. Después de ver que todo fue bien y se desplegó correctamente en pre-producción, hago mis pruebas manuales sobre el featuring desarrollado o sobre el bugfixing y tras revisar que todo esta correctamente y no hay ningún problema, puedo tomar la decisión de desplegar o no en producción. Para ello solo sería necesario crear una pull request para mergear la rama de develop en master y mergearla pero, en mi workflow no acaban aquí los jobs. Después de todo esto y una vez mergeado en producción se ejecuta un último test de performance usando lighthouse y generando un reporte pagina por pagina que publico una vez el job ha finalizado.
+El `pre-deploy` corre cuatro jobs en paralelo — cancelar runs redundantes, linting, testing y docs — y solo si todos pasan versiona y despliega en pre-producción. Luego pruebo la feature o el bugfix a mano contra esa preview. Si aguanta, desplegar a producción es solo un pull request de `dev` a `master`. Pero el pipeline no acaba en el merge: una vez en vivo, el `post-deploy` corre un pase de Lighthouse y publica un informe de rendimiento página a página. Separarlo así mantiene las verificaciones rápidas bloqueando (nada se despliega roto) y las lentas contra el sitio en vivo fuera del camino crítico.
 
-Aquí se puede ver de una forma más gráfica:
+Aquí de forma más gráfica:
 
 <Image
     src="/continuos-integration.svg"
@@ -42,7 +47,7 @@ Aquí se puede ver de una forma más gráfica:
     style={{ margin: '20px 0 20px 0' }}
 />
 
-Este es un fragmento del aspecto que tiene mi workflow de pre-deploy:
+Este es un fragmento de cómo se ve el workflow de pre-deploy (Node 22, npm — ajusta las versiones a tu proyecto, esto es de lo que se queda desactualizado):
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
@@ -57,45 +62,51 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Cancel previous redundant workflow runs
-              uses: styfle/cancel-workflow-action@0.11.0
+              uses: styfle/cancel-workflow-action@0.12.1
               with:
                   access_token: ${{ secrets.TOKEN_GITHUB }}
     code_checking:
         name: Linting
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
               with:
-                  node-version: 18
-                  cache: yarn
+                  node-version: 22
+                  cache: npm
             - name: Install dependencies
+              env:
+                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
               run: |
-                  echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+                  echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
                   echo "@xabierlameiro:registry=https://npm.pkg.github.com/" >> ~/.npmrc
-                  yarn install --frozen-lockfile
+                  npm install --legacy-peer-deps
             - name: Linter
-              run: yarn run lint
+              run: npm run lint
 ```
 
 </CH.Code>
 
 Workflow completo [en mi github](https://github.com/xabierlameiro/the-last-dance/actions/workflows/pre-deploy.yml 'en mi github')
 
+## Tres cosas que merece la pena hacer desde el día uno
+
+- **Cachea la instalación.** `actions/setup-node` con `cache: npm` restaura las descargas entre runs y recorta minutos de cada job. Apúntalo a tu lockfile real.
+- **Cancela runs redundantes.** Hacer push tres veces seguidas no debería lanzar tres pipelines enteros. El paso de cancelación de arriba (o la clave `concurrency:` nativa) mata los runs superados.
+- **Guarda los secretos en secrets.** El token del registro sale de `${{ secrets.NPM_TOKEN }}`, nunca del fichero. Si un token llega a un `.npmrc` subido, rótalo — el runner lo lee del entorno, no del repo.
+
 ## Resultados
 
-Cada uno de estos reportes dispone de su propio repositorio en github y es ahí donde se publican los resultados de cada uno de los test.
+Cada informe tiene su propio repositorio en GitHub, y ahí es donde se publica la salida de cada run:
 
-Aquí puedo ver el resultado de mis jobs cada vez que hago cambios en mi proyecto:
-
--   [Reporte de testing unitario](https://coverage.xabierlameiro.com/ 'Enlace a reporte de testing unitario')
--   [Reporte de testing end to end](https://e2e.xabierlameiro.com/ 'Enlace a reporte de testing end to end')
--   [Reporte de performance](https://performance.xabierlameiro.com/ 'Enlace a reporte de performance')
--   [Documentación](https://docs.xabierlameiro.com/ 'Enlace a documentación')
--   [Biblioteca de componentes](https://storybook.xabierlameiro.com/ 'Enlace a biblioteca de componentes')
+-   [Informe de tests unitarios](https://coverage.xabierlameiro.com/ 'Enlace al informe de tests unitarios')
+-   [Informe de tests end to end](https://e2e.xabierlameiro.com/ 'Enlace al informe end to end')
+-   [Informe de rendimiento](https://performance.xabierlameiro.com/ 'Enlace al informe de rendimiento')
+-   [Documentación](https://docs.xabierlameiro.com/ 'Enlace a la documentación')
+-   [Librería de componentes](https://storybook.xabierlameiro.com/ 'Enlace a la librería de componentes')
 
 ## Conclusiones
 
-Cada vez que desarrollo un nuevo componente en React, o creo una página nueva con Nextjs tengo la seguridad de que una batería de pruebas comprueba a fondo que lo que he añadido a mi proyecto no ha roto nada del trabajo anterior. Esto es así en parte, ya que tu eres el que tiene que crear los test en las partes más delicadas y criticas de tu aplicativo.
+Cada vez que añado un componente en React o una página en Next.js, una batería de tests comprueba que no he roto el trabajo que ya estaba — lo cual solo funciona porque eres tú quien tiene que escribir los tests de las partes delicadas y críticas. El pipeline no inventa cobertura; hace cumplir la que decidiste tener.
 
-> Puedes encontrar todo este código en mi repositorio de github y si te ha gustado este contenido puedes ayudarme con una [⭐️](https://github.com/xabierlameiro/the-last-dance 'Enlace a mi github') ¡ Gracias !
+> Puedes encontrar todo este código en mi repositorio de github, y si te ha gustado puedes ayudarme con una [⭐️](https://github.com/xabierlameiro/the-last-dance 'Enlace a mi github'). ¡Gracias!

--- a/data/blog/github-workflows/github-workflows.gl.mdx
+++ b/data/blog/github-workflows/github-workflows.gl.mdx
@@ -3,7 +3,7 @@ title: 'Integración continua con Github Actions workflow'
 slug: 'integracion-continua-con-github-actions-workflow'
 author: 'Xabier Lameiro'
 category: 'Nextjs'
-tags: ['devops']
+tags: ['github-actions', 'ci', 'nextjs', 'devops']
 locale: 'gl'
 excerpt: 'Integración continua e despregamento continuo con usando as github workflow actions nun proxecto de nextjs e despregando en vercel'
 description: 'Configura CI/CD para un proxecto Next.js con GitHub Actions: lint, tests e build en cada push, e despregamento en Vercel. O YAML do workflow explicado paso a paso.'
@@ -13,6 +13,11 @@ alternate:
         { lang: 'en', url: 'continuous-integration-with-github-actions-workflow' },
         { lang: 'es', url: 'integracion-continua-con-github-actions-workflow' },
     ]
+faq:
+    - question: 'Como executo lint, tests e build en cada push con GitHub Actions?'
+      answer: 'Engade un ficheiro .github/workflows/*.yml que se dispare en push, faga checkout do código, configure Node, instale dependencias e execute os teus scripts de lint/test/build como pasos. Divídeo en jobs paralelos para localizar un fallo rápido.'
+    - question: 'Por que separar en pre-deploy e post-deploy?'
+      answer: 'O pre-deploy corre as verificacións rápidas (lint, tests, build) antes de que se despregue nada. O post-deploy corre as lentas que só teñen sentido contra o sitio en vivo, como un informe de rendemento con Lighthouse, para que nunca bloqueen o despregamento.'
 ---
 
 # Integración continua con Github Actions workflow para este Proxecto
@@ -21,17 +26,17 @@ alternate:
 
 <GoogleAdsense />
 
-Cada un proxecto é un mundo e as súas prioridades tamén o son, pero o que teñen en común é que todos necesitan ser despregados e probados. Esta parte sempre se pode facer de forma manual, pero acaba sendo algo repetitivo e tedioso. Por iso é conveniente automatizalo, e para iso existen as ferramentas de integración continua e despregamento continuo.
+Cada proxecto é un mundo e as súas prioridades tamén, pero todos teñen algo en común: hai que probalos e despregalos. Podes facelo a man, pero acaba sendo repetitivo e tedioso — que é xusto o que a integración e o despregamento continuos existen para quitar.
 
-Neste caso imos usar as [Github Actions](https://docs.github.com/en/actions/using-workflows 'Ligazón as github Actions') para automatizar o despregamento deste proxecto en [Vercel](https://vercel.com/ 'Ligazón a Vercel'), pero tamén facer unha serie de tarefas previas como son os testing, o formato do código e a xeración da documentación.
+Aquí uso as [Github Actions](https://docs.github.com/en/actions/using-workflows 'Ligazón á documentación de github Actions') para automatizar o despregamento deste proxecto en [Vercel](https://vercel.com/ 'Ligazón a vercel'), máis as verificacións previas: testing, linting, type-checking e xeración de documentación.
 
 ## Deseño
 
-O que máis tempo pode levar é, planificar como vai ser o teu pipeline, osea que tarefas vas executar e en que orde. No meu caso púxenme a debuxar en escalidraw como podería ser o meu fluxo de tarefas e tras varios intentos uno foi o que máis me convenceu. Unha vez tes esta parte mais ou menos pensada o que tes que facer é ir ao teu proxecto e crear un cartafol no seguinte roteiro .github/workflows unha vez dentro podes crear o arquivo co nome que desexes co formato .yml no meu caso teño dous pre-deploy.yml e post-deploy.yml, aquí non vou entrar en detalle de como funciona o formato .yml, pero se que vou explicar que fai cada un dos jobs que teño en cada un dos workflows.
+A parte que máis se pensa é o propio pipeline: que tarefas corren e en que orde. Debuxei o fluxo en Excalidraw e fun iterando ata que unha forma me convenceu. A partir de aí é mecánico: creas un cartafol `.github/workflows/` e soltas os teus ficheiros `.yml`. Eu teño dous, `pre-deploy.yml` e `post-deploy.yml`, e en vez de explicar a sintaxe do YAML vou explicar que fai cada job.
 
-Primeiro executo os jobs de cancel redundacy, code checking, testing e documentation en paralelo e se todo vai ben, feito unha versión e despregamento en pre-produción. Despois de ver que todo foi ben e despregouse correctamente en pre-produción, fago as miñas probas manuais sobre o featuring desenvolvido ou sobre o bugfixing e tras revisar que todo esta correctamente e non hai ningún problema, podo tomar a decisión de despregar ou non en produción. Para iso só sería necesario crear unha pull request para mergear a rama de develop en master e mergearla pero, no meu workflow non acaban aquí os jobs. Despois de todo isto e unha vez mergeado en produción execútase un último test de performance usando lighthouse e xerando un reporte pagina por pagina que publico unha vez o job ha finalizado.
+O `pre-deploy` corre catro jobs en paralelo — cancelar runs redundantes, linting, testing e docs — e só se todos pasan versiona e desprega en pre-produción. Logo probo a feature ou o bugfix a man contra esa preview. Se aguanta, despregar a produción é só un pull request de `dev` a `master`. Pero o pipeline non acaba no merge: unha vez en vivo, o `post-deploy` corre un pase de Lighthouse e publica un informe de rendemento páxina a páxina. Separalo así mantén as verificacións rápidas bloqueando (nada se desprega roto) e as lentas contra o sitio en vivo fóra do camiño crítico.
 
-Aquí pódese ver dunha forma máis gráfica:
+Aquí de forma máis gráfica:
 
 <Image
     src="/continuos-integration.svg"
@@ -42,7 +47,7 @@ Aquí pódese ver dunha forma máis gráfica:
     style={{ margin: '20px 0 20px 0' }}
 />
 
-Este é un fragmento do aspecto que ten o meu workflow de pre-deploy:
+Este é un fragmento de como se ve o workflow de pre-deploy (Node 22, npm — axusta as versións ao teu proxecto, isto é do que queda desactualizado):
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
@@ -57,45 +62,51 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Cancel previous redundant workflow runs
-              uses: styfle/cancel-workflow-action@0.11.0
+              uses: styfle/cancel-workflow-action@0.12.1
               with:
                   access_token: ${{ secrets.TOKEN_GITHUB }}
     code_checking:
         name: Linting
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
               with:
-                  node-version: 18
-                  cache: yarn
+                  node-version: 22
+                  cache: npm
             - name: Install dependencies
+              env:
+                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
               run: |
-                  echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+                  echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
                   echo "@xabierlameiro:registry=https://npm.pkg.github.com/" >> ~/.npmrc
-                  yarn install --frozen-lockfile
+                  npm install --legacy-peer-deps
             - name: Linter
-              run: yarn run lint
+              run: npm run lint
 ```
 
 </CH.Code>
 
 Workflow completo [no meu github](https://github.com/xabierlameiro/the-last-dance/actions/workflows/pre-deploy.yml 'no meu github')
 
+## Tres cousas que paga a pena facer desde o día un
+
+- **Cachea a instalación.** `actions/setup-node` con `cache: npm` restaura as descargas entre runs e recorta minutos de cada job. Apúntao ao teu lockfile real.
+- **Cancela runs redundantes.** Facer push tres veces seguidas non debería lanzar tres pipelines enteiros. O paso de cancelación de arriba (ou a clave `concurrency:` nativa) mata os runs superados.
+- **Garda os segredos en secrets.** O token do rexistro sae de `${{ secrets.NPM_TOKEN }}`, nunca do ficheiro. Se un token chega a un `.npmrc` subido, rótao — o runner léeo do contorno, non do repo.
+
 ## Resultados
 
-Cada un destes reportes dispón do seu propio repositorio en github e é aí onde se publican os resultados de cada un dos test.
+Cada informe ten o seu propio repositorio en GitHub, e aí é onde se publica a saída de cada run:
 
-Aquí podo ver o resultado dos meus jobs cada vez que fago cambios no meu proxecto:
-
--   [Reporte de testing unitario](https://coverage.xabierlameiro.com/ 'Ligazón a Reporte de testing unitario')
--   [Reporte de testing end to end](https://e2e.xabierlameiro.com/ 'Ligazón a Reporte de testing end to end')
--   [Reporte de performance](https://performance.xabierlameiro.com/ 'Ligazón a Reporte de performance')
--   [Documentación](https://docs.xabierlameiro.com/ 'Ligazón a Documentación')
--   [Biblioteca de compoñentes](https://storybook.xabierlameiro.com/ 'Ligazón a Biblioteca de compoñentes')
+-   [Informe de tests unitarios](https://coverage.xabierlameiro.com/ 'Ligazón ao informe de tests unitarios')
+-   [Informe de tests end to end](https://e2e.xabierlameiro.com/ 'Ligazón ao informe end to end')
+-   [Informe de rendemento](https://performance.xabierlameiro.com/ 'Ligazón ao informe de rendemento')
+-   [Documentación](https://docs.xabierlameiro.com/ 'Ligazón á documentación')
+-   [Biblioteca de compoñentes](https://storybook.xabierlameiro.com/ 'Ligazón á biblioteca de compoñentes')
 
 ## Conclusións
 
-Cada vez que desenvolvo un novo compoñente en React, ou creo unha páxina nova con Nextjs teño a seguridade de que unha batería de probas comproba a fondo que o que engadín ao meu proxecto non rompeu nada do traballo anterior. Isto é así en parte, xa que o teu es o que ten que crear os test nas partes máis delicadas e criticas da túa aplicativo.
+Cada vez que engado un compoñente en React ou unha páxina en Next.js, unha batería de tests comproba que non rompín o traballo que xa estaba — o cal só funciona porque es ti quen ten que escribir os tests das partes delicadas e críticas. O pipeline non inventa cobertura; fai cumprir a que decidiches ter.
 
-> Podes atopar todo este código no meu repositorio de github e se che gustou este contido podes axudarme cunha [⭐️](https://github.com/xabierlameiro/the-last-dance 'Ligazón a O meu github') Grazas !
+> Podes atopar todo este código no meu repositorio de github, e se che gustou podes axudarme cunha [⭐️](https://github.com/xabierlameiro/the-last-dance 'Ligazón ao meu github'). Grazas!

--- a/data/blog/npm-token/npm-token.en.mdx
+++ b/data/blog/npm-token/npm-token.en.mdx
@@ -3,7 +3,7 @@ title: 'Fix "Failed to replace env in config: $\{NPM_TOKEN}" in npm and yarn'
 slug: 'npm-token-solution-error'
 author: 'Xabier Lameiro'
 category: 'Error'
-tags: ['npm']
+tags: ['npm', 'yarn', 'ci']
 locale: 'en'
 excerpt: "How to avoid losing 2 hours of your life because of an NPM bug, that doesn't let you run yarn or npm commands"
 description: 'How to fix the npm/yarn error "Failed to replace env in config: ${NPM_TOKEN}" in one minute: define the missing environment variable that your .npmrc expects, or remove the stale entry.'
@@ -14,6 +14,10 @@ faq:
       answer: 'An .npmrc file references the NPM_TOKEN environment variable but it is not defined in your shell, so npm or yarn cannot expand it and aborts the command.'
     - question: 'How do I fix "Failed to replace env in config"?'
       answer: 'Define the missing variable (export NPM_TOKEN=your_token), or locate the .npmrc that references it — in the project root or in your user home directory — and remove the stale entry. Running the install with --verbose shows which .npmrc files are being read.'
+    - question: 'Where does npm look for .npmrc files?'
+      answer: 'In order: the project folder, then your home directory (~/.npmrc), then the global prefix, then npm''s built-in config. Values are merged with the closest file winning, so a stale entry in your home .npmrc can break every project.'
+    - question: 'Why does it only fail in CI?'
+      answer: 'The .npmrc references ${NPM_TOKEN} but the CI job never received that secret in its environment. Expose it as an env var on the step that runs the install (for example NPM_TOKEN: ${{ secrets.NPM_TOKEN }} in GitHub Actions).'
 ---
 
 # Possible solution for NPM - Failed to replace env in config: $\{NPM_TOKEN}
@@ -26,13 +30,11 @@ faq:
 
 npm or yarn found an `.npmrc` file that references an environment variable (`NPM_TOKEN`) that is not defined in your shell, so it cannot expand it. Either export the variable (`export NPM_TOKEN=your_token`), or find the `.npmrc` that references it — in the project root or in your user home directory — and remove the stale entry. Run the install with `--verbose` to see exactly which `.npmrc` files are being read.
 
-In this short post I am going to show a solution for the `Failed to replace env in config: ${{NPM_TOKEN}` error that occurs when trying to run a yarn or npm command.
+The error text itself is the giveaway: `Failed to replace env in config: ${{NPM_TOKEN}`. npm is telling you it tried to substitute an `${...}` placeholder and there was nothing to put in its place.
 
-You may have encountered this error at some point when trying to run a yarn or npm command. In my case it was
-because I published one of my libraries on github and in order to install it from github, I needed a token.
-This token is generated in github and stored in the system environment variables.
+## Why it happens
 
-But it is necessary to create an .npmrc file in the root of the project and add the following content:
+To install a private package from the GitHub registry you point npm at that registry and give it a token. The token lives in an environment variable so it never ends up committed, and the `.npmrc` references it by name:
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
@@ -43,10 +45,29 @@ But it is necessary to create an .npmrc file in the root of the project and add 
 
 </CH.Code>
 
-What can happen is that you leave this file outside the project folder and save it in the user folder,
-for example in my case I saved it in the folder `C:\Users\xabierlameiro\.npmrc` and that's why I got the error.
+When you run `npm install` or `yarn`, npm reads that file and expands every `${VAR}` against your current environment. If `NPM_TOKEN` is not set in that shell, it cannot replace the placeholder and aborts — that is the exact error.
 
-To solve it, what I did was:
+## The `.npmrc` files npm actually reads
+
+This is the part that turns a one-minute fix into a two-hour one. npm does not read a single `.npmrc`; it merges several, and the closest one wins. In order of precedence:
+
+1. Project: `./.npmrc`
+2. User: `~/.npmrc` (on Windows, `C:\Users\<you>\.npmrc`)
+3. Global: `$PREFIX/etc/npmrc`
+4. npm's built-in config
+
+So a line you added to your **home** `.npmrc` months ago is applied to **every** project you install, even ones that have no idea what `NPM_TOKEN` is. That is the usual reason the error shows up in a repo you never configured for the GitHub registry.
+
+## Common causes, ranked
+
+- The variable is genuinely not defined in the shell you ran the command from.
+- The `.npmrc` lives in your home folder, not the project — so it leaks into unrelated installs. This was my case: I had saved it in `C:\Users\xabierlameiro\.npmrc`, and every project inherited the `${NPM_TOKEN}` reference.
+- The variable is set in a GUI app or a different terminal tab that did not inherit the export.
+- In CI, the secret exists but was never exposed to the step's environment.
+
+## How I fixed it
+
+First I ran the install in verbose mode to see which files npm was reading:
 
 <CH.Code style={{maxWidth: 'max-content', height:'max-content', margin: '20px 0'}}>
 
@@ -56,8 +77,51 @@ yarn install --verbose
 
 </CH.Code>
 
-It showed me the paths where I was looking for the .npmrc file and I realised that I was using it from the user folder.
+The log lists the paths it checks for `.npmrc`, and that is where I saw it was pulling the config from my user folder. I **_deleted_** it from the user folder and recreated it in the root of the project, and the error was gone.
 
-I **_deleted_** it from the user folder and recreated it in the root of the project and it no longer gave me the error.
+If you instead want the token available everywhere, define it rather than removing the reference:
 
-> I hope that if the same thing happens to you, it will help.
+<CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
+
+```bash
+export NPM_TOKEN=your_token   # macOS / Linux
+setx NPM_TOKEN your_token     # Windows, new shells only
+```
+
+</CH.Code>
+
+`npm config ls -l` prints the fully merged configuration, which is the fastest way to confirm whether the token was picked up.
+
+## Fixing it in CI
+
+The most common place this bites is continuous integration, because the runner is a fresh machine with none of your local exports. The fix is to hand the secret to the step as an environment variable — the same `NPM_TOKEN` name the `.npmrc` expects. In GitHub Actions:
+
+<CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
+
+```yaml workflow.yml
+- name: Install dependencies
+  env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  run: npm install --legacy-peer-deps
+```
+
+</CH.Code>
+
+If you generate the `.npmrc` on the runner instead of committing it, write the auth line straight into the home file before installing:
+
+<CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
+
+```bash
+echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
+echo "@your-scope:registry=https://npm.pkg.github.com/" >> ~/.npmrc
+```
+
+</CH.Code>
+
+Same idea in every CI provider: the `.npmrc` reference and the environment variable have to agree on the name, and the value has to reach the process that runs the install.
+
+## Keep the token out of git
+
+One last thing, because it is a mistake I see often. The `.npmrc` that references `${NPM_TOKEN}` is safe to commit: it holds only the *name* of the variable, not its value. What must never reach git is an `.npmrc` with the literal token pasted in (`_authToken=ghp_...`). If you did that, the token is compromised the moment it is pushed — revoke and rotate it in GitHub, do not just delete the file, because git history keeps it. The rule of thumb: an `.npmrc` that only references env vars is fine to commit and actually helps your teammates; one with real secrets belongs in `.gitignore` and, better, should not exist.
+
+> Whether it happens locally or in a pipeline, the question is always the same: does the shell that runs npm actually have `NPM_TOKEN`, and is it reading the `.npmrc` you think it is? Answer those two and the error disappears.

--- a/data/blog/npm-token/npm-token.es.mdx
+++ b/data/blog/npm-token/npm-token.es.mdx
@@ -3,7 +3,7 @@ title: 'Solución al error "Failed to replace env in config: ${NPM_TOKEN}" en np
 slug: 'npm-token-solucion-error'
 author: 'Xabier Lameiro'
 category: 'Error'
-tags: ['npm']
+tags: ['npm', 'yarn', 'ci']
 locale: 'es'
 excerpt: 'Como evitar perder 2 horas de tu vida por un error de NPM, que no deja ejecutar commandos de yarn o npm.'
 description: 'Cómo arreglar en un minuto el error de npm/yarn "Failed to replace env in config: ${NPM_TOKEN}": define la variable de entorno que espera tu .npmrc o elimina la entrada obsoleta.'
@@ -14,6 +14,10 @@ faq:
       answer: 'Un fichero .npmrc referencia la variable de entorno NPM_TOKEN pero no está definida en tu shell, así que npm o yarn no pueden expandirla y abortan el comando.'
     - question: '¿Cómo se arregla "Failed to replace env in config"?'
       answer: 'Define la variable que falta (export NPM_TOKEN=tu_token) o localiza el .npmrc que la referencia — en la raíz del proyecto o en tu carpeta de usuario — y elimina la entrada obsoleta. Ejecutar la instalación con --verbose muestra qué ficheros .npmrc se están leyendo.'
+    - question: '¿Dónde busca npm los ficheros .npmrc?'
+      answer: 'En este orden: la carpeta del proyecto, luego tu directorio de usuario (~/.npmrc), luego el prefijo global y por último la configuración interna de npm. Los valores se combinan y gana el fichero más cercano, así que una entrada obsoleta en tu .npmrc de usuario puede romper todos los proyectos.'
+    - question: '¿Por qué solo falla en CI?'
+      answer: 'El .npmrc referencia ${NPM_TOKEN} pero el job de CI nunca recibió ese secreto en su entorno. Expónlo como variable de entorno en el paso que ejecuta la instalación (por ejemplo NPM_TOKEN: ${{ secrets.NPM_TOKEN }} en GitHub Actions).'
 ---
 
 # Posible solución para NPM - Failed to replace env in config: $\{NPM_TOKEN}
@@ -26,13 +30,11 @@ faq:
 
 npm o yarn han encontrado un fichero `.npmrc` que referencia una variable de entorno (`NPM_TOKEN`) que no está definida en tu shell, así que no pueden expandirla. Exporta la variable (`export NPM_TOKEN=tu_token`) o localiza el `.npmrc` que la referencia — en la raíz del proyecto o en tu carpeta de usuario — y elimina la entrada obsoleta. Ejecuta la instalación con `--verbose` para ver exactamente qué ficheros `.npmrc` se están leyendo.
 
-En este breve post voy a enseñar una solución para el error `Failed to replace env in config: ${NPM_TOKEN}` que se produce cuando se intenta ejecutar un comando de yarn o npm.
+El propio texto del error te lo dice: `Failed to replace env in config: ${NPM_TOKEN}`. npm te está avisando de que intentó sustituir un marcador `${...}` y no había nada con lo que rellenarlo.
 
-Puede ser que en algún momento te hayas encontrado con este error al intentar ejecutar un comando de yarn o npm. En mi caso fue
-por que publique una de mis librerias en github y para poder instalarla desde github, necesitaba un token.
-Este token se genera en github y se guarda en las variables de entorno del sistema.
+## Por qué pasa
 
-Pero es necesario crear un archivo .npmrc en la raiz del proyecto y añadir el siguiente contenido:
+Para instalar un paquete privado del registro de GitHub apuntas npm a ese registro y le das un token. El token vive en una variable de entorno para que nunca acabe en el repositorio, y el `.npmrc` lo referencia por su nombre:
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
@@ -43,10 +45,29 @@ Pero es necesario crear un archivo .npmrc en la raiz del proyecto y añadir el s
 
 </CH.Code>
 
-Lo que puede ocurrir es que dejes est archivo fuera de la carpeta del proyeccto y lo guardes en la carpeta de usuario,
-por ejemplo en mi caso lo guardé en la carpeta `C:\Users\xabierlameiro\.npmrc` y por eso me daba el error.
+Cuando ejecutas `npm install` o `yarn`, npm lee ese fichero y expande cada `${VAR}` contra tu entorno actual. Si `NPM_TOKEN` no está definida en esa shell, no puede reemplazar el marcador y aborta: ese es el error exacto.
 
-Para solucionarlo, lo que hice fue:
+## Los ficheros .npmrc que npm lee de verdad
+
+Esta es la parte que convierte un arreglo de un minuto en uno de dos horas. npm no lee un único `.npmrc`; combina varios, y gana el más cercano. Por orden de precedencia:
+
+1. Proyecto: `./.npmrc`
+2. Usuario: `~/.npmrc` (en Windows, `C:\Users\<tú>\.npmrc`)
+3. Global: `$PREFIX/etc/npmrc`
+4. Configuración interna de npm
+
+Así que una línea que añadiste hace meses a tu `.npmrc` de **usuario** se aplica a **todos** los proyectos que instalas, incluso los que no tienen ni idea de qué es `NPM_TOKEN`. Esa es la razón habitual de que el error aparezca en un repo que nunca configuraste para el registro de GitHub.
+
+## Causas habituales, ordenadas
+
+- La variable no está realmente definida en la shell desde la que lanzaste el comando.
+- El `.npmrc` está en tu carpeta de usuario, no en el proyecto, y se cuela en instalaciones que no tienen nada que ver. Este fue mi caso: lo había guardado en `C:\Users\xabierlameiro\.npmrc`, y todos los proyectos heredaban la referencia a `${NPM_TOKEN}`.
+- La variable está definida en una app gráfica o en otra pestaña de terminal que no heredó el export.
+- En CI, el secreto existe pero nunca se expuso al entorno del paso.
+
+## Cómo lo arreglé
+
+Primero lancé la instalación en modo verbose para ver qué ficheros estaba leyendo npm:
 
 <CH.Code style={{maxWidth: 'max-content', height:'max-content', margin: '20px 0'}}>
 
@@ -56,8 +77,51 @@ yarn install --verbose
 
 </CH.Code>
 
-Me enseñó las rutas donde estaba buscando el archivo .npmrc y me di cuenta que lo estaba usando desde en la carpeta de usuario.
+El log lista las rutas donde busca el `.npmrc`, y ahí vi que estaba cogiendo la configuración de mi carpeta de usuario. Lo **_eliminé_** de la carpeta de usuario y lo volví a crear en la raíz del proyecto, y el error desapareció.
 
-Lo **_eliminé_** de la carpeta de usuario y lo volví a crear en la raiz del proyecto y ya no me daba el error.
+Si en cambio quieres el token disponible en todas partes, defínela en vez de quitar la referencia:
 
-> Espero que si os pasa lo mismo, os sirva de ayuda.
+<CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
+
+```bash
+export NPM_TOKEN=tu_token   # macOS / Linux
+setx NPM_TOKEN tu_token     # Windows, solo shells nuevas
+```
+
+</CH.Code>
+
+`npm config ls -l` imprime la configuración combinada completa, que es la forma más rápida de confirmar si el token se ha cogido.
+
+## Cómo arreglarlo en CI
+
+El sitio donde más muerde esto es la integración continua, porque el runner es una máquina nueva sin ninguno de tus exports locales. La solución es entregar el secreto al paso como variable de entorno, con el mismo nombre `NPM_TOKEN` que espera el `.npmrc`. En GitHub Actions:
+
+<CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
+
+```yaml workflow.yml
+- name: Install dependencies
+  env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  run: npm install --legacy-peer-deps
+```
+
+</CH.Code>
+
+Si generas el `.npmrc` en el runner en vez de subirlo al repo, escribe la línea de autenticación directamente en el fichero de usuario antes de instalar:
+
+<CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
+
+```bash
+echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
+echo "@tu-scope:registry=https://npm.pkg.github.com/" >> ~/.npmrc
+```
+
+</CH.Code>
+
+La idea es la misma en cualquier proveedor de CI: la referencia del `.npmrc` y la variable de entorno tienen que coincidir en el nombre, y el valor tiene que llegar al proceso que ejecuta la instalación.
+
+## Mantén el token fuera de git
+
+Una última cosa, porque es un fallo que veo a menudo. El `.npmrc` que referencia `${NPM_TOKEN}` se puede subir sin problema: solo contiene el *nombre* de la variable, no su valor. Lo que nunca debe llegar a git es un `.npmrc` con el token literal pegado (`_authToken=ghp_...`). Si lo hiciste, el token queda comprometido en el momento en que se sube — revócalo y rótalo en GitHub, no basta con borrar el fichero, porque el historial de git lo conserva. La regla: un `.npmrc` que solo referencia variables de entorno se puede subir y hasta ayuda a tus compañeros; uno con secretos reales va al `.gitignore` y, mejor aún, no debería existir.
+
+> Ya pase en local o en un pipeline, la pregunta es siempre la misma: ¿tiene la shell que ejecuta npm realmente `NPM_TOKEN`, y está leyendo el `.npmrc` que crees? Responde a esas dos y el error desaparece.

--- a/data/blog/npm-token/npm-token.gl.mdx
+++ b/data/blog/npm-token/npm-token.gl.mdx
@@ -3,7 +3,7 @@ title: 'Solución ao erro "Failed to replace env in config: $\{NPM_TOKEN}" en np
 slug: 'npm-token-solucion-erro'
 author: 'Xabier Lameiro'
 category: 'Error'
-tags: ['npm']
+tags: ['npm', 'yarn', 'ci']
 locale: 'gl'
 excerpt: 'Como evitar perder duas horas da túa vida por un erro de NPM, que non deixa executar comandos de yarn ou npm. Este erro producíase cando se intentaba executar un comando de yarn ou npm e aparecía o seguinte erro: Failed to replace env in config: ${NPM_TOKEN}'
 description: 'Como arranxar nun minuto o erro de npm/yarn "Failed to replace env in config: ${NPM_TOKEN}": define a variable de contorno que espera o teu .npmrc ou elimina a entrada obsoleta.'
@@ -14,6 +14,10 @@ faq:
       answer: 'Un ficheiro .npmrc referencia a variable de contorno NPM_TOKEN pero non está definida na túa shell, así que npm ou yarn non poden expandila e abortan o comando.'
     - question: 'Como se arranxa "Failed to replace env in config"?'
       answer: 'Define a variable que falta (export NPM_TOKEN=o_teu_token) ou localiza o .npmrc que a referencia — na raíz do proxecto ou no teu cartafol de usuario — e elimina a entrada obsoleta. Executar a instalación con --verbose mostra que ficheiros .npmrc se están a ler.'
+    - question: 'Onde busca npm os ficheiros .npmrc?'
+      answer: 'Nesta orde: o cartafol do proxecto, logo o teu directorio de usuario (~/.npmrc), logo o prefixo global e por último a configuración interna de npm. Os valores combínanse e gaña o ficheiro máis próximo, así que unha entrada obsoleta no teu .npmrc de usuario pode romper todos os proxectos.'
+    - question: 'Por que só falla en CI?'
+      answer: 'O .npmrc referencia ${NPM_TOKEN} pero o traballo de CI nunca recibiu ese segredo no seu contorno. Exponno como variable de contorno no paso que executa a instalación (por exemplo NPM_TOKEN: ${{ secrets.NPM_TOKEN }} en GitHub Actions).'
 ---
 
 # Posible solución para NPM - Failed to replace env in config: $\{NPM_TOKEN}
@@ -26,13 +30,11 @@ faq:
 
 npm ou yarn atoparon un ficheiro `.npmrc` que referencia unha variable de contorno (`NPM_TOKEN`) que non está definida na túa shell, así que non poden expandila. Exporta a variable (`export NPM_TOKEN=o_teu_token`) ou localiza o `.npmrc` que a referencia — na raíz do proxecto ou no teu cartafol de usuario — e elimina a entrada obsoleta. Executa a instalación con `--verbose` para ver exactamente que ficheiros `.npmrc` se están a ler.
 
-Neste breve post vou ensinar unha solución para o erro `Failed to replace env in config: ${NPM_TOKEN}` que se produce cando se tenta executar un comando de yarn ou npm.
+O propio texto do erro dío: `Failed to replace env in config: ${NPM_TOKEN}`. npm está avisándote de que tentou substituír un marcador `${...}` e non había nada co que enchelo.
 
-Pode ser que nalgún momento atopáchesche con este erro ao tentar executar un comando de yarn ou npm. No meu caso foi
-por que publique unha das miñas librerias en github e para poder instalala desde github, necesitaba un token.
-Este token xérase en github e se garda nas variables de contorna do sistema.
+## Por que pasa
 
-Pero é necesario crear un arquivo .npmrc na raiz do proxecto e engadir o seguinte contido:
+Para instalar un paquete privado do rexistro de GitHub apuntas npm a ese rexistro e dáslle un token. O token vive nunha variable de contorno para que nunca acabe no repositorio, e o `.npmrc` referéncialo polo seu nome:
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
@@ -43,10 +45,29 @@ Pero é necesario crear un arquivo .npmrc na raiz do proxecto e engadir o seguin
 
 </CH.Code>
 
-O que pode ocorrer é que deixes est arquivo fóra do cartafol do proyeccto e gárdelo no cartafol de usuario,
-por exemplo no meu caso gardeino no cartafol `C:\Users\xabierlameiro\.npmrc` e por iso dábame o erro.
+Cando executas `npm install` ou `yarn`, npm le ese ficheiro e expande cada `${VAR}` contra o teu contorno actual. Se `NPM_TOKEN` non está definida nesa shell, non pode substituír o marcador e aborta: ese é o erro exacto.
 
-Para solucionalo, o que fixen foi:
+## Os ficheiros .npmrc que npm le de verdade
+
+Esta é a parte que converte un arranxo dun minuto nun de dúas horas. npm non le un único `.npmrc`; combina varios, e gaña o máis próximo. Por orde de precedencia:
+
+1. Proxecto: `./.npmrc`
+2. Usuario: `~/.npmrc` (en Windows, `C:\Users\<ti>\.npmrc`)
+3. Global: `$PREFIX/etc/npmrc`
+4. Configuración interna de npm
+
+Así que unha liña que engadiches hai meses ao teu `.npmrc` de **usuario** aplícase a **todos** os proxectos que instalas, mesmo os que non teñen nin idea de que é `NPM_TOKEN`. Esa é a razón habitual de que o erro apareza nun repo que nunca configuraches para o rexistro de GitHub.
+
+## Causas habituais, ordenadas
+
+- A variable non está realmente definida na shell desde a que lanzaches o comando.
+- O `.npmrc` está no teu cartafol de usuario, non no proxecto, e cólase en instalacións que non teñen nada que ver. Este foi o meu caso: gardárao en `C:\Users\xabierlameiro\.npmrc`, e todos os proxectos herdaban a referencia a `${NPM_TOKEN}`.
+- A variable está definida nunha aplicación gráfica ou noutra pestana de terminal que non herdou o export.
+- En CI, o segredo existe pero nunca se expuxo ao contorno do paso.
+
+## Como o arranxei
+
+Primeiro lancei a instalación en modo verbose para ver que ficheiros estaba a ler npm:
 
 <CH.Code style={{maxWidth: 'max-content', height:'max-content', margin: '20px 0'}}>
 
@@ -56,8 +77,51 @@ yarn install --verbose
 
 </CH.Code>
 
-Ensinoume os roteiros onde estaba a buscar o arquivo .npmrc e deime conta que o estaba usando desde no cartafol de usuario.
+O log lista as rutas onde busca o `.npmrc`, e aí vin que estaba collendo a configuración do meu cartafol de usuario. **_Elimineino_** do cartafol de usuario e volvino a crear na raíz do proxecto, e o erro desapareceu.
 
-**_Elimineino_** do cartafol de usuario e volvino a crear na raiz do proxecto e xa non me daba o erro.
+Se en cambio queres o token dispoñible en todas partes, defínea en vez de quitar a referencia:
 
-> Espero que se vos pasa o mesmo, sírvavos de axuda.
+<CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
+
+```bash
+export NPM_TOKEN=o_teu_token   # macOS / Linux
+setx NPM_TOKEN o_teu_token     # Windows, só shells novas
+```
+
+</CH.Code>
+
+`npm config ls -l` imprime a configuración combinada completa, que é a forma máis rápida de confirmar se o token se colleu.
+
+## Como arranxalo en CI
+
+O sitio onde máis morde isto é a integración continua, porque o runner é unha máquina nova sen ningún dos teus exports locais. A solución é entregar o segredo ao paso como variable de contorno, co mesmo nome `NPM_TOKEN` que espera o `.npmrc`. En GitHub Actions:
+
+<CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
+
+```yaml workflow.yml
+- name: Install dependencies
+  env:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  run: npm install --legacy-peer-deps
+```
+
+</CH.Code>
+
+Se xeras o `.npmrc` no runner en vez de subilo ao repo, escribe a liña de autenticación directamente no ficheiro de usuario antes de instalar:
+
+<CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
+
+```bash
+echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
+echo "@o-teu-scope:registry=https://npm.pkg.github.com/" >> ~/.npmrc
+```
+
+</CH.Code>
+
+A idea é a mesma en calquera provedor de CI: a referencia do `.npmrc` e a variable de contorno teñen que coincidir no nome, e o valor ten que chegar ao proceso que executa a instalación.
+
+## Mantén o token fóra de git
+
+Unha última cousa, porque é un fallo que vexo a miúdo. O `.npmrc` que referencia `${NPM_TOKEN}` pódese subir sen problema: só contén o *nome* da variable, non o seu valor. O que nunca debe chegar a git é un `.npmrc` co token literal pegado (`_authToken=ghp_...`). Se o fixeches, o token queda comprometido no momento en que se sobe — revócao e rótao en GitHub, non abonda con borrar o ficheiro, porque o historial de git consérvao. A regra: un `.npmrc` que só referencia variables de contorno pódese subir e ata axuda aos teus compañeiros; un con segredos reais vai ao `.gitignore` e, mellor aínda, non debería existir.
+
+> Xa pase en local ou nun pipeline, a pregunta é sempre a mesma: ten a shell que executa npm realmente `NPM_TOKEN`, e está a ler o `.npmrc` que cres? Responde a esas dúas e o erro desaparece.

--- a/data/blog/publish-report/publish-report.en.mdx
+++ b/data/blog/publish-report/publish-report.en.mdx
@@ -3,12 +3,17 @@ title: 'How to publish the test coverage report in your React application'
 slug: 'publish-report-testing-react'
 author: 'Xabier Lameiro'
 category: 'React'
-tags: ['jest']
+tags: ['jest', 'testing', 'react', 'ci']
 locale: 'en'
 excerpt: 'In this post we are going to see how to publish the test coverage report in your React application.'
 description: 'I show you how to publish the testing coverage report with jest in your React or Nextjs application, so you or people can see the testing coverage of your project.'
 image: '/posts/publish-report.png'
 alternate: [{ lang: 'es', url: 'publicar-reporte-pruebas-react' }, { lang: 'gl', url: 'publicar-informe-probas-react' }]
+faq:
+    - question: 'How do I publish a Jest coverage report?'
+      answer: 'Point coverageDirectory at a public folder, set coverageReporters to html, generate it in a postbuild step, and add a rewrite so the host serves the folder. Then deploy it like any static site.'
+    - question: 'Should I make my coverage report public?'
+      answer: 'It is fine for an open-source project so contributors can see how well it is covered, but add noindex so search engines do not treat the machine-generated pages as thin content — that can hurt the SEO of your real pages.'
 ---
 
 # How to publish the test coverage report in your React application
@@ -17,24 +22,19 @@ alternate: [{ lang: 'es', url: 'publicar-reporte-pruebas-react' }, { lang: 'gl',
 
 <GoogleAdsense />
 
-In this post we are going to see how to publish the test coverage report in your React application. For this we will use:
+You run `jest --coverage`, get a nice HTML report in `coverage/`, and then it dies on your machine. This post turns that report into a page anyone can open — useful for an open-source project where contributors want to see how well things are tested, or just to show your work. The stack is minimal:
 
 -   [Jest](https://jestjs.io/ 'Link to jestjs website')
 
-> A Perfect "alternative" for SonarQube for a small projects.
+> A perfect "alternative" to SonarQube for small projects.
 
-It is not common or necessary to publish your test report of your application, there will even be those who think that it is somewhat imprudent because
-You can expose sensitive information from your application. But the main idea of this is that if you have an open source project and you want
-so that people can contribute, it's a good idea that they can see the test report so they know how well your project is covered or
-because you want to teach people how to test an application.
+Publishing a test report is not something everyone does, and some consider it imprudent because you can leak internal detail. The honest use case is an open-source repo where the report helps people contribute, or a teaching post. If you want it gated, a path protected by user and password is enough.
 
-However, to have extra security, it is as simple as having it in a protected path with a username and password.
-
-PD: This example is developed in a web application made with **Nextjs** but it works for any web application that uses **jest**.
+PD: this example is a **Next.js** app, but it works for any web app that uses **jest**.
 
 ## 1. Path for the report
 
-The first thing we need to do is assign the jest outputDirectory to a public folder
+First, point the jest `coverageDirectory` at a public folder:
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
@@ -60,12 +60,13 @@ const customJestConfig = {
 
 </CH.Code>
 
+`collectCoverageFrom` matters more than people think: without it, coverage is computed only over files a test happened to import, which flatters your numbers. Point it at the real source globs so untested files count as 0, not as absent.
+
 ## 2. Script to modify the report
 
-What this script does is modify the path of the static files that the report needs to function as images, css, javascript, etc.
-In addition, some report texts are customized.
+The report references its CSS/JS/images with relative paths that break once it is served from a sub-path. This script rewrites those paths and customises a couple of texts:
 
-> The alternative if you use class is to use the class [CustomReporter](https://jestjs.io/docs/configuration 'Jest configuration') and implement the onRunComplete method.
+> If you prefer a class, use a Jest [CustomReporter](https://jestjs.io/docs/configuration 'Jest configuration') and implement `onRunComplete`.
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
@@ -108,9 +109,9 @@ glob('public/coverage/**/*.?(html|css)', function (err, files) {
 
 </CH.Code>
 
-## 3. Command to generate the report when the build is generated
+## 3. Generate the report on build
 
-In order for the report to be generated in the public folder when the build is finished, we need to add the following commands in the package.json
+Add a `postbuild` step so the report lands in the public folder every time you build:
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
@@ -134,9 +135,9 @@ In order for the report to be generated in the public folder when the build is f
 
 </CH.Code>
 
-## 4. Create a redirect on the server/cloud platform
+## 4. Create a redirect on the host
 
-In my case I use Vercel but whatever platform you use, you must create a redirect so that any
+So a clean URL serves the folder's `index.html`:
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
@@ -153,4 +154,13 @@ In my case I use Vercel but whatever platform you use, you must create a redirec
 
 </CH.Code>
 
-> Here you can see an example of what the test report of this blog looks like [xabierlameiro.com/coverage](https://coverage.xabierlameiro.com/ 'Coverage section')
+## One thing I got wrong: keep it out of Google
+
+Here is the part no tutorial warns you about, and it bit this very site. Once the coverage report was public, Google indexed every one of those generated HTML pages — dozens of near-identical, text-thin files. That is textbook _low value content_, and it dilutes the ranking signals of your real pages; it was part of what got this domain flagged by AdSense. Publishing the report is fine, but tell search engines to ignore it:
+
+- Inject `<meta name="robots" content="noindex">` into the generated HTML (the same reporter script that fixes the paths can add it), or
+- Serve an `X-Robots-Tag: noindex` header for the report path or subdomain.
+
+A coverage report is for humans who go looking for it, not for search results. Ship it, then hide it from crawlers.
+
+> Here is an example of what the report of this blog looks like: [coverage.xabierlameiro.com](https://coverage.xabierlameiro.com/ 'Coverage section')

--- a/data/blog/publish-report/publish-report.es.mdx
+++ b/data/blog/publish-report/publish-report.es.mdx
@@ -3,12 +3,17 @@ title: 'Como publicar el reporte de cobertura de testing en tu aplicación de Re
 slug: 'publicar-reporte-pruebas-react'
 author: 'Xabier Lameiro'
 category: 'React'
-tags: ['jest']
+tags: ['jest', 'testing', 'react', 'ci']
 locale: 'es'
 excerpt: 'En este post vamos a ver como publicar el reporte de cobertura de testing en tu aplicación de React.'
 description: 'Muestro como publicar el reporte de cobertura de testing con jest en tu aplicación de React o Nextjs, para que tu mismo o la gente pueda ver la cobertura de testing de tu proyecto.'
 image: '/posts/publish-report.png'
 alternate: [{ lang: 'en', url: 'publish-report-testing-react' }, { lang: 'gl', url: 'publicar-informe-probas-react' }]
+faq:
+    - question: '¿Cómo publico un reporte de cobertura de Jest?'
+      answer: 'Apunta coverageDirectory a una carpeta pública, pon coverageReporters en html, genéralo en un paso postbuild y añade un rewrite para que el host sirva la carpeta. Luego despliégalo como cualquier sitio estático.'
+    - question: '¿Debería hacer público mi reporte de cobertura?'
+      answer: 'Está bien para un proyecto open source para que los que contribuyen vean lo cubierto que está, pero añade noindex para que los buscadores no traten esas páginas generadas como contenido pobre, que puede perjudicar el SEO de tus páginas de verdad.'
 ---
 
 # Como publicar el reporte de cobertura de testing en tu aplicación de React
@@ -17,25 +22,19 @@ alternate: [{ lang: 'en', url: 'publish-report-testing-react' }, { lang: 'gl', u
 
 <GoogleAdsense />
 
-En este post vamos a ver como publicar el reporte de cobertura de testing en tu aplicación de React. Para ello vamos a utilizar:
+Ejecutas `jest --coverage`, obtienes un informe HTML majo en `coverage/`, y ahí muere, en tu máquina. Este post convierte ese informe en una página que cualquiera puede abrir — útil para un proyecto open source donde quien contribuye quiere ver cómo de cubierto está todo, o simplemente para enseñar tu trabajo. El stack es mínimo:
 
 -   [Jest](https://jestjs.io/ 'Enlace a jestjs.io')
 
-> Una "alternativa" perfecta a SonarQube para pequeños proyectos.
+> Una "alternativa" perfecta a SonarQube para proyectos pequeños.
 
-No es común ni necesario publicar tu reporte de testing de tu aplicación, incluso habrá quien opine que es algo inprudente por que
-puedes exponer información sensible de tu aplicación. Pero la idea principal de esto es que si tienes un proyecto open source y quieres
-que la gente pueda contribuir, es una buena idea que puedan ver el reporte de testing para que sepan que tan bien esta cubierto tu proyecto o
-por que quieres enseñar a la gente como hacer testing en de una aplicación.
+Publicar un reporte de testing no lo hace todo el mundo, y alguno lo considera imprudente porque puedes filtrar detalle interno. El caso de uso honesto es un repo open source donde el reporte ayuda a contribuir, o un post didáctico. Si lo quieres cerrado, una ruta protegida con usuario y contraseña es suficiente.
 
-Sin embargo, para tener un extra de seguridad, es tan sencillo como tenerlo en una ruta protegida con usuario y contraseña.
-
-PD: Este ejemplo está desarrollado en una aplicación web hecha con **Nextjs** pero sirve para cualquier aplicación web que
-use **jest**.
+PD: este ejemplo está hecho con **Next.js**, pero sirve para cualquier aplicación web que use **jest**.
 
 ## 1. Ruta para el reporte
 
-Lo primero que debemos hacer es asignar el outputDirectory de jest a una carpeta publica
+Lo primero es apuntar el `coverageDirectory` de jest a una carpeta pública:
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
@@ -61,12 +60,13 @@ const customJestConfig = {
 
 </CH.Code>
 
+`collectCoverageFrom` importa más de lo que parece: sin él, la cobertura se calcula solo sobre los ficheros que algún test importó, lo que infla tus números. Apúntalo a los globs reales del código para que los ficheros sin test cuenten como 0, no como ausentes.
+
 ## 2. Script para modificar el reporte
 
-Este escript lo que hace es modificar la ruta de los archivos estáticos que el reporte necesita para funcionar como imágnes, css, javascript, etc.
-Además se customizan algunos textos del reporte.
+El reporte referencia su CSS/JS/imágenes con rutas relativas que se rompen al servirlo desde una sub-ruta. Este script reescribe esas rutas y personaliza un par de textos:
 
-> La alternativa si usa la clase es usar la clase [CustomReporter](https://jestjs.io/docs/configuration 'Página de configuración de Jest') e implementar el método onRunComplete.
+> Si prefieres una clase, usa un [CustomReporter](https://jestjs.io/docs/configuration 'Configuración de Jest') de Jest e implementa `onRunComplete`.
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
@@ -109,9 +109,9 @@ glob('public/coverage/**/*.?(html|css)', function (err, files) {
 
 </CH.Code>
 
-## 3. Comando para generar el reporte cuando se genera el build
+## 3. Genera el reporte al hacer build
 
-Para que el reporte se genere en la carpeta public cuando se termina la build, debemos agregar los siguientes comandos en el package.json
+Añade un paso `postbuild` para que el reporte caiga en la carpeta pública cada vez que compilas:
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
@@ -135,9 +135,9 @@ Para que el reporte se genere en la carpeta public cuando se termina la build, d
 
 </CH.Code>
 
-## 4. Crear una redirección en el servidor/ plafatorma en la nube
+## 4. Crea un redirect en el host
 
-En mi caso uso Vercel pero cualquier plataforma que uses, debes crear una redirección para que cuando se acceda a la ruta /coverage
+Para que una URL limpia sirva el `index.html` de la carpeta:
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
@@ -154,4 +154,13 @@ En mi caso uso Vercel pero cualquier plataforma que uses, debes crear una redire
 
 </CH.Code>
 
-> Aquí puedes ver el ejemplo de como se ve el reporte de testing de este blog [xabierlameiro.com/coverage](https://coverage.xabierlameiro.com/ 'Sección de coverage')
+## Una cosa que hice mal: mantenlo fuera de Google
+
+Aquí está la parte que ningún tutorial te avisa, y que le pasó a este mismo sitio. Una vez el reporte de cobertura fue público, Google indexó cada una de esas páginas HTML generadas — decenas de ficheros casi idénticos y con poco texto. Eso es _contenido de poco valor_ de manual, y diluye las señales de ranking de tus páginas de verdad; fue parte de lo que hizo que AdSense marcara este dominio. Publicar el reporte está bien, pero dile a los buscadores que lo ignoren:
+
+- Inyecta `<meta name="robots" content="noindex">` en el HTML generado (el mismo script del reporter que arregla las rutas puede añadirlo), o
+- Sirve una cabecera `X-Robots-Tag: noindex` para la ruta o subdominio del reporte.
+
+Un reporte de cobertura es para las personas que lo buscan, no para los resultados de búsqueda. Publícalo, y luego escóndelo de los crawlers.
+
+> Aquí un ejemplo de cómo se ve el reporte de este blog: [coverage.xabierlameiro.com](https://coverage.xabierlameiro.com/ 'Sección de cobertura')

--- a/data/blog/publish-report/publish-report.gl.mdx
+++ b/data/blog/publish-report/publish-report.gl.mdx
@@ -3,12 +3,17 @@ title: 'Como publicar o informe de cobertura das probas na túa aplicación Reac
 slug: 'publicar-informe-probas-react'
 author: 'Xabier Lameiro'
 category: 'React'
-tags: ['jest']
+tags: ['jest', 'testing', 'react', 'ci']
 locale: 'gl'
 excerpt: 'Nesta publicación imos ver como publicar o informe de cobertura das probas na túa aplicación React'
 description: 'Mostro como publicar o reporte de cobertura de testing con jest na túa aplicación de React ou Nextjs, para que tí mesmo ou a xente poida ver a cobertura de testing do teu proxecto.'
 image: '/posts/publish-report.png'
 alternate: [{ lang: 'en', url: 'publish-report-testing-react' }, { lang: 'es', url: 'publicar-reporte-pruebas-react' }]
+faq:
+    - question: 'Como publico un informe de cobertura de Jest?'
+      answer: 'Apunta coverageDirectory a un cartafol público, pon coverageReporters en html, xérao nun paso postbuild e engade un rewrite para que o host sirva o cartafol. Logo despregao como calquera sitio estático.'
+    - question: 'Debería facer público o meu informe de cobertura?'
+      answer: 'Está ben para un proxecto open source para que quen contribúe vexa o cuberto que está, pero engade noindex para que os buscadores non traten esas páxinas xeradas como contido pobre, que pode prexudicar o SEO das túas páxinas de verdade.'
 ---
 
 # Como publicar o informe de cobertura das probas na túa aplicación React
@@ -17,25 +22,19 @@ alternate: [{ lang: 'en', url: 'publish-report-testing-react' }, { lang: 'es', u
 
 <GoogleAdsense />
 
-Nesta publicación imos ver como publicar o informe de cobertura das probas na súa aplicación React. Para iso utilizaremos:
+Executas `jest --coverage`, obtés un informe HTML majo en `coverage/`, e aí morre, na túa máquina. Esta publicación converte ese informe nunha páxina que calquera pode abrir — útil para un proxecto open source onde quen contribúe quere ver o cuberto que está todo, ou simplemente para ensinar o teu traballo. O stack é mínimo:
 
--   [Jest](https://jestjs.io/ 'Enlace a documentación de Jest')
+-   [Jest](https://jestjs.io/ 'Ligazón a jestjs.io')
 
-> Unha "alternativa" perfecta de SonarQube para proxectos pequenos.
+> Unha "alternativa" perfecta a SonarQube para proxectos pequenos.
 
-Non é habitual nin necesario publicar o teu informe de probas da túa aplicación, incluso haberá quen pense que é algo imprudente porque
-pode expor información confidencial da súa aplicación. Pero a idea principal disto é que se tes un proxecto de código aberto e queres
-para que a xente poida contribuír, é unha boa idea que poidan ver o informe das probas para que saiban o ben que está cuberto o seu proxecto ou
-porque queres ensinarlle á xente a probar unha aplicación.
+Publicar un informe de probas non o fai todo o mundo, e algún considérao imprudente porque podes filtrar detalle interno. O caso de uso honesto é un repo open source onde o informe axuda a contribuír, ou un post didáctico. Se o queres pechado, unha ruta protexida con usuario e contrasinal abonda.
 
-Non obstante, para ter unha seguridade adicional, é tan sinxelo como telo nun camiño protexido cun nome de usuario e contrasinal.
-
-PD: Este exemplo desenvólvese nunha aplicación web feita con **Nextjs** pero funciona para calquera aplicación web que use
-**jest**.
+PD: este exemplo está feito con **Next.js**, pero serve para calquera aplicación web que use **jest**.
 
 ## 1. Ruta para o informe
 
-O primeiro que debemos facer é asignar o jest outputDirectory a un cartafol público
+O primeiro é apuntar o `coverageDirectory` de jest a un cartafol público:
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
@@ -61,12 +60,13 @@ const customJestConfig = {
 
 </CH.Code>
 
+`collectCoverageFrom` importa máis do que parece: sen el, a cobertura calcúlase só sobre os ficheiros que algún test importou, o que infla os teus números. Apúntao aos globs reais do código para que os ficheiros sen test conten como 0, non como ausentes.
+
 ## 2. Script para modificar o informe
 
-O que fai este script é modificar a ruta dos ficheiros estáticos que precisa o informe para funcionar como imaxes, css, javascript, etc.
-Ademais, algúns textos dos informes están personalizados.
+O informe referencia o seu CSS/JS/imaxes con rutas relativas que se rompen ao servilo desde unha sub-ruta. Este script reescribe esas rutas e personaliza un par de textos:
 
-> A alternativa se usas clase é usar a clase [CustomReporter](https://jestjs.io/docs/configuration 'Páxina de configuración de Jest') e implementar o método onRunComplete.
+> Se prefires unha clase, usa un [CustomReporter](https://jestjs.io/docs/configuration 'Configuración de Jest') de Jest e implementa `onRunComplete`.
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
@@ -109,9 +109,9 @@ glob('public/coverage/**/*.?(html|css)', function (err, files) {
 
 </CH.Code>
 
-## 3. Comando para xerar o informe cando se xera a compilación
+## 3. Xera o informe ao facer build
 
-Para que o informe se xere no cartafol público cando remate a compilación, debemos engadir os seguintes comandos no package.json
+Engade un paso `postbuild` para que o informe caia no cartafol público cada vez que compilas:
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
@@ -135,9 +135,9 @@ Para que o informe se xere no cartafol público cando remate a compilación, deb
 
 </CH.Code>
 
-## 4. Crea unha redirección no servidor/plataforma na nube
+## 4. Crea un redirect no host
 
-No meu caso eu uso Vercel pero sexa cal sexa a plataforma que use, debe crear unha redirección para que cando se acceda á ruta /coverage
+Para que unha URL limpa sirva o `index.html` do cartafol:
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
@@ -154,4 +154,13 @@ No meu caso eu uso Vercel pero sexa cal sexa a plataforma que use, debe crear un
 
 </CH.Code>
 
-> Aquí podes ver un exemplo de como é o informe de proba deste blog [xabierlameiro.com/coverage](https://coverage.xabierlameiro.com/ 'Sección de cobertura de probas')
+## Unha cousa que fixen mal: mantéreno fóra de Google
+
+Aquí está a parte que ningún titorial che avisa, e que lle pasou a este mesmo sitio. Unha vez o informe de cobertura foi público, Google indexou cada unha desas páxinas HTML xeradas — decenas de ficheiros case idénticos e con pouco texto. Iso é _contido de pouco valor_ de manual, e dilúe os sinais de ranking das túas páxinas de verdade; foi parte do que fixo que AdSense marcara este dominio. Publicar o informe está ben, pero dille aos buscadores que o ignoren:
+
+- Inxecta `<meta name="robots" content="noindex">` no HTML xerado (o mesmo script do reporter que arranxa as rutas pode engadilo), ou
+- Serve unha cabeceira `X-Robots-Tag: noindex` para a ruta ou subdominio do informe.
+
+Un informe de cobertura é para as persoas que o buscan, non para os resultados de busca. Publícao, e logo escóndeo dos crawlers.
+
+> Aquí un exemplo de como se ve o informe deste blog: [coverage.xabierlameiro.com](https://coverage.xabierlameiro.com/ 'Sección de cobertura')

--- a/data/blog/publish-storybook/publish-storybook.en.mdx
+++ b/data/blog/publish-storybook/publish-storybook.en.mdx
@@ -15,6 +15,8 @@ faq:
       answer: 'Run storybook build to produce a static site in storybook-static/, then serve that folder from any static host — Vercel, Netlify or GitHub Pages. On Vercel set the build command to npm run build-storybook and the output directory to storybook-static.'
     - question: 'Where does storybook build output the files?'
       answer: 'To the storybook-static/ folder by default. That folder is a plain static site you can host anywhere.'
+    - question: 'Why is my deployed Storybook blank or missing styles?'
+      answer: 'Almost always a base-path problem: the site is served from a sub-path but the assets are requested from the root. Host it at the domain root (a subdomain like storybook.example.com) or configure the base path, and check the browser console for 404s on the JS/CSS bundles.'
 ---
 
 # Deploying my storybook is very simple
@@ -23,7 +25,11 @@ faq:
 
 <GoogleAdsense />
 
-Once your components live in Storybook you can turn it into a **static site** and host it anywhere, so your team, your clients or your future self can browse the component library online — always up to date. Here is the whole flow: the build command, a real story, and how to deploy it to Vercel, Netlify or GitHub Pages.
+Once your components live in Storybook you can turn it into a **static site** and host it anywhere, so your team, your clients or your future self can browse the component library online — always up to date. Here is the whole flow: the build command, a real story, how to deploy it, and the gotchas that actually waste your afternoon.
+
+## Why deploy it at all?
+
+Storybook running on `localhost:6006` only helps the person who ran it. Deployed, it turns into a shared surface: designers review components without cloning the repo, QA can link a bug straight to the broken state, new teammates learn the design system by clicking through it, and you get a permanent URL for every component to paste into a pull request or a design ticket. It is the cheapest living style guide you can ship — the build already exists, you are only hosting the folder it produces. The one caveat: a public Storybook exposes your internal component API, so if the library is private, put it behind auth (an access-protected preview, basic auth, or a private host) instead of a public subdomain.
 
 ## 1. Storybook commands
 
@@ -40,7 +46,7 @@ Once your components live in Storybook you can turn it into a **static site** an
 
 ## 2. Write a story for a component
 
-A story is a single rendered state of a component. Keep one `.stories.tsx` file next to each component:
+A story is a single rendered state of a component. Keep one `.stories.tsx` file next to each component. This is the classic API most tutorials still show:
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
@@ -50,18 +56,12 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import Avatar from '.';
 
 export default {
-    /* 👇 The title prop is optional.
-     * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
-     * to learn how to generate automatic titles
-     */
     title: 'Settings / Avatar',
     component: Avatar,
 } as ComponentMeta<typeof Avatar>;
 
-//👇 We create a “template” of how args map to rendering
 const Template: ComponentStory<typeof Avatar> = (args) => <Avatar {...args} />;
 
-// 👇 Each story then reuses that template
 export const Primary = Template.bind({});
 
 Primary.args = {
@@ -73,6 +73,38 @@ Primary.args = {
 ```
 
 </CH.Code>
+
+## Stories on current Storybook (CSF3)
+
+That `ComponentStory` / `ComponentMeta` pair is the Storybook 6 API and is **deprecated** from Storybook 7 onward. On Storybook 8 (the current major in 2026) the format is CSF3, which drops the template boilerplate — a story is just an object with `args`:
+
+<CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
+
+```tsx Avatar.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import Avatar from '.';
+
+const meta: Meta<typeof Avatar> = {
+    title: 'Settings / Avatar',
+    component: Avatar,
+};
+export default meta;
+
+type Story = StoryObj<typeof Avatar>;
+
+export const Primary: Story = {
+    args: {
+        name: 'Juan Carlos de Borbón',
+        description: 'Rey emérito de España',
+        img: '/avatar.png',
+        alt: 'Quien bien se vive!',
+    },
+};
+```
+
+</CH.Code>
+
+If you are migrating, `npx storybook@latest migrate csf-2-to-3` does most of the mechanical work. Pin the version in your post or repo so readers know which API they are looking at — this is exactly the kind of thing that rots.
 
 ## 3. Build the static site
 
@@ -86,14 +118,37 @@ npx serve storybook-static  # optional: preview it locally first
 
 </CH.Code>
 
+Preview it locally before you deploy. If it looks wrong when served from `serve` (a plain static server), it will look wrong on the host too — better to find out now.
+
 ## 4. Deploy the `storybook-static` folder
 
 Point any static host at that folder:
 
 -   **Vercel:** import the repo, set **Build command** to `npm run build-storybook` and **Output directory** to `storybook-static`.
 -   **Netlify:** same build command, **Publish directory** `storybook-static`.
--   **GitHub Pages:** publish `storybook-static/` from a GitHub Action (`@storybook/storybook-deployer`, or the official `upload-pages-artifact` + `deploy-pages`).
+-   **GitHub Pages:** publish `storybook-static/` from a GitHub Action (the official `upload-pages-artifact` + `deploy-pages`).
 
-That is exactly how the example below is built on every push and served from a subdomain.
+To rebuild on every push, the shape of the CI job is short:
+
+<CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
+
+```yaml storybook.yml
+- uses: actions/setup-node@v4
+  with:
+      node-version: 22
+- run: npm ci
+- run: npm run build-storybook
+# then upload/deploy ./storybook-static with your host's action
+```
+
+</CH.Code>
+
+That is exactly how the example below is built and served from a subdomain.
+
+## Gotchas that waste an afternoon
+
+- **Blank page or missing styles**: a base-path mismatch. Host at the domain root (a subdomain works well) or set the base path; the browser console will show 404s on the bundles.
+- **Peer-dependency install failures**: Storybook majors lag behind the newest React. On React 19 you may need `--legacy-peer-deps` to install, and some addons will not have caught up — check the addon's support matrix before you upgrade, not after.
+- **Stale build**: hosts cache aggressively. If your changes do not show, confirm the deploy actually rebuilt `storybook-static` and bust the CDN cache.
 
 > Here is mine deployed on a subdomain: [https://storybook.xabierlameiro.com](https://storybook.xabierlameiro.com 'Link to my storybook')

--- a/data/blog/publish-storybook/publish-storybook.es.mdx
+++ b/data/blog/publish-storybook/publish-storybook.es.mdx
@@ -18,15 +18,21 @@ faq:
       answer: 'Ejecuta storybook build para generar un sitio estático en storybook-static/, y sirve esa carpeta desde cualquier host estático — Vercel, Netlify o GitHub Pages. En Vercel pon el comando de build en npm run build-storybook y el directorio de salida en storybook-static.'
     - question: '¿Dónde deja los archivos storybook build?'
       answer: 'En la carpeta storybook-static/ por defecto. Esa carpeta es un sitio estático que puedes alojar en cualquier sitio.'
+    - question: '¿Por qué mi Storybook desplegado sale en blanco o sin estilos?'
+      answer: 'Casi siempre es un problema de base path: el sitio se sirve desde una sub-ruta pero los assets se piden desde la raíz. Alójalo en la raíz del dominio (un subdominio como storybook.ejemplo.com) o configura el base path, y mira la consola del navegador por 404 en los bundles JS/CSS.'
 ---
 
-# Desplegar mi storybook es muy sencillo
+# Desplegar mi storybook de componentes es muy sencillo
 
 <Date date="01-04-2023" />
 
 <GoogleAdsense />
 
-Una vez que tus componentes viven en Storybook, puedes convertirlo en un **sitio estático** y alojarlo donde quieras, para que tu equipo, tus clientes o tú mismo en el futuro podáis navegar la librería de componentes online — siempre actualizada. Este es el flujo completo: el comando de build, una historia real, y cómo desplegarlo en Vercel, Netlify o GitHub Pages.
+Cuando tus componentes viven en Storybook puedes convertirlo en un **sitio estático** y alojarlo donde quieras, para que tu equipo, tus clientes o tu yo del futuro naveguen la librería de componentes online — siempre actualizada. Aquí está el flujo entero: el comando de build, una story de verdad, cómo desplegarlo y los detalles que de verdad te comen la tarde.
+
+## ¿Para qué desplegarlo?
+
+Storybook corriendo en `localhost:6006` solo ayuda a quien lo ha lanzado. Desplegado, se convierte en una superficie compartida: los diseñadores revisan componentes sin clonar el repo, QA enlaza un bug directamente al estado roto, la gente nueva aprende el sistema de diseño navegándolo, y tienes una URL permanente de cada componente para pegar en un pull request o en un ticket de diseño. Es la guía de estilo viva más barata que puedes publicar — el build ya existe, solo estás alojando la carpeta que produce. La única pega: un Storybook público expone la API interna de tus componentes, así que si la librería es privada, ponlo detrás de autenticación (una preview protegida, basic auth o un host privado) en vez de en un subdominio abierto.
 
 ## 1. Comandos de Storybook
 
@@ -41,9 +47,9 @@ Una vez que tus componentes viven en Storybook, puedes convertirlo en un **sitio
 
 `storybook build` genera un sitio estático en `storybook-static/` — esa carpeta es lo que despliegas.
 
-## 2. Escribe una historia para un componente
+## 2. Escribe una story para un componente
 
-Una historia es un único estado renderizado de un componente. Mantén un archivo `.stories.tsx` junto a cada componente:
+Una story es un único estado renderizado de un componente. Mantén un fichero `.stories.tsx` junto a cada componente. Esta es la API clásica que la mayoría de tutoriales siguen enseñando:
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
@@ -53,18 +59,12 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import Avatar from '.';
 
 export default {
-    /* 👇 The title prop is optional.
-     * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
-     * to learn how to generate automatic titles
-     */
     title: 'Settings / Avatar',
     component: Avatar,
 } as ComponentMeta<typeof Avatar>;
 
-//👇 We create a “template” of how args map to rendering
 const Template: ComponentStory<typeof Avatar> = (args) => <Avatar {...args} />;
 
-// 👇 Each story then reuses that template
 export const Primary = Template.bind({});
 
 Primary.args = {
@@ -77,26 +77,81 @@ Primary.args = {
 
 </CH.Code>
 
-## 3. Construye el sitio estático
+## Stories en el Storybook actual (CSF3)
+
+Ese par `ComponentStory` / `ComponentMeta` es la API de Storybook 6 y está **deprecada** desde Storybook 7. En Storybook 8 (el major actual en 2026) el formato es CSF3, que elimina el boilerplate del template — una story es solo un objeto con `args`:
+
+<CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
+
+```tsx Avatar.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import Avatar from '.';
+
+const meta: Meta<typeof Avatar> = {
+    title: 'Settings / Avatar',
+    component: Avatar,
+};
+export default meta;
+
+type Story = StoryObj<typeof Avatar>;
+
+export const Primary: Story = {
+    args: {
+        name: 'Juan Carlos de Borbón',
+        description: 'Rey emérito de España',
+        img: '/avatar.png',
+        alt: 'Quien bien se vive!',
+    },
+};
+```
+
+</CH.Code>
+
+Si estás migrando, `npx storybook@latest migrate csf-2-to-3` hace casi todo el trabajo mecánico. Fija la versión en el post o en el repo para que quien lo lea sepa qué API está mirando — esto es justo lo que se pudre con el tiempo.
+
+## 3. Genera el sitio estático
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
 ```bash
 npm run build-storybook   # o: yarn build-storybook
 # → genera el sitio en ./storybook-static
-npx serve storybook-static  # opcional: prévialo en local primero
+npx serve storybook-static  # opcional: pruébalo en local primero
 ```
 
 </CH.Code>
+
+Pruébalo en local antes de desplegar. Si se ve mal servido con `serve` (un servidor estático pelado), se verá mal en el host también — mejor enterarte ahora.
 
 ## 4. Despliega la carpeta `storybook-static`
 
 Apunta cualquier host estático a esa carpeta:
 
--   **Vercel:** importa el repo, pon el **Build command** en `npm run build-storybook` y el **Output directory** en `storybook-static`.
--   **Netlify:** el mismo comando de build, **Publish directory** `storybook-static`.
--   **GitHub Pages:** publica `storybook-static/` desde una GitHub Action (`@storybook/storybook-deployer`, o los oficiales `upload-pages-artifact` + `deploy-pages`).
+-   **Vercel:** importa el repo, pon **Build command** en `npm run build-storybook` y **Output directory** en `storybook-static`.
+-   **Netlify:** mismo comando de build, **Publish directory** `storybook-static`.
+-   **GitHub Pages:** publica `storybook-static/` desde una GitHub Action (la oficial `upload-pages-artifact` + `deploy-pages`).
 
-Así es exactamente como se construye el ejemplo de abajo en cada push y se sirve desde un subdominio.
+Para reconstruir en cada push, el job de CI es corto:
 
-> Aquí puedes ver el ejemplo de mi storybook desplegado en un subdominio: [https://storybook.xabierlameiro.com](https://storybook.xabierlameiro.com 'Enlace a mi storybook desplegado')
+<CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
+
+```yaml storybook.yml
+- uses: actions/setup-node@v4
+  with:
+      node-version: 22
+- run: npm ci
+- run: npm run build-storybook
+# luego sube/despliega ./storybook-static con la action de tu host
+```
+
+</CH.Code>
+
+Así es exactamente como se construye el ejemplo de abajo y se sirve desde un subdominio.
+
+## Detalles que te comen la tarde
+
+- **Página en blanco o sin estilos**: un desajuste de base path. Aloja en la raíz del dominio (un subdominio va muy bien) o configura el base path; la consola del navegador te enseñará los 404 de los bundles.
+- **Fallos de instalación por peer dependencies**: los majors de Storybook van por detrás del React más nuevo. En React 19 puede que necesites `--legacy-peer-deps` para instalar, y algún addon no habrá llegado todavía — mira la matriz de soporte del addon antes de actualizar, no después.
+- **Build cacheado**: los hosts cachean agresivo. Si tus cambios no aparecen, confirma que el deploy reconstruyó de verdad `storybook-static` e invalida la caché del CDN.
+
+> Aquí está el mío desplegado en un subdominio: [https://storybook.xabierlameiro.com](https://storybook.xabierlameiro.com 'Enlace a mi storybook')

--- a/data/blog/publish-storybook/publish-storybook.gl.mdx
+++ b/data/blog/publish-storybook/publish-storybook.gl.mdx
@@ -18,15 +18,21 @@ faq:
       answer: 'Executa storybook build para xerar un sitio estático en storybook-static/, e serve esa carpeta desde calquera host estático — Vercel, Netlify ou GitHub Pages. En Vercel pon o comando de build en npm run build-storybook e o directorio de saída en storybook-static.'
     - question: 'Onde deixa os ficheiros storybook build?'
       answer: 'Na carpeta storybook-static/ por defecto. Esa carpeta é un sitio estático que podes aloxar en calquera sitio.'
+    - question: 'Por que o meu Storybook despregado sae en branco ou sen estilos?'
+      answer: 'Case sempre é un problema de base path: o sitio sérvese desde unha sub-ruta pero os assets pídense desde a raíz. Aloxao na raíz do dominio (un subdominio como storybook.exemplo.com) ou configura o base path, e mira a consola do navegador por 404 nos bundles JS/CSS.'
 ---
 
-# Despregar o meu Storybook é moi sinxelo
+# Despregar o meu Storybook de compoñentes é moi sinxelo
 
 <Date date="01-04-2023" />
 
 <GoogleAdsense />
 
-Unha vez que os teus compoñentes viven en Storybook, podes convertelo nun **sitio estático** e aloxalo onde queiras, para que o teu equipo, os teus clientes ou ti mesmo no futuro poidades navegar a libraría de compoñentes en liña — sempre actualizada. Este é o fluxo completo: o comando de build, unha historia real, e como despregalo en Vercel, Netlify ou GitHub Pages.
+Cando os teus compoñentes viven en Storybook podes convertelo nun **sitio estático** e aloxalo onde queiras, para que o teu equipo, os teus clientes ou o teu eu do futuro naveguen a biblioteca de compoñentes en liña — sempre actualizada. Aquí está o fluxo enteiro: o comando de build, unha story de verdade, como despregalo e os detalles que de verdade che comen a tarde.
+
+## Para que despregalo?
+
+Storybook correndo en `localhost:6006` só axuda a quen o lanzou. Despregado, convértese nunha superficie compartida: os deseñadores revisan compoñentes sen clonar o repo, QA liga un bug directamente ao estado roto, a xente nova aprende o sistema de deseño navegándoo, e tes unha URL permanente de cada compoñente para pegar nun pull request ou nun ticket de deseño. É a guía de estilo viva máis barata que podes publicar — o build xa existe, só estás aloxando a carpeta que produce. A única pega: un Storybook público expón a API interna dos teus compoñentes, así que se a biblioteca é privada, ponno detrás de autenticación (unha preview protexida, basic auth ou un host privado) en vez de nun subdominio aberto.
 
 ## 1. Comandos de Storybook
 
@@ -41,9 +47,9 @@ Unha vez que os teus compoñentes viven en Storybook, podes convertelo nun **sit
 
 `storybook build` xera un sitio estático en `storybook-static/` — esa carpeta é o que despregas.
 
-## 2. Escribe unha historia para un compoñente
+## 2. Escribe unha story para un compoñente
 
-Unha historia é un único estado renderizado dun compoñente. Mantén un ficheiro `.stories.tsx` xunto a cada compoñente:
+Unha story é un único estado renderizado dun compoñente. Mantén un ficheiro `.stories.tsx` xunto a cada compoñente. Esta é a API clásica que a maioría de titoriais seguen ensinando:
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
@@ -53,18 +59,12 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import Avatar from '.';
 
 export default {
-    /* 👇 The title prop is optional.
-     * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
-     * to learn how to generate automatic titles
-     */
     title: 'Settings / Avatar',
     component: Avatar,
 } as ComponentMeta<typeof Avatar>;
 
-//👇 We create a “template” of how args map to rendering
 const Template: ComponentStory<typeof Avatar> = (args) => <Avatar {...args} />;
 
-// 👇 Each story then reuses that template
 export const Primary = Template.bind({});
 
 Primary.args = {
@@ -77,26 +77,81 @@ Primary.args = {
 
 </CH.Code>
 
-## 3. Constrúe o sitio estático
+## Stories no Storybook actual (CSF3)
+
+Ese par `ComponentStory` / `ComponentMeta` é a API de Storybook 6 e está **deprecada** desde Storybook 7. En Storybook 8 (o major actual en 2026) o formato é CSF3, que elimina o boilerplate do template — unha story é só un obxecto con `args`:
+
+<CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
+
+```tsx Avatar.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import Avatar from '.';
+
+const meta: Meta<typeof Avatar> = {
+    title: 'Settings / Avatar',
+    component: Avatar,
+};
+export default meta;
+
+type Story = StoryObj<typeof Avatar>;
+
+export const Primary: Story = {
+    args: {
+        name: 'Juan Carlos de Borbón',
+        description: 'Rey emérito de España',
+        img: '/avatar.png',
+        alt: 'Quien bien se vive!',
+    },
+};
+```
+
+</CH.Code>
+
+Se estás migrando, `npx storybook@latest migrate csf-2-to-3` fai case todo o traballo mecánico. Fixa a versión no post ou no repo para que quen o lea saiba que API está mirando — isto é xusto o que apodrece co tempo.
+
+## 3. Xera o sitio estático
 
 <CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
 
 ```bash
 npm run build-storybook   # ou: yarn build-storybook
 # → xera o sitio en ./storybook-static
-npx serve storybook-static  # opcional: prevísao en local primeiro
+npx serve storybook-static  # opcional: próbao en local primeiro
 ```
 
 </CH.Code>
+
+Próbao en local antes de despregar. Se se ve mal servido con `serve` (un servidor estático pelado), verase mal no host tamén — mellor decatarte agora.
 
 ## 4. Desprega a carpeta `storybook-static`
 
 Apunta calquera host estático a esa carpeta:
 
--   **Vercel:** importa o repo, pon o **Build command** en `npm run build-storybook` e o **Output directory** en `storybook-static`.
--   **Netlify:** o mesmo comando de build, **Publish directory** `storybook-static`.
--   **GitHub Pages:** publica `storybook-static/` desde unha GitHub Action (`@storybook/storybook-deployer`, ou os oficiais `upload-pages-artifact` + `deploy-pages`).
+-   **Vercel:** importa o repo, pon **Build command** en `npm run build-storybook` e **Output directory** en `storybook-static`.
+-   **Netlify:** mesmo comando de build, **Publish directory** `storybook-static`.
+-   **GitHub Pages:** publica `storybook-static/` desde unha GitHub Action (a oficial `upload-pages-artifact` + `deploy-pages`).
 
-Así é exactamente como se constrúe o exemplo de abaixo en cada push e se serve desde un subdominio.
+Para reconstruír en cada push, o job de CI é curto:
 
-> Aquí podes ver o exemplo do meu Storybook despregado nun subdominio: [https://storybook.xabierlameiro.com](https://storybook.xabierlameiro.com 'Enlace a storybook.xabierlameiro.com')
+<CH.Code style={{maxWidth: 'max-content', margin: '20px 0'}}>
+
+```yaml storybook.yml
+- uses: actions/setup-node@v4
+  with:
+      node-version: 22
+- run: npm ci
+- run: npm run build-storybook
+# logo sobe/desprega ./storybook-static coa action do teu host
+```
+
+</CH.Code>
+
+Así é exactamente como se constrúe o exemplo de abaixo e se serve desde un subdominio.
+
+## Detalles que che comen a tarde
+
+- **Páxina en branco ou sen estilos**: un desaxuste de base path. Aloxa na raíz do dominio (un subdominio vai moi ben) ou configura o base path; a consola do navegador ensinarache os 404 dos bundles.
+- **Fallos de instalación por peer dependencies**: os majors de Storybook van por detrás do React máis novo. En React 19 pode que precises `--legacy-peer-deps` para instalar, e algún addon non chegará aínda — mira a matriz de soporte do addon antes de actualizar, non despois.
+- **Build cacheado**: os hosts cachean agresivo. Se os teus cambios non aparecen, confirma que o deploy reconstruíu de verdade `storybook-static` e invalida a caché do CDN.
+
+> Aquí está o meu despregado nun subdominio: [https://storybook.xabierlameiro.com](https://storybook.xabierlameiro.com 'Ligazón ao meu storybook')

--- a/specs/010-content-audit-opportunity.md
+++ b/specs/010-content-audit-opportunity.md
@@ -1,7 +1,10 @@
 # SDD-010: Content audit + GSC opportunity map
 
--   **Status**: Investigation only (2026-07-17) — evidence gathered, **no content/code changed**.
-    Output is a prioritized action list to feed the enrichment work and SDD-011 (content engine).
+-   **Status**: Enrichment in progress. T1 (`uncaught-error` #425 + site-wide meta) shipped in #129.
+    T2 (`npm-token`) and the T3 cluster (`deploying-my-storybook`, `publish-report-testing-react`,
+    `continuous-integration-github-actions`) enriched 2026-07-18 on `content/sdd-010-t2-t3-enrichment`
+    (all en/es/gl: deeper content, current tooling, multi-tag taxonomy per D2). Remaining: owner's
+    4-week CTR/position re-measure in GSC; net-new topics belong to SDD-011.
 -   **Data**: GSC API (`sc-domain:xabierlameiro.com`), 90 days `2026-04-18 → 2026-07-17`,
     dimensions `page` (60 rows) and `query` (142 rows); repo inventory of `data/blog`.
 -   **Related**: [002](002-seo-technical-foundation.md), [003](003-adsense-content-remediation.md)


### PR DESCRIPTION
Continues the SDD-010 "enrich-first" content plan. T1 (React error #425 + site-wide meta) shipped in #129; this PR does **T2** and the **T3 testing/CI cluster**, all three locales (en/es/gl), following the SDD-011 editorial standard (real depth, current tooling, no fabricated experience or terminal output, multi-tag taxonomy per D2).

## Posts enriched

- **`npm-token-solution-error` (T2 — the one page that converts)**: added how npm merges `.npmrc` files and why a stale home `.npmrc` breaks unrelated projects, a CI section (GitHub Actions `env` + writing the auth line on the runner), debugging with `npm config ls -l`, and a "keep the token out of git" security note. Preserved the owner's real first-hand account. Tags → `npm, yarn, ci`.
- **`deploying-my-storybook-is-very-simple` (T3, 504 impr)**: the story example used the **deprecated Storybook 6 API** (`ComponentStory`/`ComponentMeta`); added the current **CSF3** form (`Meta`/`StoryObj`, SB8/2026), a "why deploy it" section, a CI job, and real gotchas (base-path blank page, React 19 peer-deps, cache).
- **`publish-report-testing-react` (T3)**: added the honest lesson this very site learned — publishing the coverage report **got it indexed by Google as thin content** (part of the AdSense flag), so `noindex` it. Plus a `collectCoverageFrom` gotcha and a FAQ. Tags → `jest, testing, react, ci`.
- **`continuous-integration-with-github-actions-workflow` (T3)**: the workflow snippet still showed **Node 18 + yarn**; updated to the project's real **Node 22 + npm** setup, cleaned the wall-of-text design section, added cache/secrets/concurrency tips and a FAQ. Tags → `github-actions, ci, nextjs, devops`.

## Notes

- **No fabricated experience or terminal output** (SDD-011 rule). Depth comes from factual mechanics, current versions, and lessons genuinely learned on this site (the coverage-noindex story, the CI stack).
- **Galician**: fixed objective errors and wrote correct gl prose, but it still merits a native-speaker pass (same caveat as prior content PRs).
- Tag pages: multi-tags feed the in-blog **faceted** navigation (the `/blog/tag/` listing route was intentionally reverted in #130); no new standalone tag URLs are created.

## Verification

`next build` compiles (88 static pages, enriched posts included); 12/12 files parse with gray-matter; `next start` renders the new content (verified `npm-token`'s new sections and Storybook's CSF3 block serve 200).
