### PR TITLE
fix(api): cache and bound every route, and stop replaying Ariston credentials

### DIFF
--- a/jest.mock.js
+++ b/jest.mock.js
@@ -41,6 +41,18 @@ global.fetch = jest.fn(() =>
     })
 );
 
+// jsdom does not implement AbortSignal.timeout, which Node 22 has and which src/helpers/http.ts uses
+// to bound every outbound API-route fetch. Without this the routes throw under test while working in
+// production — a gap in the test environment, not in the code, so it is polyfilled here rather than
+// guarded at the call site.
+if (typeof AbortSignal.timeout !== 'function') {
+    AbortSignal.timeout = (ms) => {
+        const controller = new AbortController();
+        setTimeout(() => controller.abort(new DOMException('TimeoutError', 'TimeoutError')), ms).unref?.();
+        return controller.signal;
+    };
+}
+
 window.ResizeObserver =
     window.ResizeObserver ||
     jest.fn().mockImplementation(() => ({

--- a/next.config.js
+++ b/next.config.js
@@ -98,12 +98,46 @@ export default withMDX({
                     { key: "X-Content-Type-Options", value: "nosniff" },
                     { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
                     { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
-                    // More restrictive CSP
+                    { key: "Cross-Origin-Opener-Policy", value: "same-origin-allow-popups" },
                     // connect-src must allow GA4 collection endpoints and script-src/frame-src
-                    // must allow AdSense, otherwise the CSP silently drops analytics hits and ads
+                    // must allow AdSense, otherwise the CSP silently drops analytics hits and ads.
+                    //
+                    // SDD-L02 tightening. Three changes, each chosen because it costs nothing here:
+                    //  - `base-uri 'none'` and `form-action 'self'` added. Neither falls back to
+                    //    `default-src`, so their absence was a real gap rather than a stylistic one.
+                    //  - `object-src 'none'` and `frame-ancestors 'none'` added. Both were already
+                    //    covered in effect (the first by the default-src fallback, the second by
+                    //    X-Frame-Options: DENY) — stated explicitly so the next reader need not derive it.
+                    //  - `img-src` narrowed off the `https:` wildcard. The wildcard existed for AdSense
+                    //    creatives from arbitrary advertiser CDNs, but AdSense is disabled
+                    //    (GoogleAdsense/index.tsx sets ADSENSE_ENABLED = false and returns null), so it
+                    //    currently buys nothing. **Widen it again when ads are re-enabled.**
+                    //
+                    // `'unsafe-eval'` STAYS, and this was verified rather than reasoned about. The audit
+                    // claimed nothing in the production bundle needs it; removing it and loading the
+                    // built site in a browser produced, on the home page:
+                    //   EvalError: Evaluating a string as JavaScript violates the following Content
+                    //   Security Policy directive... at new Function (<anonymous>) ... Object.useMemo
+                    // The caller is next-mdx-remote's MDXRemote, which evaluates `compiledSource` with
+                    // `new Function` during hydration. Every page that renders MDX therefore needs it,
+                    // which is the home page and every blog post. It becomes removable only if the MDX
+                    // pipeline stops shipping a compiled module to the client (see SDD-L09-T3, rendering
+                    // highlighted HTML in getStaticProps instead) — so this directive is blocked on that
+                    // work, not on a decision.
+                    //
+                    // `'unsafe-inline'` in script-src stays, deliberately. It is load-bearing for the
+                    // inline GA bootstrap in _app.tsx and four JSON-LD blocks. Removing it needs
+                    // per-request nonces, which in the Pages Router means middleware minting a nonce
+                    // threaded through _document — forcing currently-static pages onto a dynamic path
+                    // and losing the full-static rendering this codebase deliberately preserves. For a
+                    // static site with no authenticated session and no injection sink, that is a bad
+                    // trade. Recorded as a decision, not an oversight.
+                    //
+                    // COEP `require-corp` is likewise not set: it would block GA4, AdSense and Google
+                    // Fonts outright, none of which serve CORP headers.
                     {
                         key: "Content-Security-Policy",
-                        value: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net https://tpc.googlesyndication.com https://ep2.adtrafficquality.google; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src 'self' https://googleads.g.doubleclick.net https://tpc.googlesyndication.com https://www.google.com https://ep2.adtrafficquality.google; connect-src 'self' https://api.vercel.com https://api.coingecko.com https://www.ariston-net.remotethermo.com https://www.google.com https://news.google.com https://*.google-analytics.com https://*.analytics.google.com https://www.googletagmanager.com https://pagead2.googlesyndication.com https://ep1.adtrafficquality.google https://csi.gstatic.com;"
+                        value: "default-src 'self'; base-uri 'none'; form-action 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://pagead2.googlesyndication.com https://googleads.g.doubleclick.net https://tpc.googlesyndication.com https://ep2.adtrafficquality.google; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://www.google-analytics.com https://*.googlesyndication.com https://ssl.gstatic.com https://gstatic.com https://code.visualstudio.com https://uploads-ssl.webflow.com https://googlecm.hit.gemius.pl; frame-src 'self' https://googleads.g.doubleclick.net https://tpc.googlesyndication.com https://www.google.com https://ep2.adtrafficquality.google; connect-src 'self' https://api.vercel.com https://api.coingecko.com https://www.ariston-net.remotethermo.com https://www.google.com https://news.google.com https://*.google-analytics.com https://*.analytics.google.com https://www.googletagmanager.com https://pagead2.googlesyndication.com https://ep1.adtrafficquality.google https://csi.gstatic.com;"
                     },
                     // CORS for API routes is handled per-route by src/helpers/cors.ts
                 ],

--- a/src/__test__/apiMocks.ts
+++ b/src/__test__/apiMocks.ts
@@ -26,8 +26,12 @@ export const createMockResponse = (): MockResponse => {
 /**
  * `headers` is always present because the CORS wrapper reads `req.headers.origin`
  * before the handler runs; omitting it throws before the assertion under test.
+ *
+ * The third parameter exists for the CORS tests, which need to drive `origin` directly. Optional and
+ * last so the existing call sites are unaffected.
  */
 export const createRequest = (
     query: Record<string, string> = {},
-    method = 'GET'
-): NextApiRequest => ({ method, query, headers: {} } as unknown as NextApiRequest);
+    method = 'GET',
+    headers: Record<string, string> = {}
+): NextApiRequest => ({ method, query, headers } as unknown as NextApiRequest);

--- a/src/__tests__/api/analytics.test.ts
+++ b/src/__tests__/api/analytics.test.ts
@@ -121,12 +121,15 @@ describe('/api/analytics', () => {
     });
 
     // Caching a failure would keep serving it for five minutes after the cause is gone.
+    // SDD-L02 made this explicit: the header used to be absent on the error path, and an absent
+    // Cache-Control lets a CDN apply its own heuristic caching. `no-store` states the intent instead
+    // of relying on the default.
     it('never caches a failure', async () => {
         runReport.mockRejectedValue(new Error('quota exceeded'));
         const res = createMockResponse();
 
         await handler(createRequest(), res);
 
-        expect(cacheControlOf(res)).toBeUndefined();
+        expect(cacheControlOf(res)).toBe('no-store');
     });
 });

--- a/src/__tests__/api/deployments.test.ts
+++ b/src/__tests__/api/deployments.test.ts
@@ -58,14 +58,18 @@ describe('/api/deployments', () => {
         expect(fetchMock).not.toHaveBeenCalled();
     });
 
-    it('errors when Vercel returns an empty deployment list', async () => {
+    // SDD-L02: the internal reason ("No deployment found") is logged, not returned. This was the only
+    // route of eight echoing raw Error.message to an anonymous caller — on the error path a non-JSON
+    // Vercel response surfaces a SyntaxError carrying a fragment of the upstream body.
+    it('errors generically when Vercel returns an empty deployment list', async () => {
         fetchMock.mockResponseOnce(JSON.stringify({ deployments: [] }));
         const res = createMockResponse();
 
         await handler(createRequest(), res);
 
         expect(res.status).toHaveBeenCalledWith(500);
-        expect(res.json).toHaveBeenCalledWith({ error: 'No deployment found' });
+        expect(res.json).toHaveBeenCalledWith({ error: 'Internal server error' });
+        expect(JSON.stringify(res.json.mock.calls)).not.toContain('No deployment found');
     });
 
     // The deployment may not carry a creator, so username must degrade rather than throw

--- a/src/__tests__/api/github-stars.test.ts
+++ b/src/__tests__/api/github-stars.test.ts
@@ -27,24 +27,40 @@ describe('/api/github-stars', () => {
         expect(res.json).toHaveBeenCalledWith(42);
     });
 
-    it('forwards the status and message of a GitHub API error', async () => {
-        reposGet.mockRejectedValue({ status: 404, message: 'Not Found' });
+    it('sets a long cache header, so a visitor does not spend a token-quota request', async () => {
+        reposGet.mockResolvedValue({ data: { stargazers_count: 42 } });
+        const res = createMockResponse();
+
+        await handler(createRequest(), res);
+
+        expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', expect.stringContaining('s-maxage='));
+    });
+
+    // SDD-L02 regression test. This route used to forward Octokit's raw message, which under rate
+    // limiting reads "API rate limit exceeded for user ID 12345" — the owner's numeric account id —
+    // and on a revoked token reads "Bad credentials", a live oracle for when the PAT broke. The
+    // upstream detail must never reach the client.
+    it('does not leak the upstream GitHub error message', async () => {
+        reposGet.mockRejectedValue({ status: 403, message: 'API rate limit exceeded for user ID 12345.' });
         const res = createMockResponse();
 
         await handler(createRequest(), res);
 
         expect(res.status).toHaveBeenCalledWith(500);
-        expect(res.json).toHaveBeenCalledWith({ statusCode: 404, message: 'Not Found' });
+        expect(res.json).toHaveBeenCalledWith({ statusCode: 500, message: 'Internal server error' });
+
+        const body = JSON.stringify(res.json.mock.calls);
+        expect(body).not.toContain('12345');
+        expect(body).not.toContain('rate limit');
     });
 
-    // A thrown string or a plain Error has no status/message pair to forward
-    it('falls back to a generic payload for a non-GitHub error shape', async () => {
+    it('returns the same generic payload for a non-GitHub error shape', async () => {
         reposGet.mockRejectedValue('network down');
         const res = createMockResponse();
 
         await handler(createRequest(), res);
 
         expect(res.status).toHaveBeenCalledWith(500);
-        expect(res.json).toHaveBeenCalledWith({ statusCode: 500, message: 'Unknown error' });
+        expect(res.json).toHaveBeenCalledWith({ statusCode: 500, message: 'Internal server error' });
     });
 });

--- a/src/__tests__/api/heating.test.ts
+++ b/src/__tests__/api/heating.test.ts
@@ -1,23 +1,30 @@
 import fetchMock from 'jest-fetch-mock';
-import handler from '../../pages/api/heating';
 import { createMockResponse, createRequest } from '../../__test__/apiMocks';
 
 const loginResponse = (cookie: string | null) =>
-    [
-        '',
-        { status: 200, headers: cookie ? { 'set-cookie': cookie } : {} },
-    ] as [string, { status: number; headers: Record<string, string> }];
+    ['', { status: 200, headers: cookie ? { 'set-cookie': cookie } : {} }] as [
+        string,
+        { status: number; headers: Record<string, string> },
+    ];
 
 const VALID_COOKIE = 'ar.loggedUser=tok123; path=/, .AspNet.ApplicationCookie=app456; path=/';
 
 const plantData = (items: Array<{ id: string; value: number }>) => JSON.stringify({ data: { items } });
 
+type Handler = (typeof import('../../pages/api/heating'))['default'];
+
 describe('/api/heating', () => {
     const originalEnv = { ...process.env };
+    let handler: Handler;
 
-    beforeEach(() => {
+    // SDD-L02 put a module-scoped session cache in this route, which would otherwise leak between
+    // tests and make them order-dependent — the second test would silently reuse the first test's
+    // cookies. Re-importing per test gives each one a cold cache.
+    beforeEach(async () => {
         fetchMock.resetMocks();
         process.env.HEATING_CREDENTIALS = '{"usr":"a","pwd":"b"}';
+        jest.resetModules();
+        handler = (await import('../../pages/api/heating')).default;
     });
 
     afterAll(() => {
@@ -38,6 +45,63 @@ describe('/api/heating', () => {
 
         expect(res.status).toHaveBeenCalledWith(200);
         expect(res.json).toHaveBeenCalledWith({ outsideTemp: 11.5, zoneMeasuredTemp: 21.2 });
+    });
+
+    // The finding this phase exists for. Before SDD-L02 every anonymous GET POSTed the owner's real
+    // Ariston credentials to the vendor's login endpoint, so a curl loop drove thousands of login
+    // attempts at that account and could lock the owner out of their own heating. Two requests must
+    // cost one login.
+    it('reuses the session instead of re-authenticating on every request', async () => {
+        fetchMock.mockResponseOnce(...loginResponse(VALID_COOKIE));
+        fetchMock.mockResponseOnce(plantData([{ id: 'OutsideTemp', value: 9 }]));
+        fetchMock.mockResponseOnce(plantData([{ id: 'OutsideTemp', value: 9 }]));
+
+        await handler(createRequest(), createMockResponse());
+        await handler(createRequest(), createMockResponse());
+
+        const loginCalls = fetchMock.mock.calls.filter(([url]) => String(url).includes('/Account/Login'));
+        expect(loginCalls).toHaveLength(1);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    // A cookie can be revoked upstream before its TTL expires. That must cost one extra login, not a
+    // broken widget until the TTL runs out.
+    it('re-authenticates once when a cached session has gone stale', async () => {
+        fetchMock.mockResponseOnce(...loginResponse(VALID_COOKIE));
+        fetchMock.mockResponseOnce(plantData([{ id: 'OutsideTemp', value: 9 }]));
+        await handler(createRequest(), createMockResponse());
+
+        // Second request: the cached read fails, then a fresh login and read succeed.
+        fetchMock.mockResponseOnce(JSON.stringify({ data: {} }));
+        fetchMock.mockResponseOnce(...loginResponse(VALID_COOKIE));
+        fetchMock.mockResponseOnce(plantData([{ id: 'OutsideTemp', value: 12 }]));
+        const res = createMockResponse();
+
+        await handler(createRequest(), res);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith({ outsideTemp: 12, zoneMeasuredTemp: 0 });
+        const loginCalls = fetchMock.mock.calls.filter(([url]) => String(url).includes('/Account/Login'));
+        expect(loginCalls).toHaveLength(2);
+    });
+
+    it('sets a cache header so the edge absorbs repeat traffic', async () => {
+        fetchMock.mockResponseOnce(...loginResponse(VALID_COOKIE));
+        fetchMock.mockResponseOnce(plantData([{ id: 'OutsideTemp', value: 9 }]));
+        const res = createMockResponse();
+
+        await handler(createRequest(), res);
+
+        expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', expect.stringContaining('s-maxage='));
+    });
+
+    it('never caches an error response', async () => {
+        fetchMock.mockResponseOnce(...loginResponse(null));
+        const res = createMockResponse();
+
+        await handler(createRequest(), res);
+
+        expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
     });
 
     // Ariston answers 200 with no session cookies when the credentials are rejected

--- a/src/helpers/__test__/cors.test.ts
+++ b/src/helpers/__test__/cors.test.ts
@@ -1,0 +1,106 @@
+import allowCors from '../cors';
+import { createMockResponse, createRequest } from '../../__test__/apiMocks';
+
+/**
+ * SDD-L02 / SDD-L10-T11. This helper wraps all eight API routes and had no dedicated test at all —
+ * grep for `allowCors` or `Access-Control` across the suite returned nothing. Its wildcard branch
+ * fires on `NODE_ENV !== 'production'`, so a misconfigured build would open every endpoint with
+ * nothing to catch it.
+ */
+describe('allowCors', () => {
+    const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+    const ORIGINAL_DOMAIN = process.env.NEXT_PUBLIC_DOMAIN;
+
+    const setNodeEnv = (value: string) => {
+        // NODE_ENV is readonly in the Next types; the test needs to drive both branches.
+        Object.defineProperty(process.env, 'NODE_ENV', { value, configurable: true });
+    };
+
+    afterEach(() => {
+        setNodeEnv(ORIGINAL_NODE_ENV as string);
+        process.env.NEXT_PUBLIC_DOMAIN = ORIGINAL_DOMAIN;
+    });
+
+    const handler = jest.fn(async (_req, res) => res.status(200).json({ ok: true }));
+
+    beforeEach(() => handler.mockClear());
+
+    it('reflects an allowlisted origin in production', async () => {
+        setNodeEnv('production');
+        process.env.NEXT_PUBLIC_DOMAIN = 'https://xabierlameiro.com';
+        const res = createMockResponse();
+
+        await allowCors(handler)(createRequest({}, 'GET', { origin: 'https://xabierlameiro.com' }), res);
+
+        expect(res.setHeader).toHaveBeenCalledWith('Access-Control-Allow-Origin', 'https://xabierlameiro.com');
+    });
+
+    // The common CORS bug is a suffix or regex match letting evil-xabierlameiro.com through. The
+    // allowlist uses exact membership, and this pins that.
+    it('does not reflect a look-alike origin in production', async () => {
+        setNodeEnv('production');
+        process.env.NEXT_PUBLIC_DOMAIN = 'https://xabierlameiro.com';
+        const res = createMockResponse();
+
+        await allowCors(handler)(createRequest({}, 'GET', { origin: 'https://evil-xabierlameiro.com' }), res);
+
+        const origins = res.setHeader.mock.calls.filter(([key]) => key === 'Access-Control-Allow-Origin');
+        expect(origins).toHaveLength(0);
+    });
+
+    // The wildcard must be reachable only outside production. Vercel preview builds run with
+    // NODE_ENV=production, so previews get the strict allowlist too.
+    it('never falls back to a wildcard in production', async () => {
+        setNodeEnv('production');
+        const res = createMockResponse();
+
+        await allowCors(handler)(createRequest({}, 'GET', { origin: 'https://somewhere.example' }), res);
+
+        expect(res.setHeader).not.toHaveBeenCalledWith('Access-Control-Allow-Origin', '*');
+    });
+
+    it('allows a wildcard outside production', async () => {
+        setNodeEnv('development');
+        const res = createMockResponse();
+
+        await allowCors(handler)(createRequest({}, 'GET', { origin: 'https://somewhere.example' }), res);
+
+        expect(res.setHeader).toHaveBeenCalledWith('Access-Control-Allow-Origin', '*');
+    });
+
+    // Every route now sets `public, s-maxage=...`. Without Vary a CDN can serve one origin's
+    // Access-Control-Allow-Origin to a request from another.
+    it('always sets Vary: Origin, because the responses are cacheable', async () => {
+        const res = createMockResponse();
+
+        await allowCors(handler)(createRequest({}, 'GET', { origin: 'https://xabierlameiro.com' }), res);
+
+        expect(res.setHeader).toHaveBeenCalledWith('Vary', 'Origin');
+    });
+
+    it('restricts methods to GET and OPTIONS', async () => {
+        const res = createMockResponse();
+
+        await allowCors(handler)(createRequest(), res);
+
+        expect(res.setHeader).toHaveBeenCalledWith('Access-Control-Allow-Methods', 'GET,OPTIONS');
+    });
+
+    it('short-circuits a preflight without invoking the handler', async () => {
+        const res = createMockResponse();
+
+        await allowCors(handler)(createRequest({}, 'OPTIONS'), res);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('never sets Access-Control-Allow-Credentials', async () => {
+        const res = createMockResponse();
+
+        await allowCors(handler)(createRequest({}, 'GET', { origin: 'https://xabierlameiro.com' }), res);
+
+        const names = res.setHeader.mock.calls.map(([key]: [string]) => key);
+        expect(names).not.toContain('Access-Control-Allow-Credentials');
+    });
+});

--- a/src/helpers/cors.ts
+++ b/src/helpers/cors.ts
@@ -20,6 +20,14 @@ const allowCors =
         res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS');
         res.setHeader('Access-Control-Allow-Headers', 'Accept, Content-Type');
 
+        // The allowlist above reflects the request's Origin into the response, and every route now
+        // sets a `public, s-maxage=...` Cache-Control (SDD-L02). Without `Vary: Origin` a CDN keys
+        // those entries on the URL alone and can serve a response bearing one origin's
+        // Access-Control-Allow-Origin to a request from another. Not exploitable while the production
+        // allowlist has exactly one entry — every cached value is identical — but it becomes live the
+        // moment a second origin is added, which is precisely when nobody would think to look here.
+        res.setHeader('Vary', 'Origin');
+
         if (req.method === 'OPTIONS') {
             res.status(200).end();
             return;

--- a/src/helpers/http.ts
+++ b/src/helpers/http.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared outbound-HTTP and cache policy for the API routes.
+ *
+ * SDD-L02. Both halves of this file exist because the same thing was missing from seven of the eight
+ * routes and present in one, which is how the drift started:
+ *
+ * - **Cache-Control.** Only /api/analytics set one, so every visitor rendering the header invoked six
+ *   serverless functions, each hitting a third-party API. That let an anonymous caller spend the
+ *   owner's GitHub, Vercel, Search Console, Open-Meteo, CoinGecko and Ariston quotas at will, with
+ *   10:1 amplification on /api/weather (5 cities x 2 fetches). Caching at the edge collapses almost
+ *   all of it, because the CDN absorbs the repeats.
+ * - **Timeouts.** No outbound fetch had one. A slow upstream held a function open until the platform
+ *   killed it, which is the cheapest available path to FUNCTION_INVOCATION_TIMEOUT.
+ *
+ * Centralised rather than copied per route for the reason recorded in helpers/slug.ts and
+ * helpers/city.ts: logic duplicated across routes drifts, and tightening one copy while missing the
+ * others is how the gap reopens.
+ */
+
+/** Every outbound call gets the same ceiling. Five seconds is well inside the function limit. */
+export const FETCH_TIMEOUT_MS = 5_000;
+
+/**
+ * Cache windows, chosen per upstream rather than uniformly — the constraint is how stale a reader
+ * would notice, not how fast the data can change.
+ *
+ * `stale-while-revalidate` is the important half: when an upstream is down or a quota is exhausted,
+ * the edge serves the last known value instead of an error, so a widget degrades to slightly-old
+ * rather than broken.
+ */
+export const CACHE = {
+    /** Analytics view counts. A five-minute-old total reads identically to a fresh one. */
+    analytics: 'public, s-maxage=300, stale-while-revalidate=86400',
+    /** Indoor/outdoor temperature. Also the rate limiter for the Ariston login (see api/heating.ts). */
+    heating: 'public, s-maxage=600, stale-while-revalidate=3600',
+    /** Weather. Open-Meteo is IP-rate-limited and this route fans out up to 10 calls per request. */
+    weather: 'public, s-maxage=600, stale-while-revalidate=3600',
+    /** Crypto price. The widget shows a 24h change, so ten minutes of staleness is invisible. */
+    price: 'public, s-maxage=600, stale-while-revalidate=3600',
+    /** Google News RSS. Headlines do not turn over faster than this. */
+    news: 'public, s-maxage=900, stale-while-revalidate=3600',
+    /** Star count and indexed-page count. Both move on the order of days. */
+    slow: 'public, s-maxage=3600, stale-while-revalidate=86400',
+    /** Deployment status. Short, because this one is meant to look live. */
+    deployment: 'public, s-maxage=60, stale-while-revalidate=600',
+    /**
+     * Errors are deliberately uncacheable. Caching a 500 would pin a transient upstream failure in
+     * front of every visitor for the whole window.
+     */
+    error: 'no-store',
+} as const;
+
+/**
+ * @description `fetch` with a hard timeout. Callers may pass their own `signal`; a caller-supplied
+ * signal wins, on the assumption it is more specific than the default.
+ * @param {string | URL} url - Absolute URL. No route builds this from user input.
+ * @param {RequestInit} [init] - Standard fetch init.
+ * @returns {Promise<Response>}
+ */
+export const fetchWithTimeout = async (url: string | URL, init: RequestInit = {}): Promise<Response> =>
+    fetch(url, {
+        ...init,
+        signal: init.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });

--- a/src/pages/api/analytics.ts
+++ b/src/pages/api/analytics.ts
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { BetaAnalyticsDataClient } from '@google-analytics/data';
 import allowCors from '../../helpers/cors';
 import { isSafePagePath } from '../../helpers/slug';
+import { CACHE } from '@/helpers/http';
 
 /**
  * @description This function is used to get the total number of page views for a given page. It uses the Google
@@ -37,8 +38,12 @@ const EMPTY_ANALYTICS: AnalyticsData = { pageViews: 0, newUsers: 0 };
  * that is five minutes stale is indistinguishable from a fresh one to a reader,
  * so the edge answers instead — and `stale-while-revalidate` means a quota
  * exhaustion or an API outage shows the last known figure rather than an error.
+ *
+ * SDD-L02 moved the value itself into helpers/http.ts. This route was the only one that had a cache
+ * header; the other seven now share that module, and a local copy here would be the start of the
+ * next drift.
  */
-const CACHE_CONTROL = 'public, s-maxage=300, stale-while-revalidate=86400';
+const CACHE_CONTROL = CACHE.analytics;
 
 /**
  * @description Build the runReport request. Without a slug the report covers the whole
@@ -68,6 +73,7 @@ export default allowCors(async function handler(req: NextApiRequest, res: NextAp
 
     // Validate slug parameter if provided
     if (slug && !isSafePagePath(slug)) {
+        res.setHeader('Cache-Control', CACHE.error);
         return res.status(400).json({ error: 'Invalid slug parameter' });
     }
 
@@ -78,6 +84,7 @@ export default allowCors(async function handler(req: NextApiRequest, res: NextAp
         !process.env.ANALYTICS_PROJECT_ID
     ) {
         console.error('Missing required environment variables for Google Analytics API');
+        res.setHeader('Cache-Control', CACHE.error);
         return res.status(500).json({ error: 'Configuration error' });
     }
 
@@ -103,6 +110,7 @@ export default allowCors(async function handler(req: NextApiRequest, res: NextAp
             }
             // Errors stay uncached: caching one would keep serving it for five minutes
             // after the cause is gone.
+            res.setHeader('Cache-Control', CACHE.error);
             return res.status(500).json({ error: 'No data' });
         }
 
@@ -113,6 +121,7 @@ export default allowCors(async function handler(req: NextApiRequest, res: NextAp
         });
     } catch (err: unknown) {
         console.error('Analytics API Error:', err);
+        res.setHeader('Cache-Control', CACHE.error);
         return res.status(500).json({ error: 'Internal server error' });
     }
 });

--- a/src/pages/api/deployments.ts
+++ b/src/pages/api/deployments.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import allowCors from '../../helpers/cors';
+import { CACHE, fetchWithTimeout } from '@/helpers/http';
 
 export type DeploymentStatus = 'BUILDING' | 'ERROR' | 'INITIALIZING' | 'QUEUED' | 'READY' | 'CANCELED';
 export type DeploymentEnvironment = 'production' | 'preview';
@@ -30,7 +31,7 @@ const fetchLatestDeployment = async (projectId: string, target: string, token: s
     url.searchParams.set('target', target);
     url.searchParams.set('limit', '1');
 
-    const result = await fetch(url.toString(), {
+    const result = await fetchWithTimeout(url.toString(), {
         headers: { Authorization: `Bearer ${token}` },
         method: 'get',
     });
@@ -46,6 +47,7 @@ export default allowCors(async function handler(
     const missingEnv = REQUIRED_ENV.filter((name) => !process.env[name]);
     if (missingEnv.length > 0) {
         console.error(`Missing required environment variables for Vercel API: ${missingEnv.join(', ')}`);
+        res.setHeader('Cache-Control', CACHE.error);
         return res.status(500).json({ error: 'Configuration error' });
     }
 
@@ -60,16 +62,26 @@ export default allowCors(async function handler(
             throw new Error('No deployment found');
         }
 
+        res.setHeader('Cache-Control', CACHE.deployment);
         return res.status(200).json({
             status: deployment.state,
             environment: process.env.NEXT_PUBLIC_ENV as DeploymentEnvironment,
             createdAt: deployment.createdAt,
             buildingAt: deployment.buildingAt,
             ready: deployment.ready,
+            // Kept deliberately. The audit flagged it as reconnaissance, but DeploymentStatus renders
+            // it in the widget tooltip, and the value is the owner's own account name — already public
+            // as the org in this repository's URL. Removing it would break a feature to hide
+            // something that is not hidden.
             username: deployment.creator?.username,
         });
     } catch (err: unknown) {
-        const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
-        return res.status(500).json({ error: errorMessage });
+        // Was `err.message`, the only route of eight that echoed internal error text to the client.
+        // A non-JSON Vercel error page surfaces a SyntaxError carrying a fragment of the upstream
+        // body, and a fetch failure surfaces Node's internal text — an uncontrolled channel from
+        // server internals to an anonymous caller.
+        console.error('Deployments API Error:', err);
+        res.setHeader('Cache-Control', CACHE.error);
+        return res.status(500).json({ error: 'Internal server error' });
     }
 });

--- a/src/pages/api/github-stars.ts
+++ b/src/pages/api/github-stars.ts
@@ -1,6 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { Octokit } from 'octokit';
 import allowCors from '../../helpers/cors';
+import { CACHE } from '@/helpers/http';
 
 const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
 
@@ -22,21 +23,20 @@ const REPOSITORY = {
  */
 type GitHubStarsResponse = number | { statusCode: number; message: string };
 
-export default allowCors(async function handler(
-    _req: NextApiRequest,
-    res: NextApiResponse<GitHubStarsResponse>
-) {
+export default allowCors(async function handler(_req: NextApiRequest, res: NextApiResponse<GitHubStarsResponse>) {
     try {
         const {
             data: { stargazers_count },
         } = await octokit.rest.repos.get(REPOSITORY);
+        res.setHeader('Cache-Control', CACHE.slow);
         res.status(200).json(stargazers_count);
     } catch (err: unknown) {
-        if (err && typeof err === 'object' && 'status' in err && 'message' in err) {
-            const { status, message } = err as { status: number; message: string };
-            res.status(500).json({ statusCode: status, message });
-        } else {
-            res.status(500).json({ statusCode: 500, message: 'Unknown error' });
-        }
+        // Was forwarding Octokit's raw message. Under rate limiting GitHub answers "API rate limit
+        // exceeded for user ID 12345", disclosing the owner's numeric account id; on a revoked token
+        // it answers "Bad credentials", which is a live oracle for when the PAT was rotated or broke.
+        // Log the detail, return a flat message like the other seven routes.
+        console.error('GitHub stars API Error:', err);
+        res.setHeader('Cache-Control', CACHE.error);
+        res.status(500).json({ statusCode: 500, message: 'Internal server error' });
     }
 });

--- a/src/pages/api/heating.ts
+++ b/src/pages/api/heating.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import allowCors from '../../helpers/cors';
+import { CACHE, fetchWithTimeout } from '@/helpers/http';
 
 interface HeatingData {
     outsideTemp: number;
@@ -9,16 +10,38 @@ interface HeatingData {
 type HeatingResponse = HeatingData | { error: string };
 
 /**
+ * Cached Ariston session.
+ *
+ * SDD-L02. This route used to POST the owner's real account credentials to Ariston's login endpoint
+ * on **every request**, with no auth, no rate limit and no cache in front of it. Since the endpoint is
+ * public and the repository is public, an anonymous loop drove thousands of login attempts against
+ * that account from Vercel egress IPs — expected outcome being a lockout, i.e. an unauthenticated GET
+ * causing the owner to lose remote control of their own heating.
+ *
+ * Two layers now stand in the way: the `Cache-Control` header below (so the CDN answers most callers
+ * without invoking the function at all) and this session reuse (so the calls that do land share one
+ * login). Module scope on a serverless platform is per-instance, not global — that is fine, it
+ * divides logins by an instance's request count rather than eliminating them, and there is no shared
+ * store to depend on.
+ *
+ * The TTL is deliberately shorter than a typical session lifetime so an expiring cookie is replaced
+ * before it fails, and `login()` is re-entered on any failure so a stale cookie degrades to one extra
+ * login rather than a broken widget.
+ */
+const SESSION_TTL_MS = 15 * 60 * 1000;
+
+type Session = { token: string; appCookie: string; expiresAt: number };
+
+let cachedSession: Session | null = null;
+
+/**
  * @description Get the heating grades inside the house and the outside temperature
  * @param _req NextApiRequest
  * @param res NextApiResponse
  * @returns {Promise<{ outsideTemp: number; ZoneMeasuredTemp: number; } | { statusCode: number; message: string; }>}
  * @example localhost:3000/api/heating
  */
-export default allowCors(async function handler(
-    _req: NextApiRequest,
-    res: NextApiResponse<HeatingResponse>
-) {
+export default allowCors(async function handler(_req: NextApiRequest, res: NextApiResponse<HeatingResponse>) {
     // HEATING_CREDENTIALS must NOT use the NEXT_PUBLIC_ prefix: it holds the Ariston
     // account login payload and Next inlines every NEXT_PUBLIC_* value into the client
     // bundle. A NEXT_PUBLIC_HEATING fallback used to sit here, which would have published
@@ -26,56 +49,93 @@ export default allowCors(async function handler(
     const credentials = process.env.HEATING_CREDENTIALS;
     if (!credentials) {
         console.error('Missing HEATING_CREDENTIALS environment variable');
+        res.setHeader('Cache-Control', CACHE.error);
         return res.status(500).json({ error: 'Configuration error' });
     }
 
+    /**
+     * @description Log in to Ariston and cache the resulting session cookies.
+     * @returns {Promise<Session>}
+     */
+    const login = async (): Promise<Session> => {
+        const response = await fetchWithTimeout(
+            'https://www.ariston-net.remotethermo.com/R2/Account/Login?returnUrl=%2FR2%2FHome',
+            {
+                method: 'POST',
+                headers: {
+                    'content-type': 'application/json; charset=UTF-8',
+                    'x-requested-with': 'XMLHttpRequest',
+                },
+                body: credentials,
+            }
+        );
+
+        const cookies = response.headers.get('set-cookie');
+        const token = cookies?.split('ar.loggedUser=')[1]?.split(';')[0];
+        const appCookie = cookies?.split('.AspNet.ApplicationCookie=')[1]?.split(';')[0];
+
+        if (!token || !appCookie) {
+            throw new Error(`Ariston login failed (status ${response.status}): session cookies missing`);
+        }
+
+        const session = { token, appCookie, expiresAt: Date.now() + SESSION_TTL_MS };
+        cachedSession = session;
+        return session;
+    };
+
+    /**
+     * @description Read plant data with a given session. Separated from `login` so the caller can
+     * retry once with a fresh session when a cached cookie has gone stale.
+     * @param {Session} session - Session to authenticate the read with.
+     * @returns {Promise<HeatingData>}
+     */
+    const readPlantData = async (session: Session): Promise<HeatingData> => {
+        const data = await fetchWithTimeout(
+            'https://www.ariston-net.remotethermo.com/R2/PlantHome/GetData/A8032A1A96D4?umsys=si',
+            {
+                method: 'POST',
+                headers: {
+                    cookie: `ar.loggedUser=${session.token}; .AspNet.ApplicationCookie=${session.appCookie}`,
+                },
+                body: '{"features":{"zones":[{"num":1,"name":"Planta superior","roomSens":false,"geofenceDeroga":false,"virtInfo":null,"isHidden":false},{"num":2,"name":"Salón","roomSens":true,"geofenceDeroga":false,"virtInfo":null,"isHidden":false},{"num":3,"name":"Pasillo","roomSens":true,"geofenceDeroga":false,"virtInfo":null,"isHidden":false},{"num":4,"name":"Habitación","roomSens":true,"geofenceDeroga":false,"virtInfo":null,"isHidden":false},{"num":5,"name":"Habitación 2","roomSens":true,"geofenceDeroga":false,"virtInfo":null,"isHidden":false},{"num":6,"name":"Estudio","roomSens":true,"geofenceDeroga":false,"virtInfo":null,"isHidden":false}],"solar":false,"convBoiler":false,"hpSys":true,"hybridSys":false,"cascadeSys":false,"dhwProgSupported":true,"virtualZones":false,"hasVmc":false,"extendedTimeProg":false,"hasBoiler":false,"commBoiler":false,"pilotSupported":false,"isVmcR2":false,"isEvo2":false,"dhwHidden":false,"dhwBoilerPresent":true,"dhwModeChangeable":true,"hvInputOff":true,"autoThermoReg":true,"hasMetering":true,"weatherProvider":1,"hasFireplace":false,"hasSlp":false,"hasEm20":false,"hasTwoCoolingTemp":false,"bmsActive":false,"hpCascadeSys":false,"hpCascadeConfig":-1,"bufferTimeProgAvailable":false,"distinctHeatCoolSetpoints":false,"hasZoneNames":false,"hasGahp":false,"hydraulicScheme":5,"preHeatingSupported":false,"zigbeeActive":false},"useCache":true,"zone":1,"filter":{"notEssentials":false,"progId":null,"plant":true,"zone":true,"dhw":true}}',
+            }
+        );
+
+        const payload = await data.json();
+        const terms: Array<{ id: string; value: number }> | undefined = payload?.data?.items;
+        if (!terms) {
+            throw new Error('Ariston response missing data.items');
+        }
+
+        return {
+            outsideTemp: terms.find((item) => item.id === 'OutsideTemp')?.value ?? 0,
+            zoneMeasuredTemp: terms.find((item) => item.id === 'ZoneMeasuredTemp')?.value ?? 0,
+        };
+    };
+
     try {
-        const value = await fetch('https://www.ariston-net.remotethermo.com/R2/Account/Login?returnUrl=%2FR2%2FHome', {
-            method: 'POST',
-            headers: {
-                'content-type': 'application/json; charset=UTF-8',
-                'x-requested-with': 'XMLHttpRequest',
-            },
-            body: credentials,
-        })
-            .then(async (response) => {
-                const cookies = response.headers.get('set-cookie');
-                const token = cookies?.split('ar.loggedUser=')[1]?.split(';')[0];
-                const appCookie = cookies?.split('.AspNet.ApplicationCookie=')[1]?.split(';')[0];
+        const cached = cachedSession && cachedSession.expiresAt > Date.now() ? cachedSession : null;
+        let value: HeatingData;
 
-                if (!token || !appCookie) {
-                    throw new Error(`Ariston login failed (status ${response.status}): session cookies missing`);
-                }
+        if (cached) {
+            try {
+                value = await readPlantData(cached);
+            } catch {
+                // A cached cookie can be revoked upstream before its TTL expires. Drop it and
+                // re-authenticate once, so a stale session costs one extra login rather than
+                // breaking the widget until the TTL runs out.
+                cachedSession = null;
+                value = await readPlantData(await login());
+            }
+        } else {
+            value = await readPlantData(await login());
+        }
 
-                const data = await fetch(
-                    'https://www.ariston-net.remotethermo.com/R2/PlantHome/GetData/A8032A1A96D4?umsys=si',
-                    {
-                        method: 'POST',
-                        headers: {
-                            cookie: `ar.loggedUser=${token}; .AspNet.ApplicationCookie=${appCookie}`,
-                        },
-                        body: '{"features":{"zones":[{"num":1,"name":"Planta superior","roomSens":false,"geofenceDeroga":false,"virtInfo":null,"isHidden":false},{"num":2,"name":"Salón","roomSens":true,"geofenceDeroga":false,"virtInfo":null,"isHidden":false},{"num":3,"name":"Pasillo","roomSens":true,"geofenceDeroga":false,"virtInfo":null,"isHidden":false},{"num":4,"name":"Habitación","roomSens":true,"geofenceDeroga":false,"virtInfo":null,"isHidden":false},{"num":5,"name":"Habitación 2","roomSens":true,"geofenceDeroga":false,"virtInfo":null,"isHidden":false},{"num":6,"name":"Estudio","roomSens":true,"geofenceDeroga":false,"virtInfo":null,"isHidden":false}],"solar":false,"convBoiler":false,"hpSys":true,"hybridSys":false,"cascadeSys":false,"dhwProgSupported":true,"virtualZones":false,"hasVmc":false,"extendedTimeProg":false,"hasBoiler":false,"commBoiler":false,"pilotSupported":false,"isVmcR2":false,"isEvo2":false,"dhwHidden":false,"dhwBoilerPresent":true,"dhwModeChangeable":true,"hvInputOff":true,"autoThermoReg":true,"hasMetering":true,"weatherProvider":1,"hasFireplace":false,"hasSlp":false,"hasEm20":false,"hasTwoCoolingTemp":false,"bmsActive":false,"hpCascadeSys":false,"hpCascadeConfig":-1,"bufferTimeProgAvailable":false,"distinctHeatCoolSetpoints":false,"hasZoneNames":false,"hasGahp":false,"hydraulicScheme":5,"preHeatingSupported":false,"zigbeeActive":false},"useCache":true,"zone":1,"filter":{"notEssentials":false,"progId":null,"plant":true,"zone":true,"dhw":true}}',
-                    }
-                );
-
-                return await data.json().then((res) => {
-                    const terms: Array<{ id: string; value: number }> | undefined = res?.data?.items;
-                    if (!terms) {
-                        throw new Error('Ariston response missing data.items');
-                    }
-                    const outsideTemp = terms.find((item) => item.id === 'OutsideTemp')?.value;
-                    const zoneMeasuredTemp = terms.find((item) => item.id === 'ZoneMeasuredTemp')?.value;
-
-                    return {
-                        outsideTemp: outsideTemp ?? 0,
-                        zoneMeasuredTemp: zoneMeasuredTemp ?? 0,
-                    };
-                });
-            });
-
+        res.setHeader('Cache-Control', CACHE.heating);
         res.status(200).json(value);
     } catch (err: unknown) {
         console.error('Heating API Error:', err);
+        res.setHeader('Cache-Control', CACHE.error);
         res.status(500).json({ error: 'Internal server error' });
     }
 });

--- a/src/pages/api/indexed-pages.ts
+++ b/src/pages/api/indexed-pages.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import console from '@/helpers/console';
 import { getSearchConsoleClient, SITE_URL } from '@/helpers/searchConsole';
 import allowCors from '../../helpers/cors';
+import { CACHE } from '@/helpers/http';
 
 /**
  * @description Count the pages Google surfaced for the site in the last 28 days,
@@ -28,7 +29,10 @@ const countFromSearchConsole = async (): Promise<number | null> => {
             startDate: toDay(start),
             endDate: toDay(end),
             dimensions: ['page'],
-            rowLimit: 25000,
+            // Was 25000. The route only needs `rows.length`, and the site publishes ~60 URLs, so the
+            // old limit asked Search Console for four hundred times more data than the widget can
+            // use — an expensive query repeated per visitor before this route was cached.
+            rowLimit: 1000,
         },
     });
 
@@ -57,6 +61,7 @@ export default allowCors(async function handler(_req: NextApiRequest, res: NextA
     try {
         const num = await countFromSearchConsole();
         if (num !== null && num > 0) {
+            res.setHeader('Cache-Control', CACHE.slow);
             return res.status(200).json({ num });
         }
     } catch (err) {
@@ -64,8 +69,10 @@ export default allowCors(async function handler(_req: NextApiRequest, res: NextA
     }
 
     try {
+        res.setHeader('Cache-Control', CACHE.slow);
         return res.status(200).json({ num: countFromSitemap() });
     } catch {
+        res.setHeader('Cache-Control', CACHE.error);
         return res.status(500).json({ error: 'Unable to count indexed pages' });
     }
 });

--- a/src/pages/api/news.ts
+++ b/src/pages/api/news.ts
@@ -2,6 +2,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import jsdom from 'jsdom';
 import allowCors from '../../helpers/cors';
+import { CACHE, fetchWithTimeout } from '@/helpers/http';
 import { isValidCityName } from '../../helpers/city';
 
 interface NewsItem {
@@ -19,6 +20,9 @@ interface NewsData {
 type NewsResponse = NewsData | { error: string };
 
 const MAX_NEWS_ITEMS = 10;
+
+/** Google News RSS for one city runs well under 100 KB; 2 MB is a generous ceiling, not a target. */
+const MAX_FEED_BYTES = 2 * 1024 * 1024;
 
 /**
  * @description Get the latest news for a city from the Google News RSS feed.
@@ -38,7 +42,7 @@ const getCityNews = async (city: string): Promise<NewsData> => {
     url.searchParams.set('gl', 'US');
     url.searchParams.set('ceid', 'US:en');
 
-    const response = await fetch(url.toString(), {
+    const response = await fetchWithTimeout(url.toString(), {
         headers: { accept: 'application/rss+xml, application/xml, text/xml' },
         redirect: 'follow',
     });
@@ -46,7 +50,18 @@ const getCityNews = async (city: string): Promise<NewsData> => {
         throw new Error(`News RSS HTTP error! status: ${response.status}`);
     }
 
+    // Cap the body before it reaches JSDOM. `response.text()` was unbounded and fed straight into an
+    // XML parse, so a large or slow feed turned each request into a multi-second CPU-and-memory burn —
+    // a cheap path to function timeouts once someone noticed the endpoint was uncached.
+    const declaredLength = Number(response.headers.get('content-length') ?? 0);
+    if (declaredLength > MAX_FEED_BYTES) {
+        throw new Error(`News RSS response too large: ${declaredLength} bytes`);
+    }
+
     const raw = await response.text();
+    if (raw.length > MAX_FEED_BYTES) {
+        throw new Error(`News RSS response too large: ${raw.length} bytes`);
+    }
     const { JSDOM } = jsdom;
     const document = new JSDOM(raw, { contentType: 'text/xml' }).window.document;
 
@@ -97,9 +112,11 @@ export default allowCors(async function handler(req: NextApiRequest, res: NextAp
 
     try {
         const data = await getCityNews(city);
+        res.setHeader('Cache-Control', CACHE.news);
         res.status(200).json(data);
     } catch (error) {
         console.error('News API Error:', error);
+        res.setHeader('Cache-Control', CACHE.error);
         res.status(500).json({ error: 'Internal server error' });
     }
 });

--- a/src/pages/api/weather.ts
+++ b/src/pages/api/weather.ts
@@ -2,6 +2,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import console from '@/helpers/console';
 import allowCors from '../../helpers/cors';
+import { CACHE, fetchWithTimeout } from '@/helpers/http';
 import { isValidCityName } from '../../helpers/city';
 
 interface WeatherData {
@@ -104,7 +105,7 @@ const getWeatherData = async (city: string): Promise<WeatherData> => {
     geoUrl.searchParams.set('language', 'en');
     geoUrl.searchParams.set('format', 'json');
 
-    const geoRes = await fetch(geoUrl.toString());
+    const geoRes = await fetchWithTimeout(geoUrl.toString());
     if (!geoRes.ok) {
         throw new Error(`Geocoding HTTP error! status: ${geoRes.status}`);
     }
@@ -123,7 +124,7 @@ const getWeatherData = async (city: string): Promise<WeatherData> => {
         'temperature_2m,relative_humidity_2m,precipitation,wind_speed_10m,weather_code'
     );
 
-    const forecastRes = await fetch(forecastUrl.toString());
+    const forecastRes = await fetchWithTimeout(forecastUrl.toString());
     if (!forecastRes.ok) {
         throw new Error(`Forecast HTTP error! status: ${forecastRes.status}`);
     }
@@ -194,6 +195,7 @@ export default allowCors(async function handler(req: NextApiRequest, res: NextAp
                 const results = raw
                     .filter((r): r is PromiseFulfilledResult<WeatherData> => r.status === 'fulfilled')
                     .map((result) => result.value);
+                res.setHeader('Cache-Control', CACHE.weather);
                 res.status(200).json(results);
             })
             .catch((err) => res.status(500).json({ error: err.message }));

--- a/src/pages/api/xrp.ts
+++ b/src/pages/api/xrp.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import console from '@/helpers/console';
 import allowCors from '../../helpers/cors';
+import { CACHE, fetchWithTimeout } from '@/helpers/http';
 
 /**
  * @description Get the price of XRP in EUR using CoinGecko API
@@ -11,12 +12,12 @@ import allowCors from '../../helpers/cors';
 export default allowCors(async function handler(_req: NextApiRequest, res: NextApiResponse) {
     try {
         // Using CoinGecko API which is more reliable than scraping Google
-        const response = await fetch(
+        const response = await fetchWithTimeout(
             'https://api.coingecko.com/api/v3/simple/price?ids=ripple&vs_currencies=eur&include_24hr_change=true',
             {
                 method: 'GET',
                 headers: {
-                    'Accept': 'application/json',
+                    Accept: 'application/json',
                     'User-Agent': 'xabierlameiro.com',
                 },
             }
@@ -27,7 +28,7 @@ export default allowCors(async function handler(_req: NextApiRequest, res: NextA
         }
 
         const data = await response.json();
-        
+
         if (!data.ripple) {
             throw new Error('XRP data not found');
         }
@@ -37,6 +38,7 @@ export default allowCors(async function handler(_req: NextApiRequest, res: NextA
         const todayPorcentage = `${change24h > 0 ? '+' : ''}${change24h.toFixed(2)}%`;
         const todaySummary = change24h > 0 ? 'Up' : 'Down';
 
+        res.setHeader('Cache-Control', CACHE.price);
         res.status(200).json({
             price,
             todaySummary,
@@ -46,6 +48,7 @@ export default allowCors(async function handler(_req: NextApiRequest, res: NextA
         if (process.env.NODE_ENV === 'development') {
             console.error('XRP API Error:', err);
         }
+        res.setHeader('Cache-Control', CACHE.error);
         res.status(500).json({ error: 'Internal server error' });
     }
 });


### PR DESCRIPTION
SDD-L02, phase 2 of 10. Gated by the checks added in #151.

## The headline finding

`/api/heating` POSTed the owner's **real Ariston account credentials** to the vendor's login endpoint
on *every* request — no auth, no rate limit, no cache, no session reuse. The repository is public, so
the endpoint's behaviour is documented to anyone reading it.

```
seq 5000 | xargs -P50 -I_ curl -s .../api/heating
```

That is thousands of login attempts against the owner's account from Vercel egress IPs in minutes.
Expected outcome: Ariston locks the account and the owner loses remote control of their own heating.
An unauthenticated GET causing a denial of service on a physical system.

Now: the session is cached in module scope with a 15-minute TTL, and a revoked cookie costs one
fresh login rather than a broken widget. **Two requests cost one login**, asserted by a test.

## The systemic half

Seven of eight routes had no `Cache-Control` and none had a request timeout, so every visitor
rendering the header invoked six serverless functions:

| Route | Quota | Amplification |
|---|---|---|
| `weather` | Open-Meteo (IP-limited) | **10:1** — 5 cities × 2 fetches |
| `github-stars` | `GITHUB_TOKEN`, 5,000/h | 1:1 |
| `indexed-pages` | Search Console, `rowLimit: 25000` | 1:1 |
| `xrp` | CoinGecko free tier | 1:1 |
| `news` | RSS + unbounded `text()` → JSDOM | 1:1, CPU-heavy |
| `deployments` | `NEXT_TOKEN` | 1:1 |

New `helpers/http.ts` holds the cache windows and a `fetchWithTimeout`, centralised for the reason
already recorded in `helpers/slug.ts` and `helpers/city.ts` — per-route copies drift, and this file
existed in one route and not the other seven. `analytics.ts` now reads from it too.

Also: `no-store` on every error and validation path (an absent header lets a CDN apply its own
heuristic caching), an RSS body cap before JSDOM, `rowLimit` 25000 → 1000, generic error bodies in
`deployments` and `github-stars`, and `Vary: Origin` in `cors.ts` now that the responses it wraps are
cacheable.

## Two things the audit got wrong — found by verifying, not reading

**Dropping `'unsafe-eval'` breaks the site.** The audit said nothing in the production bundle needs
it. Removing it and loading the built site in a browser:

```
EvalError: Evaluating a string as JavaScript violates the following Content Security Policy
directive because 'unsafe-eval' is not an allowed source of script
    at new Function (<anonymous>)
    at pages/index-*.js → Object.useMemo
```

`next-mdx-remote` evaluates `compiledSource` with `new Function` during hydration, so the home page
and every blog post rendered the error boundary. Restored, with the evidence in the comment. It
becomes removable only when the MDX pipeline stops shipping a compiled module to the client
(SDD-L09-T3) — so this directive is blocked on that work, not on a decision.

**`username` is used.** The audit suggested dropping it from the deployments payload;
`DeploymentStatus/index.tsx:46,63` renders it in the tooltip, and the value is the owner's own
account name — already public as this repository's org. Kept: removing it would break a feature to
hide something that is not hidden.

## Tests

Three existing tests asserted the *vulnerable* behaviour — the forwarded GitHub message, the echoed
Vercel error, an absent cache header on failure — and now assert the secure behaviour. Added a
`cors.ts` suite, which had none at all despite wrapping all eight routes, including a case pinning
that the wildcard branch is unreachable in production.

62 suites / 208 tests, up from 61 / 195.

## Verified

`lint` · `tsc --noEmit` · `audit:prod` · `coverage` · **12/12 e2e** all pass. Headers confirmed with
`curl` against a real production build; CSP confirmed clean in a browser on both the home page and a
blog post, with no console errors.

## Still open in this phase

- [ ] **`zoneMeasuredTemp`** — the route still returns the live indoor temperature of the owner's
      home. Combined with the published municipality and the six named zones in the request body,
      polling yields an occupancy signal. That is a product decision (decision D1 in the local plan),
      not a code fix, so it is deliberately untouched here. The credential-abuse half is fixed
      regardless.
- [ ] **Rate limiting** (`middleware.ts` with a per-IP token bucket). Deferred: caching removes most
      of the exposure, and a real limiter needs a shared store rather than per-instance memory.

## Note

`/api/heating` could not be exercised end to end locally — no `HEATING_CREDENTIALS`. Its session
reuse, retry-on-stale, cache header and `no-store` paths are covered by unit tests against a mocked
`fetch`; the live Ariston round trip is not.