### PR TITLE
ci(gate): run lint, typecheck, tests and audit on PRs to master

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,9 @@
 * @xabierlameiro
+
+# MDX content is executable code, not just prose. src/helpers/mdx.ts sets `blockJS: false` — required
+# by the Code Hike highlighting pipeline — so anything merged under these paths ships client-side
+# JavaScript to every visitor. `blockDangerousJS: true` blocks the obvious globals but is not a
+# sandbox. These entries exist to make that review requirement explicit; see SECURITY.md.
+/data/blog/ @xabierlameiro
+/data/home/ @xabierlameiro
+/data/legal/ @xabierlameiro

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,17 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"
+    # SDD-L01: package-ecosystem was left as the template's empty string, which is invalid — so
+    # scheduled version updates never ran. The Dependabot PRs that did arrive came from security
+    # alerts, which fire independently of this file, giving the false impression it worked.
+    - package-ecosystem: 'npm'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+      open-pull-requests-limit: 5
+    # Keeps the SHA-pinned third-party action in pre-deploy.yml current, since a pinned SHA does not
+    # receive upstream fixes on its own.
+    - package-ecosystem: 'github-actions'
+      directory: '/'
+      schedule:
+          interval: 'weekly'

--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -27,7 +27,7 @@ jobs:
         runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v5
-            - uses: actions/setup-node@v3
+            - uses: actions/setup-node@v4
               with:
                   node-version: 22
                   cache: npm
@@ -35,7 +35,7 @@ jobs:
               run: |
                   echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
                   echo "@xabierlameiro:registry=https://npm.pkg.github.com/" >> ~/.npmrc
-                  npm install --legacy-peer-deps
+                  npm ci --legacy-peer-deps --include=optional
             - name: Execute Lighthouse
               run: |
                   sleep 10m

--- a/.github/workflows/pre-deploy.yml
+++ b/.github/workflows/pre-deploy.yml
@@ -1,26 +1,40 @@
-name: Workflow Pre-Deploy
+# The quality gate. Runs on every pull request to `master` and again after merge.
+#
+# SDD-L01: this workflow used to trigger on `push: [dev]`. `dev` went stale on 2025-07-23 (its last
+# run failed) while every PR targeted `master`, so lint, typecheck, tests and `npm audit` were
+# configured, working, and never consulted on the path to production. Now `code_checking` and
+# `testing` gate the PR; the report-publishing and versioning jobs only run after merge, guarded on
+# `github.event_name == 'push'`.
+#
+# The `deploy` job was removed rather than moved: it POSTed to a Vercel deploy hook to build a
+# *preview* from `dev`. On `master`, vercel.json already has `deploymentEnabled.master = true`, so
+# the git integration deploys every push — keeping the hook would have produced two deployments per
+# merge.
+name: Quality Gate
 on:
+    pull_request:
+        branches: [master]
     push:
-        branches: [dev]
+        branches: [master]
 
+# Native replacement for styfle/cancel-workflow-action, which was pinned by mutable tag and received
+# secrets.TOKEN_GITHUB — a PAT with write access to five other repositories. `concurrency` needs no
+# token and no third-party code, so the exposure is removed rather than pinned.
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+# Least privilege by default. Only `version` writes back to this repo, and it raises its own.
 permissions:
-    contents: write
+    contents: read
 
 jobs:
-    cancel_redundancy:
-        name: Cancel Redundant Workflow Runs
-        runs-on: ubuntu-22.04
-        steps:
-            - name: Cancel previous redundant workflow runs
-              uses: styfle/cancel-workflow-action@0.11.0
-              with:
-                  access_token: ${{ secrets.TOKEN_GITHUB }}
     code_checking:
         name: Linting
         runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v5
-            - uses: actions/setup-node@v3
+            - uses: actions/setup-node@v4
               with:
                   node-version: 22
                   cache: npm
