### PR TITLE
fix(e2e): unbreak the suite the new gate exposed

### DIFF
--- a/.github/workflows/pre-deploy.yml
+++ b/.github/workflows/pre-deploy.yml
@@ -93,17 +93,20 @@ jobs:
                   git add .
                   git commit -m "Update unit-report"
                   git push origin main
+            # chromium-headless-shell is named explicitly: dropping `channel: 'chrome'` from
+            # playwright.config.ts means the headless runs use the bundled shell, which is a separate
+            # download from `chromium` and produced "Executable doesn't exist" locally when assumed.
             - name: Install Playwright Browsers
-              run: npx playwright install --with-deps chromium
+              run: npx playwright install --with-deps chromium chromium-headless-shell
               env:
                   DEBIAN_FRONTEND: noninteractive
-            - name: Run dev server
-              run: npm run dev &
-            - name: Wait for dev server to be ready
-              run: npx wait-on http://localhost:3000
+            # `npm run dev &` + `npx wait-on` used to live here. It hung indefinitely on 2026-07-26
+            # (the wait step takes ~22s when it works; it sat for over 20 minutes), and `wait-on` was
+            # never a declared dependency, so npx fetched it from the network mid-run. The
+            # `webServer` block in playwright.config.ts now owns startup, with its own readiness
+            # probe and timeout — and it builds, so e2e runs against production output.
             - name: Run end-to-end tests
-              run: |
-                  npm run test:e2e:report
+              run: npm run test:e2e:report
             - name: Checkout e2e-report repository
               if: github.event_name == 'push'
               uses: actions/checkout@v5

--- a/e2e/landing-page.test.ts
+++ b/e2e/landing-page.test.ts
@@ -1,10 +1,26 @@
 import { Page, test, expect } from '@playwright/test';
 import { socialLinks } from '@/constants/site';
 
