### PR TITLE
ci(deploy): stop one merge costing six deployments

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,44 @@ updates:
     # SDD-L01: package-ecosystem was left as the template's empty string, which is invalid — so
     # scheduled version updates never ran. The Dependabot PRs that did arrive came from security
     # alerts, which fire independently of this file, giving the false impression it worked.
+    #
+    # SDD-L01b: grouped, after that fix produced EIGHT separate PRs in one morning. Each one is a
+    # branch, each branch was building a Vercel preview, and Dependabot rebases its branches — so
+    # `globals`, `eslint` and `cross-env` each cost two preview deployments on 2026-07-26 before
+    # anyone looked at them. Grouping means one branch and one review instead of eight.
+    #
+    # scripts/vercel-ignore-build.sh now skips preview builds on dependabot branches regardless, so
+    # this is the second of two independent brakes rather than the only one.
     - package-ecosystem: 'npm'
       directory: '/'
       schedule:
           interval: 'weekly'
-      open-pull-requests-limit: 5
+      open-pull-requests-limit: 3
+      groups:
+          # Patch and minor bumps are the ones that are usually safe to take together and rarely
+          # worth reading individually.
+          safe-updates:
+              patterns:
+                  - '*'
+              update-types:
+                  - 'minor'
+                  - 'patch'
+          # Majors stay grouped too, but separately: they need reading, and mixing them with the
+          # routine bumps would mean one red PR blocking a batch of green ones. Note the current
+          # crop includes eslint 9 -> 10 and globals 14 -> 17, which touch the flat config directly.
+          major-updates:
+              patterns:
+                  - '*'
+              update-types:
+                  - 'major'
     # Keeps the SHA-pinned third-party action in pre-deploy.yml current, since a pinned SHA does not
     # receive upstream fixes on its own.
     - package-ecosystem: 'github-actions'
       directory: '/'
       schedule:
           interval: 'weekly'
+      open-pull-requests-limit: 2
+      groups:
+          actions:
+              patterns:
+                  - '*'

--- a/.github/workflows/post-deploy.yml
+++ b/.github/workflows/post-deploy.yml
@@ -1,3 +1,10 @@
+# SDD-L01b: the Lighthouse job moved to reports.yml (weekly + manual). It pushed to
+# performance-report on every merge, and that repo has its own Vercel git integration, so each merge
+# cost an extra production deployment there — 6 of them on 2026-07-26 alone. It also burned ~10
+# minutes of runner time per merge sleeping, waiting for a deploy it was racing.
+#
+# IndexNow stays on push: telling search engines a URL changed is the one thing here that is
+# genuinely time-sensitive (SDD-013 — ChatGPT Search retrieves from Bing's index).
 name: Workflow Post-Deploy
 on:
     push:
@@ -22,38 +29,3 @@ jobs:
               run: sleep 120
             - name: Submit URLs to IndexNow
               run: node scripts/indexnow-ping.mjs || true
-    lighthouse:
-        name: Lighthouse
-        runs-on: ubuntu-22.04
-        steps:
-            - uses: actions/checkout@v5
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: 22
-                  cache: npm
-            - name: Install dependencies
-              run: |
-                  echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
-                  echo "@xabierlameiro:registry=https://npm.pkg.github.com/" >> ~/.npmrc
-                  npm ci --legacy-peer-deps --include=optional
-            - name: Execute Lighthouse
-              run: |
-                  sleep 10m
-                  npm run lighthouse-report
-            - name: Checkout performance-report repository
-              uses: actions/checkout@v5
-              with:
-                  repository: xabierlameiro/performance-report
-                  token: ${{ secrets.TOKEN_GITHUB }}
-                  path: performance-report
-            - name: Copy output folder and publish
-              run: |
-                  cd performance-report
-                  cp -r ../lighthouse .
-                  printf 'User-agent: *\nDisallow: /\n' > robots.txt
-                  printf '{ "headers": [ { "source": "/(.*)", "headers": [ { "key": "X-Robots-Tag", "value": "noindex, nofollow" } ] } ] }\n' > vercel.json
-                  git config --global user.email "action@github.com"
-                  git config --global user.name "GitHub Action"
-                  git add .
-                  git commit -m "Update performance-report"
-                  git push origin main

--- a/.github/workflows/pre-deploy.yml
+++ b/.github/workflows/pre-deploy.yml
@@ -74,28 +74,6 @@ jobs:
             # Coverage thresholds live in jest.config.js and fail this step when breached.
             - name: Run unit tests
               run: npm run coverage