@@ -28,13 +42,16 @@ jobs:
               run: |
                   echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
                   echo "@xabierlameiro:registry=https://npm.pkg.github.com/" >> ~/.npmrc
-                  npm install --legacy-peer-deps
+                  npm ci --legacy-peer-deps --include=optional
             - name: Linter
               run: npm run lint
             - name: Type check
               run: npx tsc --noEmit
+            # Wraps `npm audit --omit=dev` with a dated allowlist, because one advisory
+            # (GHSA-mh99-v99m-4gvg) has no upstream fix and is unreachable here. A stale or expired
+            # allowlist entry fails the gate, so the exception cannot rot. See scripts/audit-gate.mjs.
             - name: Security audit (production dependencies)
-              run: npm audit --omit=dev --audit-level=high
+              run: npm run audit:prod
     testing:
         name: Testing
         runs-on: ubuntu-22.04
@@ -45,7 +62,7 @@ jobs:
             NEXT_PUBLIC_ENV: 'preview'
         steps:
             - uses: actions/checkout@v5
-            - uses: actions/setup-node@v3
+            - uses: actions/setup-node@v4
               with:
                   node-version: 22
                   cache: npm
@@ -53,16 +70,19 @@ jobs:
               run: |
                   echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
                   echo "@xabierlameiro:registry=https://npm.pkg.github.com/" >> ~/.npmrc
-                  npm install --legacy-peer-deps
+                  npm ci --legacy-peer-deps --include=optional
+            # Coverage thresholds live in jest.config.js and fail this step when breached.
             - name: Run unit tests
               run: npm run coverage
             - name: Checkout unit-report repository
+              if: github.event_name == 'push'
               uses: actions/checkout@v5
               with:
                   repository: xabierlameiro/unit-report
                   token: ${{ secrets.TOKEN_GITHUB }}
                   path: unit-report
             - name: Copy report coverage folder and publish
+              if: github.event_name == 'push'
               run: |
                   cd unit-report
                   cp -r ../public/coverage/ .
@@ -85,12 +105,14 @@ jobs:
               run: |
                   npm run test:e2e:report
             - name: Checkout e2e-report repository
+              if: github.event_name == 'push'
               uses: actions/checkout@v5
               with:
                   repository: xabierlameiro/e2e-report
                   token: ${{ secrets.TOKEN_GITHUB }}
                   path: e2e-report
             - name: Copy playwright-report/index.html to e2e-report/index.html
+              if: github.event_name == 'push'
               run: |
                   cd e2e-report
                   cp -r ../playwright-report/index.html index.html
@@ -103,6 +125,8 @@ jobs:
                   git push origin main
     documentation:
         name: Documenting
+        # Pure generate-and-publish to three other repos; nothing to verify on a PR.
+        if: github.event_name == 'push'
         runs-on: ubuntu-22.04
         env:
             NEXT_PUBLIC_DOMAIN: ${{ secrets.NEXT_PUBLIC_DOMAIN }}
@@ -110,7 +134,7 @@ jobs:
             VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
         steps:
             - uses: actions/checkout@v5
-            - uses: actions/setup-node@v3
+            - uses: actions/setup-node@v4
               with:
                   node-version: 22
                   cache: npm
@@ -118,7 +142,7 @@ jobs:
               run: |
                   echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
                   echo "@xabierlameiro:registry=https://npm.pkg.github.com/" >> ~/.npmrc
-                  npm install --legacy-peer-deps
+                  npm ci --legacy-peer-deps --include=optional
             - name: Generate documentation
               run: npm run jsdoc
             - name: Checkout doc repository
@@ -158,8 +182,12 @@ jobs:
                   git push origin main
     version:
         name: Versioning
+        if: github.event_name == 'push'
         runs-on: ubuntu-22.04
         needs: [code_checking, testing, documentation]
+        # The only job that writes to this repository, so the only one that needs the scope.
+        permissions:
+            contents: write
         steps:
             - name: Checkout version repository
               uses: actions/checkout@v5
