### PR TITLE
fix(seo): datePublished one day early - parse post date without timezone round-trip

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -113,62 +113,62 @@
 
   <url>
     <loc>https://xabierlameiro.com/blog/javascript/lighthouse-reporting-automation</loc>
-    <lastmod>2023-01-23</lastmod>
+    <lastmod>2023-01-24</lastmod>
   </url>
 
   <url>
     <loc>https://xabierlameiro.com/es/blog/javascript/automatizacion-de-informes-de-lighthouse</loc>
-    <lastmod>2023-01-23</lastmod>
+    <lastmod>2023-01-24</lastmod>
   </url>
 
   <url>
     <loc>https://xabierlameiro.com/gl/blog/javascript/automatizacion-dos-informes-de-lighthouse</loc>
-    <lastmod>2023-01-23</lastmod>
+    <lastmod>2023-01-24</lastmod>
   </url>
 
   <url>
     <loc>https://xabierlameiro.com/blog/nextjs/dark-theme</loc>
-    <lastmod>2023-02-02</lastmod>
+    <lastmod>2023-02-03</lastmod>
   </url>
 
   <url>
     <loc>https://xabierlameiro.com/es/blog/nextjs/tema-oscuro</loc>
-    <lastmod>2023-02-02</lastmod>
+    <lastmod>2023-02-03</lastmod>
   </url>
 
   <url>
     <loc>https://xabierlameiro.com/gl/blog/nextjs/tema-escuro</loc>
-    <lastmod>2023-02-02</lastmod>
+    <lastmod>2023-02-03</lastmod>
   </url>
 
   <url>
     <loc>https://xabierlameiro.com/blog/react/how-document-my-react-components-with-jsdoc</loc>
-    <lastmod>2023-01-15</lastmod>
+    <lastmod>2023-01-16</lastmod>
   </url>
 
   <url>
     <loc>https://xabierlameiro.com/es/blog/react/documentar-mis-componentes-de-react</loc>
-    <lastmod>2023-01-15</lastmod>
+    <lastmod>2023-01-16</lastmod>
   </url>
 
   <url>
     <loc>https://xabierlameiro.com/gl/blog/react/documentar-os-meus-compoñentes-de-react</loc>
-    <lastmod>2023-01-15</lastmod>
+    <lastmod>2023-01-16</lastmod>
   </url>
 
   <url>
     <loc>https://xabierlameiro.com/blog/react/filter-for-positions</loc>
-    <lastmod>2023-03-06</lastmod>
+    <lastmod>2023-03-07</lastmod>
   </url>
 
   <url>
     <loc>https://xabierlameiro.com/es/blog/react/filtro-para-posiciones</loc>
-    <lastmod>2023-03-06</lastmod>
+    <lastmod>2023-03-07</lastmod>
   </url>
 
   <url>
     <loc>https://xabierlameiro.com/gl/blog/react/filtro-para-posicions</loc>
-    <lastmod>2023-03-06</lastmod>
+    <lastmod>2023-03-07</lastmod>
   </url>
 
   <url>
@@ -188,32 +188,32 @@
 
   <url>
     <loc>https://xabierlameiro.com/blog/nextjs/counter-for-github-stars-repository</loc>
-    <lastmod>2023-01-10</lastmod>
+    <lastmod>2023-01-11</lastmod>
   </url>
 
   <url>
     <loc>https://xabierlameiro.com/es/blog/nextjs/contador-de-estrellas-de-github</loc>
-    <lastmod>2023-01-10</lastmod>
+    <lastmod>2023-01-11</lastmod>
   </url>
 
   <url>
     <loc>https://xabierlameiro.com/gl/blog/nextjs/contador-de-estrelas-de-github</loc>
-    <lastmod>2023-01-10</lastmod>
+    <lastmod>2023-01-11</lastmod>
   </url>
 
   <url>
     <loc>https://xabierlameiro.com/blog/nextjs/make-a-views-counter-with-google-analytics</loc>
-    <lastmod>2023-01-09</lastmod>
+    <lastmod>2023-01-10</lastmod>
   </url>
 
   <url>
     <loc>https://xabierlameiro.com/es/blog/nextjs/hacer-un-contador-de-vistas-con-google-analytics</loc>
-    <lastmod>2023-01-09</lastmod>
+    <lastmod>2023-01-10</lastmod>
   </url>
 
   <url>
     <loc>https://xabierlameiro.com/gl/blog/nextjs/facer-un-contador-de-vistas-con-google-analytics</loc>
-    <lastmod>2023-01-09</lastmod>
+    <lastmod>2023-01-10</lastmod>
   </url>
 
   <url>
@@ -263,17 +263,17 @@
 
   <url>
     <loc>https://xabierlameiro.com/blog/nextjs/translate-slugs-web-pages</loc>
-    <lastmod>2023-01-11</lastmod>
+    <lastmod>2023-01-12</lastmod>
   </url>
 
   <url>
     <loc>https://xabierlameiro.com/es/blog/nextjs/como-traducir-las-urls</loc>
