### PR TITLE
docs(readme): match the README to the repo's actual state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,44 @@
 # the-last-dance — Personal Website
 
-My personal website and blog, built with Next.js, MDX, TypeScript, Storybook, and Jest. Deployed on Vercel.
+My personal website and blog, built with Next.js, MDX, TypeScript, Storybook and Jest. Deployed on Vercel.
 
-[![CI](https://github.com/xabierlameiro/the-last-dance/actions/workflows/ci.yml/badge.svg)](https://github.com/xabierlameiro/the-last-dance/actions/workflows/ci.yml)
+[![Post-Deploy](https://github.com/xabierlameiro/the-last-dance/actions/workflows/post-deploy.yml/badge.svg)](https://github.com/xabierlameiro/the-last-dance/actions/workflows/post-deploy.yml)
 
 ## Stack
 
-| Layer           | Choice                                    |
-| --------------- | ----------------------------------------- |
-| Framework       | Next.js (Pages Router)                    |
-| Language        | TypeScript                                |
-| Content         | MDX                                       |
-| Testing         | Jest + Testing Library + Storybook        |
-| Package manager | Yarn (Berry)                              |
-| CI/CD           | GitHub Actions + Vercel                   |
-| Node.js         | v18.20.0 (pinned in `.nvmrc`)             |
+| Layer           | Choice                                               |
+| --------------- | ---------------------------------------------------- |
+| Framework       | Next.js 15 (Pages Router)                            |
+| Language        | TypeScript                                           |
+| Content         | MDX                                                  |
+| i18n            | `en`, `es`, `gl` (Next.js i18n routing + react-intl) |
+| Unit tests      | Jest + Testing Library                               |
+| Component docs  | Storybook                                            |
+| E2E tests       | Playwright                                           |
+| Package manager | npm (`package-lock.json`)                            |
+| CI/CD           | GitHub Actions + Vercel                              |
+| Node.js         | 22 (pinned in `.nvmrc` and `engines`)                |
 
 ## Project structure
 
 ```
 data/             # Blog posts and content in MDX format
-public/           # Static assets, coverage reports, docs
+docs/             # Editorial and writing standards
+e2e/              # Playwright end-to-end tests
+lighthouse/       # Lighthouse report generator
+public/           # Static assets, coverage reports, generated docs
+scripts/          # Build and post-deploy scripts (llms.txt, posters, IndexNow, trending)
+specs/            # Design and remediation specs
 src/
   components/     # Reusable components (with Storybook stories + Jest tests)
   constants/      # App-wide constants
   context/        # React context providers
   helpers/        # Utility functions
   hooks/          # Custom React hooks
-  intl/           # i18n translations (en + es)
+  intl/           # i18n translations (en + es + gl)
   pages/          # Next.js pages and API routes
+  types/          # Shared TypeScript types
+  __tests__/      # Tests for API routes and pages
 styles/           # Global CSS styles
 ```
 
@@ -45,29 +55,63 @@ nvm use
 cp .env.example .env.development
 
 # Install dependencies
-yarn install
+npm install --legacy-peer-deps
 
 # Start development server
-yarn dev
+npm run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000).
 
+`--legacy-peer-deps` is not optional. `@code-hike/mdx@0.8.3` declares
+`peer react@"^16.8.3 || ^17 || ^18"`, which conflicts with the React 19 this
+project runs, so a plain `npm install` fails with `ERESOLVE`. CI installs the
+same way.
+
+## Environment variables
+
+`.env.example` lists every key. The ones that change behaviour locally:
+
+| Variable             | Used for                                                            |
+| -------------------- | ------------------------------------------------------------------- |
+| `NEXT_PUBLIC_DOMAIN` | Canonical URLs and hreflang tags                                    |
+| `NEXT_PUBLIC_ENV`    | Gates the Google Analytics scripts — they load only on `production` |
+| `NEXT_PUBLIC_GA`     | GA4 measurement ID for the client-side gtag scripts                 |
+| `ANALYTICS_*`        | Service-account credentials for the GA4 Data API (view counters)    |
+| `GITHUB_TOKEN`       | Repository star counter                                             |
+
 ## Scripts
 
-| Script         | Description                  |
-| -------------- | ---------------------------- |
-| `yarn dev`     | Start development server     |
-| `yarn build`   | Production build             |
-| `yarn start`   | Start production server      |
-| `yarn lint`    | ESLint                       |
-| `yarn test`    | Jest unit tests              |
-| `yarn storybook` | Start Storybook dev server |
+| Script                      | Description                                      |
+| --------------------------- | ------------------------------------------------ |
+| `npm run dev`               | Start development server                         |
+| `npm run build`             | Production build (runs `prebuild` → `llms.txt`)  |
+| `npm start`                 | Start production server                          |
+| `npm run lint`              | ESLint                                           |
+| `npm run typecheck`         | `tsc --noEmit`                                   |
+| `npm test`                  | Jest unit tests                                  |
+| `npm run coverage`          | Jest with coverage, written to `public/coverage` |
+| `npm run test:e2e`          | Playwright end-to-end tests                      |
+| `npm run storybook`         | Start Storybook dev server on port 6006          |
+| `npm run jsdoc`             | Generate API docs into `public/docs`             |
+| `npm run lighthouse-report` | Lighthouse report for every sitemap URL          |
+| `npm run trending`          | Trending-content radar                           |
+| `npm run prettier`          | Format the repository                            |
 
-## Deployment
+## CI/CD
 
-Deployed automatically to [Vercel](https://vercel.com) on every push to `master`.
+| Workflow             | Trigger              | What it does                                                                             |
+| -------------------- | -------------------- | ---------------------------------------------------------------------------------------- |
+| `post-deploy.yml`    | push to `master`     | IndexNow ping (Bing), then Lighthouse reports published to `performance-report`          |
+| `trending-radar.yml` | Mondays 07:00 UTC    | Opens an issue with data-driven post briefs; never publishes content itself              |
+| `pre-deploy.yml`     | push to `dev`        | Lint, typecheck, `npm audit`, unit + e2e tests, JSDoc, version bump, Vercel preview deploy |
+
+Production deploys to [Vercel](https://vercel.com) on every push to `master`.
+
+`pre-deploy.yml` only runs on the `dev` branch. Work has been landing on
+`master` through pull requests instead, so it has not run since July 2025 — the
+lint, typecheck, unit, e2e and audit gates it owns are currently dormant.
 
 ## License
 
-[MIT](./LICENSE)
+[MIT](./LICENSE.txt)


### PR DESCRIPTION
The README described the project as it was set up years ago. Everything
below was checked against the tree rather than rewritten from memory.

| The README said | The repo actually does |
|---|---|
| Package manager **Yarn (Berry)**, `yarn install` / `yarn dev` / `yarn test` | No `yarn.lock`, no `packageManager` field. Only `package-lock.json`; CI runs `npm install --legacy-peer-deps` |
| Node.js **v18.20.0** pinned in `.nvmrc` | `.nvmrc` says `22`; `engines.node` says `22.x` |
| CI badge → `workflows/ci.yml` | No such workflow. They are `pre-deploy.yml`, `post-deploy.yml`, `trending-radar.yml` |
| i18n: **en + es** | `next.config.js`: `locales: ['en', 'es', 'gl']` |
| Testing: Jest + Testing Library + Storybook | Playwright too, driving `e2e/` via `playwright.config.ts` |
| Structure: `data/ public/ src/ styles/` | Missing `scripts/`, `lighthouse/`, `e2e/`, `specs/`, `docs/`, `src/types/` |
| 6 scripts | Missing `typecheck`, `coverage`, `test:e2e`, `jsdoc`, `lighthouse-report`, `trending`, `prettier` |
| `[MIT](./LICENSE)` | The file is `LICENSE.txt` — broken link |
| Framework: Next.js (Pages Router) | ✅ correct, kept |

The **Running locally** section was the one that mattered: a contributor
following it ran `yarn install` against a repo that only has an npm
lockfile, producing a dependency tree CI never validates.

## Added

- An environment-variable table — `.env.example` has ten keys and the
  README explained none of them.
- A CI/CD table.
- The real reason `--legacy-peer-deps` is required: `@code-hike/mdx@0.8.3`
  declares `peer react@"^16.8.3 || ^17 || ^18"`, which conflicts with
  React 19, so a plain `npm install` fails with `ERESOLVE`. Verified by
  running it.

## One thing worth a separate decision

`pre-deploy.yml` only triggers on pushes to `dev`. Work has been landing
on `master` through pull requests, so it last ran on **2025-07-23** — its
lint, typecheck, `npm audit --omit=dev --audit-level=high`, unit-test and
Playwright gates have been dormant for a year. The README now says so,
but the fix is a workflow change, not a docs change.

The badge is deliberately post-deploy only: a `pre-deploy` badge would
render the year-old `dev` result, which is worse than no badge.

`package.json` still carries a Yarn-only `resolutions` field that npm
ignores. Left alone — it is not a docs change.