@@ -167,24 +195,22 @@ jobs:
                   fetch-depth: 0
                   token: ${{ secrets.TOKEN_GITHUB }}
             - name: Version
+              # Pinned to the v5.0.2 commit rather than the mutable tag: this step runs in a checkout
+              # where TOKEN_GITHUB is persisted, so a retargeted tag would inherit that access.
               id: version
-              uses: paulhatch/semantic-version@v5.0.2
+              uses: paulhatch/semantic-version@ea50fff3e41d24bb283f22b7343c4b3a314282fb
               with:
                   version_format: '${major}.${minor}.${patch}'
                   major_pattern: 'MAJOR -'
                   minor_pattern: 'MINOR -'
             - name: Update version in package.json and add tag
+              # `[skip ci]` stops the version bump from re-triggering this workflow. It was harmless
+              # while the trigger was `push: [dev]` and the bump landed elsewhere; now that the
+              # trigger is `push: [master]` and the bump pushes to master, without it every release
+              # would start another run, which would release again. The marker is honoured for
+              # `push` and `pull_request` events.
               run: |
                   git config --global user.email "action@github.com"
                   git config --global user.name "GitHub Action"
-                  npm version ${{ steps.version.outputs.version }}
+                  npm version ${{ steps.version.outputs.version }} -m "chore(release): %s [skip ci]"
                   git push --follow-tags
-
-    deploy:
-        name: Trigger deploy on preview environment
-        runs-on: ubuntu-22.04
-        needs: [version]
-        steps:
-            - name: Deploy to Vercel
-              run: |
-                  curl -X POST https://api.vercel.com/v1/integrations/deploy/${{ secrets.PRJ }}

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ migration/.next
 
 # local dev-server config (Claude Code Browser pane), machine-specific
 .claude/launch.json
+
+# Playwright artifacts (written into the repo root by `npm run test:e2e`)
+/playwright-report
+/test-results

--- a/.npmrc
+++ b/.npmrc
@@ -7,5 +7,14 @@
 ; This does NOT weaken security: the real gate is the production-scoped
 ; `npm audit --omit=dev --audit-level=high` step in .github/workflows/pre-deploy.yml,
 ; which the explicit `npm audit` command still runs regardless of this flag, plus
-; Dependabot alerts. `npm audit --omit=dev` reports 0 vulnerabilities.
+; Dependabot alerts.
+;
+; SDD-L01 correction (2026-07-26): this comment used to claim `npm audit --omit=dev` reports 0
+; vulnerabilities. It reports 8 high, all of them the same advisory — brace-expansion unbounded
+; expansion (CWE-400), reached via googleapis -> gaxios -> rimraf -> glob -> minimatch. Not
+; exploitable here: brace-expansion only runs when something expands a brace glob, and no
+; request-controlled string reaches a glob on the searchConsole request path. But the claim was
+; false, and it was the stated justification for this flag, so it is corrected rather than left
+; standing. The production audit gate now runs on every PR to master, where it will fail on this
+; advisory until googleapis ships a fix — that failure is the intended signal.
 audit=false

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,21 +1,50 @@
 # Security Policy
 
-## Supported Versions
+## Reporting a vulnerability
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
+Please report security issues **privately**, using GitHub's private vulnerability reporting on this
+repository: open the **Security** tab and choose *Report a vulnerability*. That opens a channel only
+the maintainer can see.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+Please do not open a public issue for a security problem, and please do not disclose it publicly
+before it is fixed.
 
-## Reporting a Vulnerability
+What to expect:
 
