### PR TITLE
docs(blog): link the memory leak post to the measurement case study

### DIFF
--- a/data/blog/nextjs-memory-leak/nextjs-memory-leak.en.mdx
+++ b/data/blog/nextjs-memory-leak/nextjs-memory-leak.en.mdx
@@ -5,7 +5,7 @@ author: 'Xabier Lameiro'
 category: 'Nextjs'
 tags: ['memory-leak', 'node', 'performance']
 locale: 'en'
-updated: '2026-07-21'
+updated: '2026-07-22'
 excerpt: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory · OOMKilled (exit code 137) · 504 FUNCTION_INVOCATION_TIMEOUT'
 description: 'Three open memory leaks in Next.js 15.5–16.3, how to tell which one you have from heap snapshots, and why on serverless a leak shows up as a 504 timeout.'
 image: '/posts/nextjs-memory-leak.png'
@@ -158,6 +158,8 @@ It boots your standalone build route by route in a fresh process, drives real lo
 ```
 
 That is the stepwise growth of leak 3 with the sandbox `TimeoutsManager` named in the retainer chain — the same diagnosis as above, in about three minutes.
+
+The full protocol, why each step exists, and the before/after pair that proves the diagnosis was right are in [how to measure a Next.js memory leak and prove the diagnosis](https://xabierlameiro.com/blog/nextjs/measure-nextjs-memory-leak).
 
 Two honest data points from measuring all three: #94890 reproduced with a tenth of the original load; #94919 did **not** reproduce on a standalone build even with 4,000 real mid-stream disconnections per cycle — the repro's pages answer in ~6 ms, so there is no stream left to abandon. That matches the reporter's own note that the magnitude scales with the RSC payload: if you suspect leak 2, measure your heaviest real pages, not a minimal repro. Every verdict ships with the raw snapshots and a machine-readable `run.json`, so you can verify every claim yourself in DevTools.
 

--- a/data/blog/nextjs-memory-leak/nextjs-memory-leak.es.mdx
+++ b/data/blog/nextjs-memory-leak/nextjs-memory-leak.es.mdx
@@ -5,7 +5,7 @@ author: 'Xabier Lameiro'
 category: 'Nextjs'
 tags: ['memory-leak', 'node', 'performance']
 locale: 'es'
-updated: '2026-07-21'
+updated: '2026-07-22'
 excerpt: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory · OOMKilled (exit code 137) · 504 FUNCTION_INVOCATION_TIMEOUT'
 description: 'Tres fugas de memoria abiertas en Next.js 15.5–16.3, cómo identificar la tuya con heap snapshots y por qué en serverless la fuga se disfraza de un 504.'
 image: '/posts/nextjs-memory-leak.png'
@@ -158,6 +158,8 @@ Arranca tu build standalone ruta a ruta en un proceso limpio, genera carga real 
 ```
 
 Eso es el crecimiento escalonado de la fuga 3 con el `TimeoutsManager` del sandbox nombrado en la cadena de retención — el mismo diagnóstico de arriba, en unos tres minutos.
+
+El protocolo completo, por qué existe cada paso y el par antes/después que demuestra que el diagnóstico era correcto están en [cómo medir una fuga de memoria en Next.js y demostrar el diagnóstico](https://xabierlameiro.com/blog/nextjs/medir-fuga-de-memoria-nextjs).
 
 Dos datos honestos de medir las tres: #94890 reprodujo con una décima parte de la carga original; #94919 **no** reprodujo en un build standalone ni con 4.000 desconexiones reales a mitad de stream por ciclo — las páginas del repro responden en ~6 ms, así que no queda stream que abandonar. Encaja con la nota del propio reporter de que la magnitud escala con el payload RSC: si sospechas de la fuga 2, mide tus páginas reales más pesadas, no un repro mínimo. Cada veredicto viene con los snapshots crudos y un `run.json` legible por máquina, para que verifiques cada afirmación en DevTools.
 

--- a/data/blog/nextjs-memory-leak/nextjs-memory-leak.gl.mdx
+++ b/data/blog/nextjs-memory-leak/nextjs-memory-leak.gl.mdx
@@ -5,7 +5,7 @@ author: 'Xabier Lameiro'
 category: 'Nextjs'
 tags: ['memory-leak', 'node', 'performance']
 locale: 'gl'
-updated: '2026-07-21'
+updated: '2026-07-22'
 excerpt: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory · OOMKilled (exit code 137) · 504 FUNCTION_INVOCATION_TIMEOUT'
 description: 'Tres fugas de memoria abertas en Next.js 15.5–16.3, como identificar a túa con heap snapshots e por que en serverless a fuga se disfraza dun 504.'
 image: '/posts/nextjs-memory-leak.png'
@@ -158,6 +158,8 @@ Arrinca o teu build standalone ruta a ruta nun proceso limpo, xera carga real (i
 ```
 
 Iso é o crecemento en chanzos da fuga 3 co `TimeoutsManager` do sandbox nomeado na cadea de retención — o mesmo diagnóstico de arriba, nuns tres minutos.
+
+O protocolo completo, por que existe cada paso e o par antes/despois que demostra que o diagnóstico era correcto están en [como medir unha fuga de memoria en Next.js e demostrar o diagnóstico](https://xabierlameiro.com/gl/blog/nextjs/medir-fuga-de-memoria-en-nextjs).
 
 Dous datos honestos de medir as tres: #94890 reproduciu cunha décima parte da carga orixinal; #94919 **non** reproduciu nun build standalone nin con 4.000 desconexións reais a metade de stream por ciclo — as páxinas do repro responden en ~6 ms, así que non queda stream que abandonar. Encaixa coa nota do propio reporter de que a magnitude escala co payload RSC: se sospeitas da fuga 2, mide as túas páxinas reais máis pesadas, non un repro mínimo. Cada veredicto vén cos snapshots crus e un `run.json` lexible por máquina, para que verifiques cada afirmación en DevTools.
 


### PR DESCRIPTION
## What

Adds a link from the three locales of the production memory-leak post to the
new measurement case study, at the end of the "How I measured this" section,
and bumps `updated` to 2026-07-22 on all three.

## Why

The link only ran one way: the case study points here twice, this post pointed
nowhere. This is the page with the accumulated authority and the inbound
traffic, so it is the one that should pass equity to the new post, not the
other way round.

Placement is deliberate. A reader who reaches "How I measured this" has already
diagnosed and now wants the method — that is exactly what the case study covers.

Absolute URLs, matching the convention already used for the cross-locale links
in these files.

## Not included: the heating endpoint

Looked into the red X on the header. It is not a code bug, so there is nothing
to fix in this PR:

- `/api/heating` returns `500 {"error":"Configuration error"}`, which is the
  branch that fires when `process.env.HEATING_CREDENTIALS` is missing.
- `485fa9d` renamed `NEXT_PUBLIC_HEATING` to `HEATING_CREDENTIALS` but kept a
  fallback to the old name, so production kept working. A later commit removed
  that fallback — correctly, since `NEXT_PUBLIC_*` values are exposed to the
  client bundle and this one holds the Ariston login payload.
- Production still only has the old variable set, and the code no longer reads it.

Fix is in Vercel, not here: add `HEATING_CREDENTIALS` with the value currently
in `NEXT_PUBLIC_HEATING`, delete `NEXT_PUBLIC_HEATING`, redeploy.