### PR TITLE
fix(lighthouse): use namespace import for chrome-launcher

### DIFF
--- a/lighthouse/assets/lighthouse.js
+++ b/lighthouse/assets/lighthouse.js
@@ -1,7 +1,8 @@
 // Usage: `node lighthouse/assets/lighthouse.js`
 import fs from 'fs';
 import lighthouse from 'lighthouse';
-import chromeLauncher from 'chrome-launcher';
+// chrome-launcher is native ESM and exposes no default export, only named ones.
+import * as chromeLauncher from 'chrome-launcher';
 import { chart, nodeStructure, options, DOMAIN, translations } from './constants.js';
 
 try {


### PR DESCRIPTION
## Problem

The `Lighthouse` job in `.github/workflows/post-deploy.yml` has been failing on
every deploy. From run
[29928477323](https://github.com/xabierlameiro/the-last-dance/actions/runs/29928477323):

```
lighthouse/assets/lighthouse.js:4
import chromeLauncher from 'chrome-launcher';
       ^^^^^^^^^^^^^^
SyntaxError: The requested module 'chrome-launcher' does not provide an export named 'default'
```

`chrome-launcher` is native ESM (`"type": "module"`) and exposes no default
export — only `launch`, `killAll`, `Launcher` and `getChromePath`. Checked both
`1.2.0` (the version pinned in `package-lock.json`) and `1.2.1` (what the
workflow's `npm install --legacy-peer-deps` actually resolves for `^1.2.0`):
neither has a default export, so the job cannot link the module.

## Fix

Namespace import instead of default import. `launch` and `killAll` are named
exports, so the two call sites are unchanged.

```diff
-import chromeLauncher from 'chrome-launcher';
+import * as chromeLauncher from 'chrome-launcher';
```

## Verification

Reproduced locally with the exact versions CI installs
(`chrome-launcher@1.2.1`, `lighthouse@12.8.2`): the same `SyntaxError` before
the change, and after it `npm run lighthouse-report` links, launches Chrome and
writes real reports for the sitemap URLs.

## Why it matters beyond the report

`post-deploy` also runs the `IndexNow ping` job, which is what tells Bing — and
therefore ChatGPT Search — about new posts. With Lighthouse failing on every
run the whole workflow was permanently red, so a future IndexNow failure would
have gone unnoticed. IndexNow is currently succeeding; this restores the red
status as an actual signal.