-Use this section to tell people how to report a vulnerability.
+- **Acknowledgement** within 7 days.
+- **An assessment** — whether it is confirmed, and the intended fix — within 30 days.
+- **Credit** in the fix commit or release notes if you would like it. Say so in your report.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+This is a personal site maintained by one person in their own time, so please read those windows as
+good-faith targets rather than a service level agreement.
+
+## Scope
+
+The site is `xabierlameiro.com` and this repository is its source. In scope:
+
+- The public API routes under `src/pages/api/`.
+- Anything that could expose the maintainer's credentials or third-party API tokens.
+- Cross-site scripting, request forgery, or injection through the MDX content pipeline.
+- Dependency vulnerabilities that are actually reachable from production code.
+
+Out of scope:
+
+- Findings that only apply to development or test tooling and never ship. See
+  `specs/008-dev-audit-vulnerabilities.md` for the standing assessment, and
+  `scripts/audit-gate.mjs` for the reviewed exceptions in production dependencies.
+- Missing security headers that are load-bearing for Google Analytics or AdSense. The
+  `Content-Security-Policy` in `next.config.js` documents which directives are deliberate and why.
+- Volumetric denial of service.
+
+## Supported versions
+
+There is one deployed version — whatever `master` currently is. There are no maintained release
+branches, so fixes land on `master` and deploy from there. The `version` field in `package.json` is
+a release counter, not a support matrix.
+
+## Content contributions are executable code
+
+`src/helpers/mdx.ts` deliberately allows JavaScript expressions in MDX (`blockJS: false`) because the
+syntax-highlighting pipeline requires them. A merged pull request touching `data/blog/**` or
+`data/home/**` therefore ships client-side JavaScript to every visitor. `.github/CODEOWNERS` marks
+those paths so the review requirement is explicit rather than remembered.

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,19 +19,41 @@ const customJestConfig = {
     ],
     testPathIgnorePatterns: ['e2e', 'migration'],
     coverageDirectory: 'public/coverage',
+    // SDD-L01. Coverage was collected and published for a long time without any threshold, so
+    // nothing stopped it sliding. These numbers are the floor MEASURED on 2026-07-26 after the
+    // collectCoverageFrom globs below were corrected (84.39 stmts / 67.63 branches / 81.44 funcs),
+    // rounded down by about a point of tolerance. They are a ratchet, not a target: raise them when
+    // coverage genuinely improves, and never lower them to make a red build green.
+    //
+    // Global-only on purpose. Jest also accepts per-directory keys, but its documented interaction
+    // with `global` is ambiguous about whether matched files are excluded from the global aggregate
+    // — and a threshold whose semantics are unclear is worse than one fewer threshold. Per-path
+    // floors for src/helpers/ (63% stmts) and src/hooks/ (77%) belong in SDD-L10, once the
+    // behaviour is pinned down empirically.
+    coverageThreshold: {
+        global: {
+            statements: 83,
+            branches: 66,
+            functions: 80,
+            lines: 83,
+        },
+    },
     testEnvironment: 'jest-environment-jsdom',
     // html powers the published report; lcovonly feeds Sonar and json feeds fallow health --coverage
     coverageReporters: ['html', 'lcovonly', 'json'],
     // helpers and API routes hold unit-testable logic and belong in the coverage picture;
     // leaving them out reported 84% while a third of the codebase was simply unmeasured.
     // src/pages/**/*.tsx stays out on purpose: those are integration-level, covered by e2e.