-    <lastmod>2023-01-11</lastmod>
+    <lastmod>2023-01-12</lastmod>
   </url>
 
   <url>
     <loc>https://xabierlameiro.com/gl/blog/nextjs/como-traducir-as-urls</loc>
-    <lastmod>2023-01-11</lastmod>
+    <lastmod>2023-01-12</lastmod>
   </url>
 
   <url>

--- a/src/helpers/__test__/fileReader.test.ts
+++ b/src/helpers/__test__/fileReader.test.ts
@@ -1,0 +1,29 @@
+import { getPostBySlug } from '../fileReader';
+
+// The post date comes from the `<Date date="MM-DD-YYYY" />` tag in the MDX body and feeds
+// datePublished in the Article JSON-LD. The old implementation parsed the tag with
+// `new Date(...)` (LOCAL midnight) + `toISOString()` (UTC), which published every post one
+// day early in timezones ahead of UTC — these tests pin the timezone to catch that shift.
+describe('getPostBySlug', () => {
+    const originalTimezone = process.env.TZ;
+
+    afterEach(() => {
+        if (originalTimezone === undefined) {
+            delete process.env.TZ;
+        } else {
+            process.env.TZ = originalTimezone;
+        }
+    });
+
+    it('Should keep the calendar day of the Date tag in a timezone ahead of UTC', () => {
+        process.env.TZ = 'Europe/Madrid';
+        const post = getPostBySlug('uncaught-error-minified-react-error');
+        expect(post.meta.date).toBe('2023-01-05');
+    });
+
+    it('Should keep the calendar day of the Date tag in a timezone behind UTC', () => {
+        process.env.TZ = 'America/New_York';
+        const post = getPostBySlug('uncaught-error-minified-react-error');
+        expect(post.meta.date).toBe('2023-01-05');
+    });
+});

--- a/src/helpers/fileReader.ts
+++ b/src/helpers/fileReader.ts
@@ -101,9 +101,20 @@ const findPostBySlug = (slug: string | { params: { slug: string } }): ParsedPost
 const extractPostDate = (content: string): string | null => {
     const match = content.match(/<Date\s+date="([^"]+)"/);
     if (!match) return null;
-    const parsed = new Date(match[1]);
-    if (isNaN(parsed.getTime())) return null;
-    return parsed.toISOString().split('T')[0];
+    // Build the ISO string from the MM-DD-YYYY components directly: V8 parses non-ISO
+    // date strings as LOCAL midnight, so round-tripping through `new Date(...)` +
+    // `toISOString()` shifted every post one day early in timezones ahead of UTC
+    // (e.g. Europe/Madrid: "07-18-2026" → "2026-07-17").
+    const componentsMatch = match[1].match(/^(\d{2})-(\d{2})-(\d{4})$/);
+    if (!componentsMatch) return null;
+    const [, month, day, year] = componentsMatch;
+    // Date.UTC normalizes overflow ("13-40-2023" would roll over), so a round-trip
+    // mismatch means the components were not a real calendar date.
+    const utcDate = new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)));
+    if (utcDate.getUTCMonth() !== Number(month) - 1 || utcDate.getUTCDate() !== Number(day)) {
+        return null;
+    }
+    return `${year}-${month}-${day}`;
 };
 
 /**


### PR DESCRIPTION
## Bug

`extractPostDate` (src/helpers/fileReader.ts) parsed the `<Date date="MM-DD-YYYY" />` tag with `new Date(match[1])` + `.toISOString()`. V8 parses non-ISO date strings as **local midnight**, and `toISOString()` converts to UTC — so in any timezone ahead of UTC (the site builds in Europe/Madrid) every post's `datePublished` in the Article JSON-LD, and the sitemap `lastmod` for posts without an `updated:` field, came out **one day early** (`01-05-2023` became `2023-01-04`).

## Fix

Build the ISO date from the MM-DD-YYYY components directly — no `Date` round-trip, no timezone involved — with a `Date.UTC` normalization guard that rejects impossible dates. All 13 existing date values in the corpus match the strict format (checked before changing).

## Tests

New `src/helpers/__test__/fileReader.test.ts`: pins `TZ` ahead of (Europe/Madrid) and behind (America/New_York) UTC and asserts the calendar day survives. Confirmed the ahead-of-UTC case fails against the old implementation (`TZ=Europe/Madrid node -e` reproduces `2023-01-04`).

## Verification (run locally)

- 104/104 jest tests (50 suites) · eslint clean · tsc 0 errors
- Full `next build` (88 pages): built HTML now emits `"datePublished":"2023-01-05"` for the `01-05-2023` tag; `dateModified` (from `updated:`) untouched
- `public/sitemap.xml` regenerated: 21 `lastmod` entries move to the correct day (included in the PR)

Independent of PR #134 (content only); no overlap in changed files.
