### PR TITLE
fix(consent): move the cookie gate off the Dock and make Accept visible

### DIFF
--- a/e2e/cookie-consent.test.ts
+++ b/e2e/cookie-consent.test.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+
+// Must stay in sync with CONSENT_STORAGE_KEY in src/components/CookieConsent/index.tsx. Duplicated
+// rather than imported because that module imports a CSS module, which Playwright cannot transform.
+const CONSENT_STORAGE_KEY = 'cookie-consent';
+
+/**
+ * Regression guard for the consent notification.
+ *
+ * The previous implementation was a full-width bar pinned to `bottom: 0` at `z-index: 10000`, which
+ * sat over the Dock — the site's only navigation — and swallowed clicks on it until answered. Its
+ * Accept button and policy link also computed 1.00:1 against the light background (white on white),
+ * so in practice a first-time visitor saw an invisible overlay blocking their only way to navigate.
+ * These tests exist so none of that can come back quietly.
+ */
+test.describe('Cookie consent', () => {
+    test.beforeEach(async ({ page }) => {
+        // `addInitScript` runs on every navigation, so an unguarded `removeItem` would also wipe the
+        // answer on `page.reload()` and the "stay away on the next visit" case could never pass. The
+        // sessionStorage flag survives a reload within the tab, so this clears once per test only.
+        await page.addInitScript((key) => {
+            if (window.sessionStorage.getItem('e2e-consent-cleared')) return;
+            window.localStorage.removeItem(key);
+            window.sessionStorage.setItem('e2e-consent-cleared', '1');
+        }, CONSENT_STORAGE_KEY);
+        await page.goto('/');
+    });
+
+    test('should ask, with both choices visible', async ({ page }) => {
+        await expect(page.getByTestId('consent-accept')).toBeVisible();
+        await expect(page.getByTestId('consent-reject')).toBeVisible();
+    });
+
+    // The defect that broke the whole suite: the Dock must stay operable while the card is shown.
+    test('should leave the Dock clickable while it is shown', async ({ page }) => {
+        await expect(page.getByTestId('consent-accept')).toBeVisible();
+
+        // Would time out with "subtree intercepts pointer events" if the card covered the Dock.
+        await page.getByTestId('home').click({ timeout: 5000 });
+        await expect(page.getByTestId('consent-accept')).toBeVisible();
+    });
+
+    test('should not overlap the Dock', async ({ page }) => {
+        await expect(page.getByTestId('consent-accept')).toBeVisible();
+
+        const card = await page.getByRole('dialog').boundingBox();
+        const dock = await page.getByTestId('home').boundingBox();
+        expect(card).not.toBeNull();
+        expect(dock).not.toBeNull();
+        // The card sits above the Dock with clear air between them.
+        expect(card!.y + card!.height).toBeLessThan(dock!.y);
+    });
+
+    test('should record the grant and stay away on the next visit', async ({ page }) => {
+        await page.getByTestId('consent-accept').click();
+
+        await expect(page.getByTestId('consent-accept')).toBeHidden();
+        expect(await page.evaluate((key) => window.localStorage.getItem(key), CONSENT_STORAGE_KEY)).toBe('granted');
+
+        await page.reload();
+        await expect(page.getByTestId('consent-accept')).toBeHidden();
+    });
+
+    test('should be dismissable with the keyboard', async ({ page }) => {
+        await expect(page.getByTestId('consent-accept')).toBeVisible();
+
+        await page.keyboard.press('Escape');
+
+        await expect(page.getByTestId('consent-accept')).toBeHidden();
+        // Escape must mean "no", never consent by omission.
+        expect(await page.evaluate((key) => window.localStorage.getItem(key), CONSENT_STORAGE_KEY)).toBe('denied');
+    });
+});