+    // Match both extensions per directory. Single-extension globs silently dropped three tested
+    // modules from the denominator — src/components/SEO/jsonLd.ts, src/constants/survey.tsx (the XSS
+    // sanitiser) and src/helpers/mdxjs.tsx — which is the same blind spot the note above describes.
     collectCoverageFrom: [
-        'src/components/**/*.tsx',
-        'src/hooks/**/*.ts',
-        'src/helpers/**/*.ts',
+        'src/components/**/*.{ts,tsx}',
+        'src/hooks/**/*.{ts,tsx}',
+        'src/helpers/**/*.{ts,tsx}',
         'src/pages/api/**/*.ts',
-        'src/constants/**/*.ts',
-        'src/context/**/*.tsx',
+        'src/constants/**/*.{ts,tsx}',
+        'src/context/**/*.{ts,tsx}',
         'scripts/trending/lib.js',
     ],
     moduleNameMapper: {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "start:debugg": "cross-env NODE_OPTIONS='--inspect' next start",
         "start": "next start",
         "lint": "eslint .",
+        "audit:prod": "node scripts/audit-gate.mjs",
         "typecheck": "tsc --noEmit",
         "test": "jest --silent",
         "coverage": "rm -rf public/coverage && jest --coverage --silent && node custom-reporter.js",

--- a/scripts/audit-gate.mjs
+++ b/scripts/audit-gate.mjs
@@ -1,0 +1,128 @@
+/**
+ * Production dependency audit gate.
+ *
+ * SDD-L01. Replaces a bare `npm audit --omit=dev --audit-level=high` in CI, which cannot express
+ * "this specific advisory is known, unreachable, and has no upstream fix yet". The choice was
+ * between weakening the gate to `--audit-level=critical` (which would also stop reporting real high
+ * findings) and an explicit, dated exception. This is the exception.
+ *
+ * Three things make the allowlist honest rather than a mute button:
+ *   1. An entry must name the advisory, why it is unreachable, and a review date.
+ *   2. A stale entry FAILS the gate. If an allowlisted advisory disappears upstream, the entry has
+ *      to be deleted — an allowlist that silently outlives its cause is how audit gates rot.
+ *   3. A past review date FAILS the gate, so an exception cannot be permanent by neglect.
+ *
+ * Anything high or critical that is not allowlisted fails, exactly as before.
+ */
+import { execFileSync } from 'node:child_process';
+
+const BLOCKING = new Set(['high', 'critical']);
+
+/**
+ * @type {Array<{id: number, ghsa: string, package: string, reason: string, reviewBy: string}>}
+ */
+const ALLOWLIST = [
+    {
+        id: 1124334,
+        ghsa: 'GHSA-mh99-v99m-4gvg',
+        package: 'brace-expansion',
+        reason:
+            'DoS via unbounded brace expansion (CWE-400/770, CVSS 7.5), range <=5.0.7. Reached only ' +
+            'as googleapis -> googleapis-common -> gaxios -> rimraf -> glob -> minimatch -> ' +
+            'brace-expansion. rimraf runs on googleapis\' own cleanup paths; no request-controlled ' +
+            'string reaches a glob pattern anywhere in this app (searchConsole.ts passes fixed ' +
+            'resource names, and api/indexed-pages.ts reads a fixed literal path), so the ' +
+            'expansion this advisory abuses is never fed attacker input. ' +
+            'No upstream fix: googleapis is already at its latest (173.0.0) and the vulnerable ' +
+            'chain sits below it. Forcing brace-expansion to ^5.0.8 via overrides was tried and ' +
+            'REJECTED — it clears the audit but breaks runtime, because minimatch@9 calls ' +
+            'brace_expansion_1.default() and 5.x dropped the default export ' +
+            '("TypeError: (0, brace_expansion_1.default) is not a function"). A green audit over ' +
+            'broken globbing is worse than a documented exception.',
+        reviewBy: '2026-10-26',
+    },
+];
+
+// Resolve both executables absolutely rather than letting the shell search PATH — a PATH lookup in a
+// CI script is a hijack surface, and sonarjs/no-os-command-from-path rejects it. `npm_execpath` is
+// npm's own CLI entry point, set whenever this runs through an npm script.
+const npmCliPath = process.env.npm_execpath;
+if (!npmCliPath) {
+    console.error('Run this through npm (`npm run audit:prod`) so npm_execpath is set.');
+    process.exit(1);
+}
+
+const raw = (() => {
+    try {
+        // npm audit exits non-zero when it finds anything, so the throw is expected, not an error.
+        return execFileSync(process.execPath, [npmCliPath, 'audit', '--omit=dev', '--json'], {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+    } catch (err) {
+        if (err.stdout) return err.stdout;
+        throw err;
+    }
+})();
+
+const report = JSON.parse(raw);
+const allowedIds = new Set(ALLOWLIST.map((entry) => entry.id));
+
+/** Advisory ids actually present in this audit, mapped to the packages they affect. */
+const present = new Map();
+for (const [pkg, vuln] of Object.entries(report.vulnerabilities ?? {})) {
+    if (!BLOCKING.has(vuln.severity)) continue;
+    for (const via of vuln.via) {
+        if (typeof via !== 'object') continue;
+        if (!present.has(via.source)) present.set(via.source, { title: via.title, packages: new Set() });
+        present.get(via.source).packages.add(pkg);
+    }
+}
+
+const failures = [];
+
+for (const [id, info] of present) {
+    if (allowedIds.has(id)) continue;
+    failures.push(
+        `Unreviewed advisory ${id}: ${info.title}\n` +
+            `    packages: ${[...info.packages].join(', ')}\n` +
+            `    Fix it, or add a dated entry to ALLOWLIST in scripts/audit-gate.mjs explaining why it is unreachable.`
+    );
+}
+
+const today = new Date().toISOString().slice(0, 10);
+for (const entry of ALLOWLIST) {
+    if (!present.has(entry.id)) {
+        failures.push(
+            `Stale allowlist entry ${entry.id} (${entry.ghsa}, ${entry.package}): the advisory no longer ` +
+                `appears in the production audit. Delete the entry — it is now hiding nothing and would ` +
+                `hide a regression if the advisory returned.`
+        );
+        continue;
+    }
+    if (entry.reviewBy < today) {
+        failures.push(
+            `Allowlist entry ${entry.id} (${entry.ghsa}) was due for review on ${entry.reviewBy}. ` +
+                `Re-check whether an upstream fix exists, then either remove the entry or move the date.`
+        );
+    }
+}
+
+const counts = report.metadata?.vulnerabilities ?? {};
+console.log(
+    `Production audit: ${counts.critical ?? 0} critical, ${counts.high ?? 0} high, ` +
+        `${counts.moderate ?? 0} moderate, ${counts.low ?? 0} low.`
+);
+for (const entry of ALLOWLIST) {
+    if (present.has(entry.id)) {
+        console.log(`  allowed until ${entry.reviewBy}: ${entry.ghsa} (${entry.package})`);
+    }
+}
+
+if (failures.length > 0) {
+    console.error(`\nAudit gate failed with ${failures.length} issue(s):\n`);
+    for (const failure of failures) console.error(`  - ${failure}\n`);
+    process.exit(1);
+}
+
+console.log('Audit gate passed: no unreviewed high or critical advisories in production dependencies.');

--- a/vercel.json
+++ b/vercel.json
@@ -8,5 +8,5 @@
         }
     },
     "buildCommand": "npm run build",
-    "installCommand": "npm install --legacy-peer-deps --include=optional"
+    "installCommand": "npm ci --legacy-peer-deps --include=optional"
 }