-            - name: Checkout unit-report repository
-              if: github.event_name == 'push'
-              uses: actions/checkout@v5
-              with:
-                  repository: xabierlameiro/unit-report
-                  token: ${{ secrets.TOKEN_GITHUB }}
-                  path: unit-report
-            - name: Copy report coverage folder and publish
-              if: github.event_name == 'push'
-              run: |
-                  cd unit-report
-                  cp -r ../public/coverage/ .
-                  printf 'User-agent: *\nDisallow: /\n' > robots.txt
-                  printf '{ "headers": [ { "source": "/(.*)", "headers": [ { "key": "X-Robots-Tag", "value": "noindex, nofollow" } ] } ] }\n' > vercel.json
-                  git config --global user.email "action@github.com"
-                  git config --global user.name "GitHub Action"
-                  git add .
-                  git commit -m "Update unit-report"
-                  git push origin main
-            # chromium-headless-shell is named explicitly: dropping `channel: 'chrome'` from
-            # playwright.config.ts means the headless runs use the bundled shell, which is a separate
-            # download from `chromium` and produced "Executable doesn't exist" locally when assumed.
             - name: Install Playwright Browsers
               run: npx playwright install --with-deps chromium chromium-headless-shell
               env:
@@ -107,87 +85,11 @@ jobs:
             # probe and timeout — and it builds, so e2e runs against production output.
             - name: Run end-to-end tests
               run: npm run test:e2e:report
-            - name: Checkout e2e-report repository
-              if: github.event_name == 'push'
-              uses: actions/checkout@v5
-              with:
-                  repository: xabierlameiro/e2e-report
-                  token: ${{ secrets.TOKEN_GITHUB }}
-                  path: e2e-report
-            - name: Copy playwright-report/index.html to e2e-report/index.html
-              if: github.event_name == 'push'
-              run: |
-                  cd e2e-report
-                  cp -r ../playwright-report/index.html index.html
-                  printf 'User-agent: *\nDisallow: /\n' > robots.txt
-                  printf '{ "headers": [ { "source": "/(.*)", "headers": [ { "key": "X-Robots-Tag", "value": "noindex, nofollow" } ] } ] }\n' > vercel.json
-                  git config --global user.email "action@github.com"
-                  git config --global user.name "GitHub Action"
-                  git add .
-                  git commit -m "Update e2e-report"
-                  git push origin main
-    documentation:
-        name: Documenting
-        # Pure generate-and-publish to three other repos; nothing to verify on a PR.
-        if: github.event_name == 'push'
-        runs-on: ubuntu-22.04
-        env:
-            NEXT_PUBLIC_DOMAIN: ${{ secrets.NEXT_PUBLIC_DOMAIN }}
-            VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-            VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-        steps:
-            - uses: actions/checkout@v5
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: 22
-                  cache: npm
-            - name: Install dependencies
-              run: |
-                  echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
-                  echo "@xabierlameiro:registry=https://npm.pkg.github.com/" >> ~/.npmrc
-                  npm ci --legacy-peer-deps --include=optional
-            - name: Generate documentation
-              run: npm run jsdoc
-            - name: Checkout doc repository
-              uses: actions/checkout@v5
-              with:
-                  repository: xabierlameiro/doc-report
-                  token: ${{ secrets.TOKEN_GITHUB }}
-                  path: doc
-            - name: Copy documentation and publish
-              run: |
-                  cd doc
-                  cp -r ../public/docs/ .
-                  printf 'User-agent: *\nDisallow: /\n' > robots.txt
-                  printf '{ "headers": [ { "source": "/(.*)", "headers": [ { "key": "X-Robots-Tag", "value": "noindex, nofollow" } ] } ] }\n' > vercel.json
-                  git config --global user.email "action@github.com"
-                  git config --global user.name "GitHub Action"
-                  git add .
-                  git commit -m "Update doc-report"
-                  git push origin main
-            - name: Checkout stb-report repository
-              uses: actions/checkout@v5
-              with:
-                  repository: xabierlameiro/stb-report
-                  token: ${{ secrets.TOKEN_GITHUB }}
-                  path: stb-report
-            - name: Copy storybook and publish
-              run: |
-                  npm run build-storybook
-                  cd stb-report
-                  cp -r ../storybook-static/ .
-                  printf 'User-agent: *\nDisallow: /\n' > robots.txt
-                  printf '{ "headers": [ { "source": "/(.*)", "headers": [ { "key": "X-Robots-Tag", "value": "noindex, nofollow" } ] } ] }\n' > vercel.json
-                  git config --global user.email "action@github.com"
-                  git config --global user.name "GitHub Action"
-                  git add .
-                  git commit -m "Update stb-report"
-                  git push origin main
     version:
         name: Versioning
         if: github.event_name == 'push'
         runs-on: ubuntu-22.04