+// Must stay in sync with CONSENT_STORAGE_KEY / ConsentChoice in
+// src/components/CookieConsent/index.tsx. Duplicated rather than imported because that module
+// imports a CSS module, which Playwright's transform cannot resolve.
+const CONSENT_STORAGE_KEY = 'cookie-consent';
+const CONSENT_DENIED = 'denied';
+
 let page: Page;
 
 test.beforeAll(async ({ browser }) => {
     page = await browser.newPage({});
+    // Answer the consent banner before the first navigation. It is `position: fixed; bottom: 0;
+    // left: 0; right: 0; z-index: 10000` — the full width of the viewport directly over the Dock,
+    // which is this site's only navigation — so while it is unanswered it intercepts every click
+    // there. That is what timed these tests out on `getByTestId('home')`: the banner was swallowing
+    // the click, not the dock being broken.
+    // 'denied' rather than 'granted' so the suite does not opt itself into analytics.
+    await page.addInitScript(
+        ([key, choice]) => window.localStorage.setItem(key, choice),
+        [CONSENT_STORAGE_KEY, CONSENT_DENIED]
+    );
 });
 
 test.afterAll(async () => {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,11 @@ export default tseslint.config(
             'data/**',
             'next-env.d.ts',
             '**/*.stories.tsx',
+            // Playwright's generated HTML report and traces. Gitignoring them is not enough: flat
+            // config does not read .gitignore, so `eslint .` linted the bundled report JS and
+            // produced ~9,000 errors as soon as the suite had been run locally.
+            'playwright-report/**',
+            'test-results/**',
         ],
     },
     js.configs.recommended,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,13 +17,29 @@ const opts = {
 
 export default defineConfig({
     use: {
-        channel: 'chrome',
+        // Bundled Chromium rather than `channel: 'chrome'`. CI installs `--with-deps chromium`, so
+        // asking for system Chrome only worked because the ubuntu-22.04 image happens to ship it.
         viewport: { width: 1280, height: 720 },
         ignoreHTTPSErrors: true,
+        // `video: 'on-first-retry'` could never fire while retries defaulted to 0.
         video: 'on-first-retry',
+        trace: 'on-first-retry',
         baseURL: baseUrl,
         ...opts,
     },
     testDir: './e2e',
     reporter: [['html']],
+    retries: process.env.CI ? 2 : 0,
+    forbidOnly: !!process.env.CI,
+    // Playwright owns the server lifecycle. CI previously did `npm run dev &` in one step and
+    // `npx wait-on` in the next, which hung indefinitely on 2026-07-26 (that step takes ~22s when it
+    // works; it sat for over 20 minutes) and pulled `wait-on` from the network at run time because it
+    // is not a declared dependency. `webServer` has its own readiness probe and timeout, and it
+    // serves a production build, so e2e exercises what actually deploys instead of the dev server.
+    webServer: {
+        command: 'npm run build && npm start',
+        url: baseUrl,
+        reuseExistingServer: !process.env.CI,
+        timeout: 300_000,
+    },
 });


### PR DESCRIPTION
Follow-up to #151. Those changes were pushed to that branch after it had already been merged, so
they never reached `master`. Cherry-picked onto a clean branch off `master`.

**This matters now**: `master` currently has the gate from #151 without these fixes, so the next PR's
`Testing` job will fail on the consent banner and may hang for 20+ minutes on `npx wait-on`.

## What the gate found on its first run

`Testing` failed legitimately. The consent banner intercepts every click on the Dock:

```
<div class="cookieConsent_message__..."> from <div role="dialog" aria-live="polite" ...>
subtree intercepts pointer events
```

The suite has been broken since the banner landed in #149/#150. Nothing reported it because the
workflow had not run since 2025-07-23. Fixed by seeding a `'denied'` consent choice via
`addInitScript` before the first navigation.

## And a second failure the gate found

The next run **hung for over 20 minutes** on `Wait for dev server to be ready` — a step that takes
~22s when it works. Two causes, both flagged in the audit:

- `npm run dev &` in one step and `npx wait-on` in the next, with no readiness contract and no
  timeout between them.
- `wait-on` is not a declared dependency, so `npx` fetched it from the network mid-run.

Replaced with Playwright's `webServer` block, which has its own readiness probe and a 300s timeout,
and runs `npm run build && npm start` so e2e exercises production output rather than the dev server.
This pulls SDD-L10-T3 forward, deliberately: a gate that hangs is not a gate.

While the config was open — `retries: 2` on CI (`video: 'on-first-retry'` was already set but could
never fire at 0 retries), `trace: 'on-first-retry'`, `forbidOnly`, and `channel: 'chrome'` dropped
since CI installs bundled Chromium and requesting system Chrome only worked because the
ubuntu-22.04 image happens to ship it. The workflow now installs `chromium-headless-shell`
explicitly too; assuming it came with `chromium` produced "Executable doesn't exist" when verifying
locally.

## Third fix: ESLint was linting the Playwright report

Gitignoring `playwright-report/` is not enough — flat config does not read `.gitignore`, so
`eslint .` linted the report's bundled JS and produced ~9,000 errors as soon as the suite had run
locally. CI happened not to hit it because lint runs in a separate job from e2e.

## Verified

`lint` PASS · `tsc --noEmit` PASS · `audit:prod` PASS · `coverage` PASS (61 suites, 195 tests) ·
**12/12 e2e with `CI=1` against the webServer-built app.**

## Worth a separate look

The same banner is `position: fixed; bottom: 0; left: 0; right: 0; z-index: 10000` — full viewport
width directly over the Dock, the site's only navigation — and its Accept button and policy link
compute **1.00:1** in the light theme (white on white). Light is what every first visit gets,
because `useDarkMode` never reads `matchMedia` on mount. So a first-time visitor plausibly has an
invisible full-width overlay swallowing clicks on the only navigation. Playwright demonstrated the
interception mechanically here. Not fixed in this PR — it needs the colour-token work, tracked
separately.