### PR DESCRIPTION
## Why

The quality suite was configured, working, and never consulted on the path to production.

```
pre-deploy.yml   triggered on: push → [dev]
origin/dev       last commit 2025-07-23   (12 months stale)
last run         2025-07-23 → failure
origin/master    deploys via vercel.json, protection: {checks: null, reviews: 0}
```

Every recent PR targeted `master`, no workflow had a `pull_request` trigger, and `master` had no
required checks. So the path from commit to production was: open PR → merge (nothing blocks) →
Vercel deploys. Lint, typecheck, tests, coverage and `npm audit` all existed and were all bypassed.

This PR makes them run. It is phase 1 of a 10-phase remediation plan from a full audit; its only
job is to make the other nine enforceable.

## What changed

**The gate**
- Trigger on `pull_request: [master]`. `Linting` and `Testing` run on PRs; the report-publishing and
  versioning jobs are guarded on `github.event_name == 'push'`.
- `[skip ci]` on the version bump. Harmless while the trigger was `dev`; on `master` the bump pushes
  to the branch it triggers on, so without it every release would release again.
- `deploy` job **removed**, not moved: it POSTed to a hook for a `dev` → preview build, and
  `vercel.json` already deploys `master` via the git integration. Keeping it would double-deploy.

**Supply chain**
- `styfle/cancel-workflow-action` **removed** in favour of native `concurrency` — it was pinned by
  mutable tag and received a PAT with write access to five other repos. No token, no third-party
  code. `paulhatch/semantic-version` pinned to its v5.0.2 commit.