--- a/e2e/landing-page.test.ts
+++ b/e2e/landing-page.test.ts
@@ -11,12 +11,13 @@ let page: Page;
 
 test.beforeAll(async ({ browser }) => {
     page = await browser.newPage({});
-    // Answer the consent banner before the first navigation. It is `position: fixed; bottom: 0;
-    // left: 0; right: 0; z-index: 10000` — the full width of the viewport directly over the Dock,
-    // which is this site's only navigation — so while it is unanswered it intercepts every click
-    // there. That is what timed these tests out on `getByTestId('home')`: the banner was swallowing
-    // the click, not the dock being broken.
-    // 'denied' rather than 'granted' so the suite does not opt itself into analytics.
+    // Answer the consent notification before the first navigation, so these tests exercise the page
+    // rather than the notification. 'denied' so the suite does not opt itself into analytics.
+    //
+    // It used to be a full-width bar at `bottom: 0` with `z-index: 10000`, directly over the Dock —
+    // this site's only navigation — and it intercepted every click there until answered, which is what
+    // timed these tests out on `getByTestId('home')`. It is now a macOS-style notification in the
+    // top-right; the dedicated suite below guards that it stays out of the Dock's way.
     await page.addInitScript(
         ([key, choice]) => window.localStorage.setItem(key, choice),
         [CONSENT_STORAGE_KEY, CONSENT_DENIED]

--- a/src/components/CookieConsent/__test__/cookieConsent.test.tsx
+++ b/src/components/CookieConsent/__test__/cookieConsent.test.tsx
@@ -46,6 +46,36 @@ describe('CookieConsent', () => {
         });
     });
 
+    // Escape must mean "no", never "yes" by omission: the default state is already denied, and a
+    // notification the keyboard cannot dismiss is a trap.
+    it('answers denied on Escape', () => {
+        render(<CookieConsent />);
+        fireEvent.keyDown(window, { key: 'Escape' });
+
+        expect(window.localStorage.getItem(CONSENT_STORAGE_KEY)).toBe('denied');
+        expect(screen.queryByTestId('consent-accept')).not.toBeInTheDocument();
+    });
+
+    // Regression guard. `role="dialog"` + `aria-live` on one node is invalid — a dialog is a window,
+    // not a live region — and made some screen readers announce the subtree as an atomic update while
+    // also reporting a dialog.
+    it('is a named dialog, not a live region', () => {
+        render(<CookieConsent />);
+        const dialog = screen.getByRole('dialog');
+
+        expect(dialog).toHaveAttribute('aria-labelledby', 'cookie-consent-title');
+        expect(dialog).not.toHaveAttribute('aria-live');
+        // Non-modal on purpose: it is a notification beside the page, so focus is not trapped.
+        expect(dialog).not.toHaveAttribute('aria-modal');
+    });
+
+    // It used to be a full-width bar at `bottom: 0`, directly over the Dock — the only navigation
+    // this site has — intercepting clicks on it until answered.
+    it('does not render as a bottom-anchored full-width bar', () => {
+        render(<CookieConsent />);
+        expect(screen.getByRole('dialog').className).not.toMatch(/banner/);
+    });
+
     it('does not ask when there is nowhere to record the answer', () => {
         // Private mode and cookie-blocking extensions make getItem throw. Asking on
         // every page load would be worse than staying on the denied defaults.

--- a/src/components/CookieConsent/cookieConsent.module.css
+++ b/src/components/CookieConsent/cookieConsent.module.css
@@ -1,80 +1,145 @@
-.banner {
+/**
+ * Styled as a macOS notification, not a web cookie bar.
+ *
+ * It used to be a full-width footer banner at `bottom: 0` with `z-index: 10000`, which sat directly
+ * over the Dock — the only navigation this site has — and swallowed clicks on it until answered.
+ * macOS puts this class of alert in the top-right, under the menu bar, so that is where it goes now:
+ * same geometry as the Notification component (top: 42px, right: 20px, 340px wide), the Dock stays
+ * reachable, and the metaphor holds.
+ */
+.notification {
     position: fixed;
-    z-index: 10000;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: center;
-    gap: 15px;
-    padding: 15px 20px;
-    background-color: rgba(var(--blog-background));
+    top: 42px;
+    right: 20px;
+    z-index: 9999;
+    width: 340px;
+    max-width: calc(100vw - 40px);
+    padding: 14px 16px 16px;
+    border-radius: 14px;
+    /* Vibrancy, matching the Dock. Kept at 0.94 rather than fully translucent on purpose: the
+       contrast of the text below is only predictable if the surface is nearly opaque, and this
+       component's whole defect was unreadable text. */
+    background-color: rgba(var(--blog-background), 0.94);
+    backdrop-filter: blur(20px) saturate(180%);
+    -webkit-backdrop-filter: blur(20px) saturate(180%);
+    border: 1px solid rgba(var(--blog-border));
+    box-shadow: 0 8px 32px 0 rgb(31 38 135 / 25%);
     color: rgba(var(--blog-font));
-    border-top: 1px solid rgba(var(--blog-border));
-    box-shadow: 0 -8px 32px 0 rgb(31 38 135 / 37%);
-    font-size: 14px;
+    font-family: var(--font-family);
+    font-size: 13px;
+    animation: slide-in 0.35s cubic-bezier(0.2, 0.9, 0.3, 1) both;
 }
 
-.copy {
-    flex: 1 1 420px;
-    max-width: 720px;
+.header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 6px;
+}
+
+/* The app "icon" a macOS notification carries. Decorative — the title text is the accessible name. */
+.icon {
+    flex-shrink: 0;
+    height: 16px;
+    width: 16px;
+    color: rgba(var(--link-on-surface));
 }
 
 .title {
-    font-size: 16px;
-    font-weight: 400;
-    margin-bottom: 5px;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
 }
 
 .message {
-    font-size: 14px;
-    line-height: 1.3;
+    font-size: 13px;
+    line-height: 1.4;
+    color: rgba(var(--blog-font));
 }
 
+/* Was --blog-font-selected, which is #FFF in BOTH themes and therefore invisible on the light
+   background: a computed 1.00:1. --link-on-surface is theme-scoped — 7.20:1 light, 7.84:1 dark. */
 .message a {
-    color: rgba(var(--blog-font-selected));
+    color: rgba(var(--link-on-surface));
     text-decoration: underline;
+    text-underline-offset: 2px;
 }
 
 .actions {
     display: flex;
-    gap: 10px;
-    flex-shrink: 0;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 14px;
 }
 
+/**
+ * Both buttons are the same size and sit side by side, one click each. Accept is the filled default
+ * the way a macOS dialog marks its primary action, but Reject is a fully legible, equally reachable
+ * button — not a link, not hidden behind a "manage preferences" step. Prominence is allowed; making
+ * refusal harder than acceptance is not.
+ */
 .button {
     cursor: pointer;
-    padding: 8px 18px;
-    font-family: var(--font-family);
-    font-size: 14px;
-    border-radius: 6px;
+    min-width: 88px;
+    padding: 6px 14px;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 500;
+    border-radius: 8px;
     border: 1px solid rgba(var(--blog-border));
-    background-color: transparent;
+    background-color: rgba(var(--blog-header));
     color: rgba(var(--blog-font));
-}
-
-.button:hover,
-.button:focus-visible {
-    border-color: rgba(var(--blog-font-selected));
+    transition: filter 0.15s ease;
 }
 
 .accept {
-    background-color: rgba(var(--blog-font-selected));
-    border-color: rgba(var(--blog-font-selected));
-    color: rgba(var(--blog-background));
+    /* #FFF on #1D589A = 7.20:1 in both themes. */
+    background-color: rgba(var(--blue-color));
+    border-color: rgba(var(--blue-color));
+    color: rgba(var(--white-color));
 }
 
+.button:hover {
+    filter: brightness(1.08);
+}
+
+/* The old rule used --blog-font-selected here too, so the only focus style in the whole codebase
+   computed 1.00:1 in the light theme — an invisible focus ring on the consent gate. */
+.button:focus-visible {
+    outline: 2px solid rgba(var(--link-on-surface));
+    outline-offset: 2px;
+}
+
+@keyframes slide-in {
+    from {
+        opacity: 0;
+        transform: translateX(calc(100% + 20px));
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .notification {
+        animation: none;
+    }
+}
+
+/* On a phone the notification spans the width under the menu bar, still nowhere near the Dock. */
 @media screen and (max-width: 768px) {
-    .banner {
+    .notification {
+        top: 32.5px;
+        right: 10px;
+        left: 10px;
+        width: auto;
+        max-width: none;
         font-size: 12px;
-        padding: 12px 15px;
-        gap: 10px;
     }
 
     .actions {
-        width: 100%;
+        margin-top: 12px;
     }
 
     .button {

--- a/src/components/CookieConsent/index.tsx
+++ b/src/components/CookieConsent/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 import Link from 'next/link';
+import { BsCookie } from 'react-icons/bs';
 import { clx } from '@/helpers';
 import styles from './cookieConsent.module.css';
 
@@ -65,18 +66,42 @@ const CookieConsent = () => {
     const handleAccept = React.useCallback(() => answer('granted'), [answer]);
     const handleReject = React.useCallback(() => answer('denied'), [answer]);
 
+    // Escape answers "no". The default state is already denied, so dismissing without choosing must
+    // not be read as acceptance — and a notification the keyboard cannot dismiss is a trap.
+    React.useEffect(() => {
+        if (!needsAnswer) return undefined;
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') handleReject();
+        };
+        window.addEventListener('keydown', onKeyDown);
+        return () => window.removeEventListener('keydown', onKeyDown);
+    }, [needsAnswer, handleReject]);
+
     if (!needsAnswer) return null;
 
     return (
-        <div className={styles.banner} role="dialog" aria-live="polite" aria-labelledby="cookie-consent-title">
-            <div className={styles.copy}>
+        /**
+         * `role="dialog"` without `aria-modal`, and no focus trap: this is a macOS-style notification
+         * sitting beside the page, not a modal over it, so trapping focus would misdescribe it and
+         * strand a keyboard user. The previous markup paired `role="dialog"` with `aria-live`, which is
+         * invalid — a dialog is a window, not a live region — and made some screen readers announce the
+         * whole subtree as an atomic update while also reporting a dialog.
+         */
+        <section
+            className={styles.notification}
+            role="dialog"
+            aria-labelledby="cookie-consent-title"
+            aria-describedby="cookie-consent-message"
+        >
+            <div className={styles.header}>
+                <BsCookie className={styles.icon} aria-hidden="true" />
                 <div className={styles.title} id="cookie-consent-title">
                     {formatMessage({ id: 'consent.title' })}
                 </div>
-                <div className={styles.message}>
-                    {formatMessage({ id: 'consent.message' })}{' '}
-                    <Link href="/legal/cookies-policy">{formatMessage({ id: 'legal.cookies-policy' })}</Link>
-                </div>
+            </div>
+            <div className={styles.message} id="cookie-consent-message">
+                {formatMessage({ id: 'consent.message' })}{' '}
+                <Link href="/legal/cookies-policy">{formatMessage({ id: 'legal.cookies-policy' })}</Link>
             </div>
             <div className={styles.actions}>
                 <button type="button" className={styles.button} onClick={handleReject} data-testid="consent-reject">
@@ -91,7 +116,7 @@ const CookieConsent = () => {
                     {formatMessage({ id: 'consent.accept' })}
                 </button>
             </div>
-        </div>
+        </section>
     );
 };
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -20,6 +20,9 @@
 }
 
 [data-theme='dark'] {
+    /* Link colour that works ON a surface, per theme. --blue-color is theme-independent and
+       computes 2.31:1 on the dark background, so it cannot be used for text there. 7.84:1. */
+    --link-on-surface: 145, 180, 230;
     --blog-nav: 48, 41, 51;
     --blog-header: 53, 45, 55;
     --blog-background: 30, 30, 30;
@@ -35,6 +38,8 @@
 }
 
 [data-theme='light'] {
+    /* 7.20:1 on white — same value as --blue-color, which is correct in this theme. */
+    --link-on-surface: 29, 88, 154;
     --blog-nav: 204, 202, 219;
     --blog-header: 255, 255, 255;
     --blog-background: 255, 255, 255;


### PR DESCRIPTION
Was pushed to the #161 branch after that PR had already been merged, so it never reached `master`.
Cherry-picked onto a clean branch. Independent of #161's API work — this is UI only.

## The problem

The consent bar was a full-width footer pinned to `bottom: 0` at `z-index: 10000`, sitting directly
over the **Dock — the only navigation this site has** — and intercepting every click there until
answered.

Its Accept button and policy link used `--blog-font-selected` on `--blog-background`. That token is
`#FFF` in **both** themes, so on the light background they computed **1.00:1**: white on white. Light
is what every first visit gets, because `useDarkMode` never reads `matchMedia` on mount.

So a first-time visitor got an invisible full-width overlay swallowing clicks on their only way to
navigate, with "Reject" as the only legible control. Playwright demonstrated the interception
mechanically — it is what made the e2e suite time out in #160.

## The fix

Restyled as a **macOS notification**, which is where this class of alert belongs in the metaphor —
reusing the geometry of the existing (unused) `Notification` component: top-right under the menu bar,
340px, 14px radius, vibrancy via `backdrop-filter` to match the Dock, sliding in from the right and
respecting `prefers-reduced-motion`.

Verified in a browser against a production build:

| | Before | After |
|---|---|---|
| Overlaps the Dock | yes | **no** |
| `elementFromPoint` at Dock centre | the banner | **a Dock icon** |
| Accept button | **1.00:1** | **7.20:1** |
| Policy link (light / dark) | **1.00:1** | 7.20:1 / **7.84:1** |
| Reject (light / dark) | — | 14.94:1 / 12.43:1 |

The link needed a new theme-scoped `--link-on-surface` token, because `--blue-color` is
theme-independent and computes 2.31:1 on the dark background — which also pre-stages part of the
`A-H7` fix.

## On making acceptance the obvious choice

Accept is the filled primary, the way a macOS dialog marks its default action, so the intended choice
reads first — and with the button now *visible at all*, the practical change is large: previously it
was literally impossible to accept.

Reject stays a full, legible, equally sized button one click away. Prominence is fine; making refusal
harder is not, so it is not demoted to a link or hidden behind a "manage preferences" step — that
would be a dark pattern and would fail EDPB guidance that refusing must be as easy as accepting.

## Accessibility, since the component was being rewritten anyway

- `Escape` answers **denied**. Consent by omission would be wrong, and a notification the keyboard
  cannot dismiss is a trap.
- Dropped the invalid `role="dialog"` + `aria-live` pairing — a dialog is a window, not a live region.
- Non-modal on purpose, no focus trap: it is a notification beside the page, and it already renders
  before `<Layout>`, so it is the first thing a keyboard user reaches.
- The only `:focus-visible` rule in the entire codebase lived here and also computed 1.00:1. Fixed.

## Tests

3 unit cases (Escape answers denied, dialog-not-live-region, not a bottom-anchored bar) and a new e2e
suite whose central case **clicks a Dock icon while the card is shown** — the exact interaction that
used to time out after 30s.

62 suites / 211 unit tests, 17 e2e. `lint`, `tsc`, `audit:prod`, `coverage` and e2e all pass.