-        needs: [code_checking, testing, documentation]
+        needs: [code_checking, testing]
         # The only job that writes to this repository, so the only one that needs the scope.
         permissions:
             contents: write

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -1,0 +1,182 @@
+# Publishes the five report sites: coverage, e2e, JSDoc, Storybook and Lighthouse.
+#
+# SDD-L01b. These jobs used to hang off every push to `master`, inside the quality gate and the
+# post-deploy workflow. Each one pushes to a separate repository that has its own Vercel git
+# integration, so a single merge cost SIX deployments — one for the site and five for the reports.
+# Measured on 2026-07-26: `performance-report` alone took 6 production deployments in a day, every one
+# of them the same "Update performance-report" commit from this action.
+#
+# None of these reports is time-critical. Coverage, docs and a Lighthouse run are things you consult,
+# not things anyone is waiting on within minutes of a merge — so they move to a weekly cadence with a
+# manual trigger for when you do want them fresh. This removes 5 deployments per merge, which is the
+# single largest saving available.
+name: Publish reports
+
+on:
+    schedule:
+        # Mondays 06:00 UTC, an hour before the trending radar so they do not contend for runners.
+        - cron: '0 6 * * 1'
+    workflow_dispatch: {}
+
+concurrency:
+    group: ${{ github.workflow }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    coverage_and_e2e:
+        name: Coverage and e2e reports
+        runs-on: ubuntu-22.04
+        env:
+            NEXT_PUBLIC_DOMAIN: ${{ secrets.NEXT_PUBLIC_DOMAIN }}
+            VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+            VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+            NEXT_PUBLIC_ENV: 'preview'
+        steps:
+            - uses: actions/checkout@v5
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  cache: npm
+            - name: Install dependencies
+              run: |
+                  echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+                  echo "@xabierlameiro:registry=https://npm.pkg.github.com/" >> ~/.npmrc
+                  npm ci --legacy-peer-deps --include=optional
+            - name: Run unit tests with coverage
+              run: npm run coverage
+            - name: Checkout unit-report repository
+              uses: actions/checkout@v5
+              with:
+                  repository: xabierlameiro/unit-report
+                  token: ${{ secrets.TOKEN_GITHUB }}
+                  path: unit-report
+            - name: Copy report coverage folder and publish
+              run: |
+                  cd unit-report
+                  cp -r ../public/coverage/ .
+                  printf 'User-agent: *\nDisallow: /\n' > robots.txt
+                  printf '{ "headers": [ { "source": "/(.*)", "headers": [ { "key": "X-Robots-Tag", "value": "noindex, nofollow" } ] } ] }\n' > vercel.json
+                  git config --global user.email "action@github.com"
+                  git config --global user.name "GitHub Action"
+                  git add .
+                  git diff --staged --quiet || git commit -m "Update unit-report"
+                  git push origin main
+            - name: Install Playwright Browsers
+              run: npx playwright install --with-deps chromium chromium-headless-shell
+              env:
+                  DEBIAN_FRONTEND: noninteractive
+            - name: Run end-to-end tests
+              run: npm run test:e2e:report
+            - name: Checkout e2e-report repository
+              uses: actions/checkout@v5
+              with:
+                  repository: xabierlameiro/e2e-report
+                  token: ${{ secrets.TOKEN_GITHUB }}
+                  path: e2e-report
+            - name: Copy playwright-report/index.html to e2e-report/index.html
+              run: |
+                  cd e2e-report
+                  cp -r ../playwright-report/index.html index.html
+                  printf 'User-agent: *\nDisallow: /\n' > robots.txt
+                  printf '{ "headers": [ { "source": "/(.*)", "headers": [ { "key": "X-Robots-Tag", "value": "noindex, nofollow" } ] } ] }\n' > vercel.json
+                  git config --global user.email "action@github.com"
+                  git config --global user.name "GitHub Action"
+                  git add .
+                  git diff --staged --quiet || git commit -m "Update e2e-report"
+                  git push origin main
+
+    documentation:
+        name: JSDoc and Storybook
+        runs-on: ubuntu-22.04
+        env:
+            NEXT_PUBLIC_DOMAIN: ${{ secrets.NEXT_PUBLIC_DOMAIN }}
+            VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+            VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+        steps:
+            - uses: actions/checkout@v5
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  cache: npm
+            - name: Install dependencies
+              run: |
+                  echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+                  echo "@xabierlameiro:registry=https://npm.pkg.github.com/" >> ~/.npmrc
+                  npm ci --legacy-peer-deps --include=optional
+            - name: Generate documentation
+              run: npm run jsdoc
+            - name: Checkout doc repository
+              uses: actions/checkout@v5
+              with:
+                  repository: xabierlameiro/doc-report
+                  token: ${{ secrets.TOKEN_GITHUB }}
+                  path: doc
+            - name: Copy documentation and publish
+              run: |
+                  cd doc
+                  cp -r ../public/docs/ .
+                  printf 'User-agent: *\nDisallow: /\n' > robots.txt
+                  printf '{ "headers": [ { "source": "/(.*)", "headers": [ { "key": "X-Robots-Tag", "value": "noindex, nofollow" } ] } ] }\n' > vercel.json
+                  git config --global user.email "action@github.com"
+                  git config --global user.name "GitHub Action"
+                  git add .
+                  git diff --staged --quiet || git commit -m "Update doc-report"
+                  git push origin main
+            - name: Checkout stb-report repository
+              uses: actions/checkout@v5
+              with:
+                  repository: xabierlameiro/stb-report
+                  token: ${{ secrets.TOKEN_GITHUB }}
+                  path: stb-report
+            - name: Copy storybook and publish
+              run: |
+                  npm run build-storybook
+                  cd stb-report
+                  cp -r ../storybook-static/ .
+                  printf 'User-agent: *\nDisallow: /\n' > robots.txt
+                  printf '{ "headers": [ { "source": "/(.*)", "headers": [ { "key": "X-Robots-Tag", "value": "noindex, nofollow" } ] } ] }\n' > vercel.json
+                  git config --global user.email "action@github.com"
+                  git config --global user.name "GitHub Action"
+                  git add .
+                  git diff --staged --quiet || git commit -m "Update stb-report"
+                  git push origin main
+
+    lighthouse:
+        name: Lighthouse
+        runs-on: ubuntu-22.04
+        steps:
+            - uses: actions/checkout@v5
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  cache: npm
+            - name: Install dependencies
+              run: |
+                  echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+                  echo "@xabierlameiro:registry=https://npm.pkg.github.com/" >> ~/.npmrc
+                  npm ci --legacy-peer-deps --include=optional
+            # No `sleep 10m` here. That existed because this job used to chase a deployment that had
+            # just started; on a schedule the site is already live, so it measures whatever is in
+            # production right now.
+            - name: Execute Lighthouse
+              run: npm run lighthouse-report
+            - name: Checkout performance-report repository
+              uses: actions/checkout@v5
+              with:
+                  repository: xabierlameiro/performance-report
+                  token: ${{ secrets.TOKEN_GITHUB }}
+                  path: performance-report
+            - name: Copy output folder and publish
+              run: |
+                  cd performance-report
+                  cp -r ../lighthouse .
+                  printf 'User-agent: *\nDisallow: /\n' > robots.txt
+                  printf '{ "headers": [ { "source": "/(.*)", "headers": [ { "key": "X-Robots-Tag", "value": "noindex, nofollow" } ] } ] }\n' > vercel.json
+                  git config --global user.email "action@github.com"
+                  git config --global user.name "GitHub Action"
+                  git add .
+                  git diff --staged --quiet || git commit -m "Update performance-report"
+                  git push origin main

--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Vercel "Ignored Build Step". Referenced by `ignoreCommand` in vercel.json.
+#
+# Contract is inverted from how it reads: exit 0 means SKIP the build, exit 1 means BUILD it.
+#
+# SDD-L01b. Vercel's `git.deploymentEnabled` object only overrides the branches it names —
+# "unspecified branches default to true" — so with only `master` and `dev` listed, every `fix/*` and
+# every `dependabot/*` branch was building a preview on each push. Dependabot also rebases its
+# branches, which pushes again and builds again: `globals`, `eslint` and `cross-env` each produced two
+# previews on 2026-07-26 alone.
+#
+# Policy: production always builds; preview builds are skipped for dependabot branches only. A
+# dependency bump has nothing to look at in a browser, while a preview of a real change is how PRs get
+# reviewed here.
+#
+# `VERCEL_ENV` and `VERCEL_GIT_COMMIT_REF` are both documented system environment variables.
+
+set -eu
+
+# Never skip production. Guard first so a malformed ref below can never take the site down.
+if [ "${VERCEL_ENV:-}" = "production" ]; then
+    echo "vercel-ignore-build: production — building."
+    exit 1
+fi
+
+branch="${VERCEL_GIT_COMMIT_REF:-}"
+
+case "$branch" in
+    dependabot/*)
+        echo "vercel-ignore-build: '$branch' is a dependabot branch — skipping preview build."
+        exit 0
+        ;;
+    *)
+        echo "vercel-ignore-build: '$branch' — building preview."
+        exit 1
+        ;;
+esac

--- a/vercel.json
+++ b/vercel.json
@@ -8,5 +8,6 @@
         }
     },
     "buildCommand": "npm run build",
-    "installCommand": "npm ci --legacy-peer-deps --include=optional"
+    "installCommand": "npm ci --legacy-peer-deps --include=optional",
+    "ignoreCommand": "sh scripts/vercel-ignore-build.sh"
 }


### PR DESCRIPTION
Measured on 2026-07-26, not assumed. Three independent amplifiers were burning the Vercel daily
deployment budget.

## 1. Satellite fan-out — the big one

Publishing the coverage, e2e, JSDoc, Storybook and Lighthouse reports hung off **every push to
master**. Each pushes to a separate repository, and each of those has its own Vercel git integration.

**One merge = six deployments.** Confirmed via the Vercel API: `performance-report` took **6
production deployments in a day**, every one the same `Update performance-report` commit from the
action.

Moved to a new `reports.yml` on a **weekly schedule + `workflow_dispatch`**. None of these is
time-critical — coverage and a Lighthouse run are things you consult, not things anyone waits on
minutes after a merge.

Two extras while moving them:
- The publish steps now `git diff --staged --quiet || git commit`, so an **unchanged report no longer
  commits and therefore no longer deploys**.
- Dropped `sleep 10m` from Lighthouse. It existed to chase a deployment it was racing; on a schedule
  the site is already live. That also returns ~10 minutes of runner time per merge.

**A merge drops from 6 deployments to 1.**

## 2. Every branch was building a preview

`vercel.json` named only `master` and `dev`. Per Vercel's docs:

> `deploymentEnabled` object: **"Unspecified branches default to true."**

So every `fix/*` and every `dependabot/*` branch built a preview on each push — ≥14 in this project
today.

Added `scripts/vercel-ignore-build.sh` as the `ignoreCommand`. Verified across six cases:

| `VERCEL_ENV` | branch | result |
|---|---|---|
| production | `master` | **BUILD** |
| preview | `fix/sdd-l06-a11y` | **BUILD** |
| preview | `dependabot/npm_and_yarn/eslint-10.8.0` | **SKIP** |
| preview | `dependabot/github_actions/actions/checkout-7` | **SKIP** |
| preview | *(no ref)* | **BUILD** |
| production | `dependabot/...` | **BUILD** ← safety guard |

Policy per your call: previews stay for real PRs (that is how you have been reviewing them), and go
away for dependency bumps, which have nothing to look at in a browser.

## 3. Dependabot fan-out

Fixing the empty `package-ecosystem` in SDD-L01 was correct, but it produced **8 PRs in one morning**
— and Dependabot rebases its branches, so `globals`, `eslint` and `cross-env` each cost **two** preview
deployments before anyone read them.

Now grouped: one PR for minor/patch, one for majors. Kept separate deliberately — the current crop
includes `eslint` 9 → 10 and `globals` 14 → 17, which touch the flat config directly, and a risky
major should not block a batch of safe bumps. Open-PR limits lowered to 3 and 2.

## What stays on push

IndexNow. Telling search engines a URL changed is the one genuinely time-sensitive thing in the
post-deploy path (SDD-013 — ChatGPT Search retrieves from Bing's index).

## Verified

All four workflow YAMLs and both config files parse. `lint`, `tsc`, `audit:prod` and `coverage` pass.

## Note on the 8 open Dependabot PRs

**Do not merge them one by one** — that would cost roughly 8 previews + 8 production + 40 satellite
deployments. Land this PR first, then close them and let the grouped config re-open two. I have a
read on which are wanted and which are risky; details in the follow-up comment.