- Workflow permissions narrowed to `contents: read`, raised only by the `version` job.
- `npm install` → `npm ci` everywhere including `vercel.json`. This closed a live drift: `next` was
  installed at 15.5.20 against a declared `^15.5.21`.

**Coverage**
- The globs matched one extension per directory, silently dropping `SEO/jsonLd.ts` and the XSS
  sanitiser `constants/survey.tsx` from the denominator. Both are at 100%. `helpers/mdxjs.tsx` is at
  0% and now visible.
- `coverageThreshold` added at the measured floor, verified to fail the build when breached.

**Audit**
- `scripts/audit-gate.mjs` replaces bare `npm audit`, with one dated allowlist entry for
  `GHSA-mh99-v99m-4gvg`. A stale or expired entry fails the gate, so the exception cannot rot.

**Hygiene** — dependabot's empty `package-ecosystem` (so version updates ran for the first time),
`setup-node` v3 → v4, Playwright artifacts gitignored, the false "0 vulnerabilities" claim in
`.npmrc` corrected, template `SECURITY.md` replaced, `data/**` marked in `CODEOWNERS`.

## Measured

| | Before | After |
|---|---|---|
| Gate on path to production | none | lint + tsc + audit + coverage per PR |
| `next` installed vs declared | 15.5.20 vs `^15.5.21` | 15.5.21 |
| Coverage files instrumented | 74 | **78** |
| Statements | 84.93% (wrong denominator) | **84.39%** (honest) |
| Branches | 67.07% | **67.63%** |
| Coverage threshold | none | 83/66/80/83, fails when breached |
| Production audit exit | 1 (8 high, unreviewed) | **0** (6 high, 1 dated exception) |

Local run: `lint` PASS · `tsc --noEmit` PASS · `audit:prod` PASS · `coverage` PASS (61 suites, 195
tests) · `next build` PASS · all three workflow YAMLs parse.

## One rejected approach, recorded

Forcing `brace-expansion@^5.0.8` via overrides clears the audit to 0 vulnerabilities — and **breaks
runtime**. `minimatch@9` calls `brace_expansion_1.default()`, which 5.x dropped:

```
TypeError: (0 , brace_expansion_1.default) is not a function
    at braceExpand (node_modules/googleapis-common/node_modules/minimatch/dist/commonjs/index.js:160)
```

Verified by execution, not assumed. `googleapis` is already at its latest (173.0.0), so there is no
upstream fix. A green audit over broken globbing is worse than a documented exception — hence the
allowlist.

## Follow-ups this PR does not do

- [ ] **Required status checks on `master`** (1 review, `enforce_admins`). Repository settings, and
      they can only be set once these checks have run. **Until then the gate reports but does not
      block, so this PR is not finished on its own.**
- [ ] **Delete `origin/dev`.** Destructive; confirm `git log origin/master..origin/dev` is empty and
      keep an `archive/dev-2025-07-23` tag first.

## Note for the first run

`next build` needs `NEXT_PUBLIC_DOMAIN`; without it page-data collection fails on
`undefined/api/github-stars`. Pre-existing and unrelated to this PR, but relevant if the new PR run
builds in a clean environment.