### PR TITLE
fix(a11y): real dialog semantics, contrast tokens and motion preferences

### DIFF
--- a/e2e/cookie-consent.test.ts
+++ b/e2e/cookie-consent.test.ts
@@ -43,7 +43,9 @@ test.describe('Cookie consent', () => {
     test('should not overlap the Dock', async ({ page }) => {
         await expect(page.getByTestId('consent-accept')).toBeVisible();
 
-        const card = await page.getByRole('dialog').boundingBox();
+        // Scoped by name: SDD-L06 gave the page's own window a real `role="dialog"` too, so a bare
+        // role query now matches both and Playwright's strict mode rejects it.
+        const card = await page.getByRole('dialog', { name: 'Cookies' }).boundingBox();
         const dock = await page.getByTestId('home').boundingBox();
         expect(card).not.toBeNull();
         expect(dock).not.toBeNull();

--- a/src/components/Blog/NavList/navlist.module.css
+++ b/src/components/Blog/NavList/navlist.module.css
@@ -27,9 +27,13 @@
     color: rgba(var(--blue-color));
 }
 
+/* SDD-L06: was `var(--blog-color)`, which is defined nowhere in the codebase — the declaration was
+   dropped by the browser, so the selected state fell back to the inherited colour and had never
+   actually been verified. --blog-font-selected is the token that pairs with the selected row's
+   --blue-color background (7.20:1). */
 .selected .number,
 .postList .selected svg {
-    color: rgba(var(--blog-color));
+    color: rgba(var(--blog-font-selected));
 }
 
 .selected {

--- a/src/components/DeploymentStatus/deploymentstatus.module.css
+++ b/src/components/DeploymentStatus/deploymentstatus.module.css
@@ -29,3 +29,33 @@
 .canceled {
     background-color: var(--status-canceled);
 }
+
+/**
+ * SDD-L06. A second channel besides hue, so the six states are distinguishable without colour
+ * perception (WCAG 1.4.1). The dot keeps its colour; the glyph is what actually differentiates it.
+ */
+.status {
+    display: grid;
+    place-content: center;
+    font-size: 9px;
+    line-height: 1;
+    color: rgba(var(--blog-background));
+    font-weight: 700;
+}
+
+.status[data-status='ready']::after {
+    content: '✓';
+}
+.status[data-status='building']::after,
+.status[data-status='initializing']::after {
+    content: '·';
+}
+.status[data-status='queued']::after {
+    content: '…';
+}
+.status[data-status='error']::after {
+    content: '!';
+}
+.status[data-status='canceled']::after {
+    content: '×';
+}

--- a/src/components/DeploymentStatus/index.tsx
+++ b/src/components/DeploymentStatus/index.tsx
@@ -51,7 +51,23 @@ const DeploymentStatus = () => {
         <RenderManager error={isError} loading={isLoading}>
             <Tooltip>
                 <Tooltip.Trigger>
-                    <div className={`${styles.status} ${status ? styles[status.toLowerCase()] : ''}`} />
+                    {/*
+                     * SDD-L06: was an empty <div> — no text, no label, no role. A screen reader
+                     * announced nothing, and sighted users had only hue to go on: every one of the six
+                     * states computes between 1.01:1 and 2.93:1 against the LIGHT header gradient, so
+                     * low-vision users could not see it at all and colour-blind users could not tell
+                     * ready from error. `role="img"` plus a name carries the state to assistive tech,
+                     * and the glyph gives it a second, non-colour channel (WCAG 1.4.1).
+                     */}
+                    <span
+                        role="img"
+                        aria-label={f(
+                            { id: 'deploymentstatus.tooltip' },
+                            { status, username, environment, createdAt: '' }
+                        )}
+                        data-status={status ? status.toLowerCase() : 'unknown'}
+                        className={`${styles.status} ${status ? styles[status.toLowerCase()] : ''}`}
+                    />
                 </Tooltip.Trigger>
                 <Tooltip.Content>
                     {f(

--- a/src/components/Dialog/__test__/dialog.test.tsx
+++ b/src/components/Dialog/__test__/dialog.test.tsx
@@ -1,5 +1,5 @@
 import Dialog from '..';
-import { render, screen } from '@/test';
+import { fireEvent, render, screen } from '@/test';
 
 describe('Dialog component', () => {
     it('Should renders header, body and footer', () => {
@@ -8,14 +8,71 @@ describe('Dialog component', () => {
         expect(screen.getByTestId('dialog-body')).toBeInTheDocument();
         expect(screen.getByTestId('dialog-footer')).toBeInTheDocument();
     });
+
     it('Should render with padding and modal mode', () => {
         render(<Dialog open withPadding modalMode />);
         expect(screen.getByTestId('dialog')).toBeInTheDocument();
         expect(screen.getByTestId('dialog')).toHaveClass('padding');
         expect(screen.getByTestId('dialog')).toHaveClass('modalMode');
     });
+
     it('Should not visisble', () => {
         render(<Dialog />);
         expect(screen.getByTestId('dialog')).not.toHaveClass('open');
+    });
+
+    /**
+     * SDD-L06. This primitive backs all eight pages and was a plain <div>: no role, no accessible
+     * name, no Escape, and — the part the audit could not settle without a runtime check — a closed
+     * window hidden only by `transform: scale(0)`, which is purely visual. Its buttons and links
+     * stayed in the tab order and in the accessibility tree.
+     */
+    it('Should be a dialog with an accessible name from its header', () => {
+        render(<Dialog open header={<span>Settings</span>} />);
+
+        expect(screen.getByRole('dialog')).toHaveAccessibleName('Settings');
+    });
+
+    it('Should prefer an explicit label over the header', () => {
+        render(<Dialog open label="Blog" header={<span>Settings</span>} />);
+
+        expect(screen.getByRole('dialog')).toHaveAccessibleName('Blog');
+    });
+
+    // Most windows here are NOT modal — the Dock and menu bar stay usable behind them — so claiming
+    // aria-modal would tell assistive tech the rest of the page is inert when it is not.
+    it('Should only claim aria-modal in modalMode', () => {
+        const { rerender } = render(<Dialog open />);
+        expect(screen.getByTestId('dialog')).not.toHaveAttribute('aria-modal');
+
+        rerender(<Dialog open modalMode />);
+        expect(screen.getByTestId('dialog')).toHaveAttribute('aria-modal', 'true');
+    });
+
+    // The regression that matters: a closed window must not be reachable.
+    it('Should be inert while closed, and not while open', () => {
+        const { rerender } = render(<Dialog />);
+        expect(screen.getByTestId('dialog')).toHaveAttribute('inert');
+
+        rerender(<Dialog open />);
+        expect(screen.getByTestId('dialog')).not.toHaveAttribute('inert');
+    });
+
+    it('Should close on Escape when it can be closed', () => {
+        const onClose = jest.fn();
+        render(<Dialog open onClose={onClose} />);
+
+        fireEvent.keyDown(window, { key: 'Escape' });
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('Should ignore Escape while closed', () => {
+        const onClose = jest.fn();
+        render(<Dialog onClose={onClose} />);
+
+        fireEvent.keyDown(window, { key: 'Escape' });
+
+        expect(onClose).not.toHaveBeenCalled();
     });
 });

--- a/src/components/Dialog/dialog.module.css
+++ b/src/components/Dialog/dialog.module.css
@@ -7,6 +7,19 @@
     max-width: 100vw;
     height: calc(100vh - 50px);
     transform: scale(0);
+    /**
+     * SDD-L06 NOTE, deliberately left as `--white-color`.
+     *
+     * This is theme-independent, so every window stays white even under `[data-theme='dark']` while
+     * the text tokens inside it switch — light-on-white. Changing it to `--blog-background` was tried
+     * and reverted in the same phase: the token resolves correctly on this element (verified as
+     * `30,30,30` in the browser) yet `background-color` still computes white, and the cause was not
+     * isolated. Shipping a half-working dark surface is worse than a consistently light one.
+     *
+     * It has never surfaced in production because the dark theme has effectively never run —
+     * `useDarkMode` is mounted only by /settings, so `data-theme` stays at the "light" hardcoded in
+     * _document.tsx everywhere else. Fixing the theme and fixing this surface have to land together.
+     */
     background: rgba(var(--white-color));
     box-shadow: 0 8px 32px 0 rgb(31 38 135 / 37%);
     transition: all 0.3s ease-in;

--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -12,6 +12,10 @@ type Props = {
     body?: ReactNode;
     footer?: ReactNode;
     large?: boolean;
+    /** Accessible name for the window. Falls back to labelling by the header's content. */
+    label?: string;
+    /** Called on Escape. Omit for a window that has no way to close. */
+    onClose?: () => void;
 };
 
 /**
@@ -35,6 +39,8 @@ type Props = {
  * @param {ReactNode} body - The body of the dialog
  * @param {ReactNode} footer - The footer of the dialog
  * @param {boolean} large - If true, the dialog will be large
+ * @param {string} label - Accessible name for the window
+ * @param {Function} onClose - Invoked when Escape is pressed
  * @returns {JSX.Element}
  */
 
@@ -49,12 +55,49 @@ const Dialog = (props: Props) => {
         header = <></>,
         body = <></>,
         footer = <></>,
+        label,
+        onClose,
     } = props;
 
+    const headerId = React.useId();
+
+    // Escape closes, when there is something to close. A window a keyboard user cannot dismiss is a
+    // trap, and this primitive backs every page on the site.
+    React.useEffect(() => {
+        if (!open || !onClose) return undefined;
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') onClose();
+        };
+        window.addEventListener('keydown', onKeyDown);
+        return () => window.removeEventListener('keydown', onKeyDown);
+    }, [open, onClose]);
+
     return (
+        /**
+         * SDD-L06. This was a plain `<div>`: no role, no accessible name, no focus management, no
+         * Escape — on all eight pages of the site. A screen-reader user was never told a window had
+         * opened or what it was called.
+         *
+         * `aria-modal` only in `modalMode`. The macOS-window premise means most of these are *not*
+         * modal — the Dock and menu bar stay usable behind them — and claiming otherwise would tell
+         * assistive tech the rest of the page is inert when it is not. Focus is likewise not trapped,
+         * for the same reason.
+         *
+         * `inert` when closed is the important half, and it is what the audit could not settle
+         * without a runtime check: `dialog.module.css` hides a closed window with
+         * `transform: scale(0)`, which is purely visual. Its buttons and links stayed in the tab order
+         * and in the accessibility tree, so a keyboard user could tab into an invisible window and a
+         * screen reader would read out windows that were not on screen. `inert` removes both while
+         * leaving the scale transition intact, which `display: none` would not.
+         */
         <div
             ref={dialogRef}
             data-testid="dialog"
+            role="dialog"
+            aria-modal={modalMode ? true : undefined}
+            aria-label={label}
+            aria-labelledby={label ? undefined : headerId}
+            inert={!open}
             className={clx(
                 className,
                 styles.dialog,
@@ -64,7 +107,9 @@ const Dialog = (props: Props) => {
                 large ? styles.large : ''
             )}
         >
-            <header data-testid="dialog-header">{header}</header>
+            <header data-testid="dialog-header" id={headerId}>
+                {header}
+            </header>
             {/* SDD-L05: was <main>. Layout already wraps children in one, so every page shipped
                 two landmarks — invalid, and it breaks the "skip to main content" idiom because a
                 screen-reader user gets two ambiguous "main" regions. On the blog the real article

--- a/src/components/QuestionBlock/__test__/questionBlock.test.tsx
+++ b/src/components/QuestionBlock/__test__/questionBlock.test.tsx
@@ -55,6 +55,89 @@ describe('QuestionBlock component', () => {
         expect(screen.queryByTestId('question-block')).not.toBeInTheDocument();
     });
 
+    /**
+     * SDD-L06. The question was a bare <div> beside the options rather than labelling them, so a
+     * screen reader announced "Yes, radio button, 1 of 2" with no idea what was being asked.
+     */
+    it('Should group the options under the question as a radiogroup', () => {
+        render(
+            <QuestionBlock
+                question={question}
+                index={0}
+                currentQuestionNum={0}
+                answers={[]}
+                handleAnswerOptionClick={jest.fn()}
+            />
+        );
+
+        expect(screen.getByRole('group', { name: /Sample question/ })).toBeInTheDocument();
+        for (const radio of screen.getAllByRole('radio')) {
+            expect(radio).toHaveAccessibleName();
+        }
+    });
+
+    /**
+     * id/htmlFor used to be the answer text itself. That text contains spaces, which is invalid in an
+     * id, and it repeats across questions — 'Si' appears in two, 'Lo desconozco' in three. htmlFor
+     * resolves to the FIRST matching id in the document, so clicking a label could toggle another
+     * question's radio. Rendering two blocks with the same answer texts pins that.
+     */
+    it('Should give every option a unique, whitespace-free id across questions', () => {
+        render(
+            <>
+                <QuestionBlock
+                    question={question}
+                    index={0}
+                    currentQuestionNum={0}
+                    answers={[]}
+                    handleAnswerOptionClick={jest.fn()}
+                />
+                <QuestionBlock
+                    question={question}
+                    index={1}
+                    currentQuestionNum={1}
+                    answers={[]}
+                    handleAnswerOptionClick={jest.fn()}
+                />
+            </>
+        );
+
+        const ids = screen.getAllByRole('radio').map((radio) => radio.id);
+
+        expect(ids).toHaveLength(4);
+        expect(new Set(ids).size).toBe(4);
+        for (const id of ids) expect(id).not.toMatch(/\s/);
+    });
+
+    it('Should route a label click to its own question, not the first matching id', () => {
+        const first = jest.fn();
+        const second = jest.fn();
+        render(
+            <>
+                <QuestionBlock
+                    question={question}
+                    index={0}
+                    currentQuestionNum={0}
+                    answers={[]}
+                    handleAnswerOptionClick={first}
+                />
+                <QuestionBlock
+                    question={question}
+                    index={1}
+                    currentQuestionNum={1}
+                    answers={[]}
+                    handleAnswerOptionClick={second}
+                />
+            </>
+        );
+
+        // The SECOND block's "Yes" — under the old scheme both labels pointed at the same id.
+        fireEvent.click(screen.getAllByLabelText('Yes')[1]);
+
+        expect(second).toHaveBeenCalledTimes(1);
+        expect(first).not.toHaveBeenCalled();
+    });
+
     it('Should render string content as inert text, never as HTML', () => {
         const payload = '<img src=x onerror="alert(1)">';
         render(

--- a/src/components/QuestionBlock/index.tsx
+++ b/src/components/QuestionBlock/index.tsx
@@ -18,30 +18,46 @@ type Props = {
 const QuestionBlock = ({ question, index, currentQuestionNum, answers, handleAnswerOptionClick }: Props) => {
     if (currentQuestionNum !== index) return null;
 
+    /**
+     * SDD-L06. Two defects here, both invisible to a sighted mouse user.
+     *
+     * The question was a bare `<div>` sitting beside the options rather than labelling them, so a
+     * screen reader announced "Frontend, radio button, 1 of 3" with no indication of what was being
+     * asked. `<fieldset>` + `<legend>` is the native way to say "these options answer this question".
+     *
+     * And `id`/`htmlFor` were the answer text itself. That text contains spaces
+     * ("Remoto 100% pero solo en España"), which is invalid in an id, and it repeats across
+     * questions — 'Si' appears in two, 'Lo desconozco' in three. `htmlFor` resolves to the *first*
+     * matching id in the document, so clicking a label could toggle another question's radio. The id
+     * is now derived from the question and option indices, which are unique by construction.
+     */
     return (
-        <div data-testid="question-block" className={styles.question}>
-            <div>{question.questionContent}</div>
-            {question.answerOptions?.map((answerOption) => (
-                <label htmlFor={answerOption.answerText} key={answerOption.answerText}>
-                    <input
-                        onChange={(e) =>
-                            handleAnswerOptionClick({
-                                question: question.questionText || '',
-                                answer: e.target.value,
-                                isCorrect: answerOption.isCorrect,
-                                questionNum: index,
-                            })
-                        }
-                        type="radio"
-                        id={answerOption.answerText}
-                        name={String(index)}
-                        value={answerOption.answerText}
-                        checked={answers[index]?.answer === answerOption.answerText}
-                    />
-                    {answerOption.answerText}
-                </label>
-            ))}
-        </div>
+        <fieldset data-testid="question-block" className={styles.question}>
+            <legend>{question.questionContent}</legend>
+            {question.answerOptions?.map((answerOption, optionIndex) => {
+                const optionId = `q${index}-a${optionIndex}`;
+                return (
+                    <label htmlFor={optionId} key={optionId}>
+                        <input
+                            onChange={(e) =>
+                                handleAnswerOptionClick({
+                                    question: question.questionText || '',
+                                    answer: e.target.value,
+                                    isCorrect: answerOption.isCorrect,
+                                    questionNum: index,
+                                })
+                            }
+                            type="radio"
+                            id={optionId}
+                            name={String(index)}
+                            value={answerOption.answerText}
+                            checked={answers[index]?.answer === answerOption.answerText}
+                        />
+                        {answerOption.answerText}
+                    </label>
+                );
+            })}
+        </fieldset>
     );
 };
 

--- a/src/components/SearchInput/__test__/search.test.tsx
+++ b/src/components/SearchInput/__test__/search.test.tsx
@@ -17,4 +17,40 @@ describe('SearchInput component', () => {
         fireEvent.change(searchInput, { target: { value: 'Hello World' } });
         expect((searchInput as HTMLInputElement).value).toBe('Hello World');
     });
+
+    /**
+     * SDD-L06. This field had no label, no aria-label and no id: a placeholder was the only cue, and
+     * a placeholder is not a label — it vanishes on first keystroke and gives voice-control users
+     * nothing to say. A screen reader announced "edit, blank".
+     *
+     * The intl mock returns message ids, so the accessible name reads as `search.label` here.
+     */
+    it('Should have an accessible name', () => {
+        render(<SearchInput />);
+
+        expect(screen.getByRole('searchbox')).toHaveAccessibleName('search.label');
+    });
+
+    it('Should accept an explicit label', () => {
+        render(<SearchInput label="Find a legal document" />);
+
+        expect(screen.getByRole('searchbox')).toHaveAccessibleName('Find a legal document');
+    });
+
+    // `type="search"` reports the field's purpose (WCAG 1.3.5); it was `text`.
+    it('Should be a search field, with autocomplete off', () => {
+        render(<SearchInput />);
+        const input = screen.getByTestId('search-input');
+
+        expect(input).toHaveAttribute('type', 'search');
+        expect(input).toHaveAttribute('autocomplete', 'off');
+    });
+
+    // The default placeholder used to be a hardcoded English 'Search', and ArticlePanel renders this
+    // with no prop — so every blog post showed English placeholder text in es and gl.
+    it('Should take its default placeholder from the catalogue, not a hardcoded string', () => {
+        render(<SearchInput />);
+
+        expect(screen.getByTestId('search-input')).toHaveAttribute('placeholder', 'search.label');
+    });
 });

--- a/src/components/SearchInput/index.tsx
+++ b/src/components/SearchInput/index.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+import { useIntl } from 'react-intl';
 import styles from './search.module.css';
 
 type Props = {
@@ -6,6 +8,8 @@ type Props = {
     value?: string;
     onBlur?: () => void;
     onChange?: () => void;
+    /** Accessible name. Defaults to the shared `search.label` message. */
+    label?: string;
 };
 
 /**
@@ -17,20 +21,42 @@ type Props = {
  * @param {Function} onBlur - Callback function when input is blurred
  * @param {Function} onChange - Callback function when input is changed
  * @param {string} placeHolderText - The placeholder text for the input
+ * @param {string} label - Accessible name for the field
  * @returns {JSX.Element}
  */
-const SearchInput = ({ value, disabled, onBlur, onChange, placeHolderText = 'Search' }: Props) => {
+const SearchInput = ({ value, disabled, onBlur, onChange, placeHolderText, label }: Props) => {
+    const { formatMessage: f } = useIntl();
+    const id = React.useId();
+
+    /**
+     * SDD-L06. This had no label, no aria-label and no id — a placeholder was the only cue, and a
+     * placeholder is not a label: it disappears the moment anything is typed, and voice-control users
+     * have no name to speak. A screen reader announced "edit, blank".
+     *
+     * The placeholder also defaulted to a hardcoded English 'Search', and `ArticlePanel` renders this
+     * with no prop at all — so every blog post showed an English placeholder in `es` and `gl`.
+     *
+     * `type="search"` rather than `text` so the field reports its purpose (1.3.5), and
+     * `autoComplete="off"` because there is nothing here worth restoring.
+     */
     return (
-        <input
-            type="text"
-            data-testid="search-input"
-            value={value}
-            onBlur={onBlur}
-            onChange={onChange}
-            className={styles.input}
-            disabled={disabled}
-            placeholder={placeHolderText}
-        />
+        <>
+            <label htmlFor={id} className="visuallyHidden">
+                {label ?? f({ id: 'search.label' })}
+            </label>
+            <input
+                id={id}
+                type="search"
+                autoComplete="off"
+                data-testid="search-input"
+                value={value}
+                onBlur={onBlur}
+                onChange={onChange}
+                className={styles.input}
+                disabled={disabled}
+                placeholder={placeHolderText ?? f({ id: 'search.label' })}
+            />
+        </>
     );
 };
 export default SearchInput;

--- a/src/hooks/__test__/usePrefersReducedMotion.test.tsx
+++ b/src/hooks/__test__/usePrefersReducedMotion.test.tsx
@@ -1,0 +1,60 @@
+import { renderHook, act } from '@testing-library/react';
+import usePrefersReducedMotion from '../usePrefersReducedMotion';
+
+/**
+ * SDD-L06. The global `prefers-reduced-motion` CSS block cannot stop motion that JavaScript paints —
+ * the survey's confetti is a canvas on a timer — so this hook gates it. These tests pin the two
+ * things that matter: it reports the preference, and it keeps reporting it when the user changes it
+ * mid-session.
+ */
+describe('usePrefersReducedMotion', () => {
+    const listeners = new Set<(event: MediaQueryListEvent) => void>();
+
+    const mockMatchMedia = (matches: boolean) => {
+        listeners.clear();
+        Object.defineProperty(window, 'matchMedia', {
+            writable: true,
+            configurable: true,
+            value: jest.fn().mockImplementation((query: string) => ({
+                matches,
+                media: query,
+                addEventListener: (_: string, cb: (event: MediaQueryListEvent) => void) => listeners.add(cb),
+                removeEventListener: (_: string, cb: (event: MediaQueryListEvent) => void) => listeners.delete(cb),
+            })),
+        });
+    };
+
+    it('reports false when the preference is not set', () => {
+        mockMatchMedia(false);
+        const { result } = renderHook(() => usePrefersReducedMotion());
+        expect(result.current).toBe(false);
+    });
+
+    it('reports true when the preference is set', () => {
+        mockMatchMedia(true);
+        const { result } = renderHook(() => usePrefersReducedMotion());
+        expect(result.current).toBe(true);
+    });
+
+    it('follows the preference when it changes mid-session', () => {
+        mockMatchMedia(false);
+        const { result } = renderHook(() => usePrefersReducedMotion());
+        expect(result.current).toBe(false);
+
+        act(() => {
+            listeners.forEach((cb) => cb({ matches: true } as MediaQueryListEvent));
+        });
+
+        expect(result.current).toBe(true);
+    });
+
+    it('detaches its listener on unmount', () => {
+        mockMatchMedia(false);
+        const { unmount } = renderHook(() => usePrefersReducedMotion());
+        expect(listeners.size).toBe(1);
+
+        unmount();
+
+        expect(listeners.size).toBe(0);
+    });
+});

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -5,18 +5,59 @@ const scheme = {
     dark: 'dark' as const,
 };
 
+/** Where an explicit choice is kept, so it survives a reload and outranks the OS preference. */
+export const THEME_STORAGE_KEY = 'theme';
+
+/**
+ * @description The active theme, and a way to change it.
+ *
+ * SDD-L06. This used to initialise to `null` and only call `setTheme` from the media-query **change**
+ * listener — it never read `mediaQuery.matches` on mount. So `data-theme` stayed at the `"light"`
+ * hardcoded in `_document.tsx` unless the visitor flipped their OS theme mid-session, and a
+ * dark-preference visitor got the light palette. That is what turned the light theme's contrast
+ * failures from theme-specific into universal, and it also meant the dark theme was effectively never
+ * exercised: several of its tokens had never been rendered.
+ *
+ * An explicit choice is now persisted and wins over the OS preference, which is what a theme toggle
+ * is for — otherwise the next OS change would silently undo it.
+ *
+ * @returns {object} theme, toggleTheme and the scheme constants.
+ */
 const useDarkMode = (): { theme: null | 'dark' | 'light'; toggleTheme: () => void; scheme: typeof scheme } => {
     const [theme, setTheme] = React.useState<null | 'dark' | 'light'>(null);
 
     React.useEffect(() => {
-        if (typeof window !== 'undefined' && window.matchMedia) {
-            const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-            const handler = (event: MediaQueryListEvent) => {
-                setTheme(event.matches ? scheme.dark : scheme.light);
-            };
-            mediaQuery.addEventListener('change', handler);
-            return () => mediaQuery.removeEventListener('change', handler);
+        if (typeof window === 'undefined' || !window.matchMedia) return undefined;
+
+        const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+        // Resolve after mount rather than during render: reading storage or matchMedia while
+        // rendering would make the server and client markup disagree.
+        let stored: string | null = null;
+        try {
+            stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+        } catch {
+            // Storage blocked (private mode, extensions). Fall through to the OS preference.
         }
+
+        if (stored === scheme.dark || stored === scheme.light) {
+            setTheme(stored);
+        } else {
+            setTheme(mediaQuery.matches ? scheme.dark : scheme.light);
+        }
+
+        // Follow the OS only while the visitor has not made a choice of their own.
+        const handler = (event: MediaQueryListEvent) => {
+            let hasExplicitChoice = false;
+            try {
+                hasExplicitChoice = window.localStorage.getItem(THEME_STORAGE_KEY) !== null;
+            } catch {
+                hasExplicitChoice = false;
+            }
+            if (!hasExplicitChoice) setTheme(event.matches ? scheme.dark : scheme.light);
+        };
+        mediaQuery.addEventListener('change', handler);
+        return () => mediaQuery.removeEventListener('change', handler);
     }, []);
 
     React.useEffect(() => {
@@ -25,9 +66,17 @@ const useDarkMode = (): { theme: null | 'dark' | 'light'; toggleTheme: () => voi
         }
     }, [theme]);
 
-    const toggleTheme = () => {
-        setTheme(theme === scheme.dark ? scheme.light : scheme.dark);
-    };
+    const toggleTheme = React.useCallback(() => {
+        setTheme((current) => {
+            const next = current === scheme.dark ? scheme.light : scheme.dark;
+            try {
+                window.localStorage.setItem(THEME_STORAGE_KEY, next);
+            } catch {
+                // The choice still applies to this page view.
+            }
+            return next;
+        });
+    }, []);
 
     return { theme, scheme, toggleTheme };
 };

--- a/src/hooks/usePrefersReducedMotion.ts
+++ b/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,31 @@
+import React from 'react';
+
+/**
+ * @description Whether the visitor has asked their OS to reduce motion.
+ *
+ * SDD-L06. The global `@media (prefers-reduced-motion: reduce)` block in globals.css covers CSS
+ * animations and transitions, but it cannot reach motion that JavaScript paints — the survey's
+ * confetti is a canvas driven by a timer, so the only way to stop it is not to render it.
+ *
+ * Starts `false` and resolves after mount, deliberately: reading `matchMedia` during render would
+ * make the server and client markup disagree. Erring toward "motion allowed" for one frame is the
+ * safe direction — the alternative would flash content off for everyone.
+ *
+ * @returns {boolean} True when the reduce-motion preference is set.
+ */
+const usePrefersReducedMotion = (): boolean => {
+    const [prefersReducedMotion, setPrefersReducedMotion] = React.useState(false);
+
+    React.useEffect(() => {
+        const query = window.matchMedia('(prefers-reduced-motion: reduce)');
+        setPrefersReducedMotion(query.matches);
+
+        const onChange = (event: MediaQueryListEvent) => setPrefersReducedMotion(event.matches);
+        query.addEventListener('change', onChange);
+        return () => query.removeEventListener('change', onChange);
+    }, []);
+
+    return prefersReducedMotion;
+};
+
+export default usePrefersReducedMotion;

--- a/src/intl/translations.ts
+++ b/src/intl/translations.ts
@@ -35,6 +35,8 @@ export const messages = {
         'legal.legal-notice': 'Legal Notice',
         'legal.privacy-policy': 'Privacy Policy',
         'consent.title': 'Cookies',
+        // SDD-L06: the search field had no label at all; a placeholder is not one.
+        'search.label': 'Search',
         // Side-panel toggles (SDD-L05): the grabbers had no accessible name.
         'blog.toggleCategories': 'Show categories and tags',
         'blog.togglePosts': 'Show posts in this category',
@@ -133,6 +135,7 @@ export const messages = {
         'legal.legal-notice': 'Aviso Legal',
         'legal.privacy-policy': 'Política de Privacidad',
         'consent.title': 'Cookies',
+        'search.label': 'Buscar',
         'blog.toggleCategories': 'Mostrar categorías y etiquetas',
         'blog.togglePosts': 'Mostrar entradas de esta categoría',
         'nav.social': 'Redes sociales',
@@ -227,6 +230,7 @@ export const messages = {
         'legal.legal-notice': 'Aviso Legal',
         'legal.privacy-policy': 'Política de Privacidade',
         'consent.title': 'Cookies',
+        'search.label': 'Buscar',
         'blog.toggleCategories': 'Amosar categorías e etiquetas',
         'blog.togglePosts': 'Amosar entradas desta categoría',
         'nav.social': 'Redes sociais',

--- a/src/pages/survey.tsx
+++ b/src/pages/survey.tsx
@@ -7,6 +7,7 @@ import useWindowResize from '@/hooks/useWindowResize';
 import useSurvey, { type Question } from '@/hooks/useSurvey';
 import NavigationArrows from '@/components/NavigationArrows';
 import QuestionBlock from '@/components/QuestionBlock';
+import usePrefersReducedMotion from '@/hooks/usePrefersReducedMotion';
 
 const Survey = () => {
     const { width, height } = useWindowResize();
@@ -21,10 +22,23 @@ const Survey = () => {
         handlePreviousQuestion,
         handleAnswerOptionClick,
     } = useSurvey();
+    const prefersReducedMotion = usePrefersReducedMotion();
 
     return (
         <>
-            <Confetti width={width} height={height} numberOfPieces={100} run={surveySuccess} />
+            {/*
+             * SDD-L06: a full-viewport 100-piece burst with no opt-out. Large-area unexpected motion
+             * is the canonical vestibular trigger, and the global prefers-reduced-motion block cannot
+             * help here — this is a canvas painting on a timer, not a CSS animation. So it is gated in
+             * JS, and the canvas is hidden from assistive tech either way.
+             */}
+            <Confetti
+                width={width}
+                height={height}
+                numberOfPieces={100}
+                run={surveySuccess && !prefersReducedMotion}
+                aria-hidden="true"
+            />
             <SEO
                 noimage={false}
                 meta={{

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,7 +3,6 @@
     --white-color: 255, 255, 255;
     --color-available-arrow: 95, 91 98;
     --grey-color: 236, 232, 238;
-    --dark-grey-color: 166, 166, 166;
     --red-color: 237, 106, 94;
     --yellow-color: 245, 190, 79;
     --green-color: 98, 199, 86;
@@ -23,6 +22,9 @@
     /* Link colour that works ON a surface, per theme. --blue-color is theme-independent and
        computes 2.31:1 on the dark background, so it cannot be used for text there. 7.84:1. */
     --link-on-surface: 145, 180, 230;
+    /* SDD-L06: was theme-independent #A6A6A6, which is 2.43:1 on the LIGHT aside panel. Dark keeps
+       the original value — 5.45:1 on --blog-header #352D37 — and light gets a darker grey. */
+    --dark-grey-color: 166, 166, 166;
     --blog-nav: 48, 41, 51;
     --blog-header: 53, 45, 55;
     --blog-background: 30, 30, 30;
@@ -30,7 +32,9 @@
     --blog-font-selected: 255, 255, 255;
     --blog-font-description: 160, 156, 161;
     --blog-icons: 160, 157, 162;
-    --blog-border: 30, 30, 30;
+    /* SDD-L06: was 30,30,30 — identical to --blog-background, so the border did not exist at
+       all (1.00:1). #6B6B6B is 3.13:1 there. */
+    --blog-border: 107, 107, 107;
     --input-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="490" height="490"><path fill="none" stroke="rgba(160, 157, 162)" stroke-width="36" stroke-linecap="round" d="m280,278a153,153 0 1,0-2,2l170,170m-91-117 110,110-26,26-110-110" /></svg>');
     --header-background: linear-gradient(to right, rgba(47, 41, 51, 1), rgba(30, 30, 30, 1));
     --terminal-header: 62, 54, 63;
@@ -40,14 +44,18 @@
 [data-theme='light'] {
     /* 7.20:1 on white — same value as --blue-color, which is correct in this theme. */
     --link-on-surface: 29, 88, 154;
+    /* 5.33:1 on white. */
+    --dark-grey-color: 107, 107, 107;
     --blog-nav: 204, 202, 219;
     --blog-header: 255, 255, 255;
     --blog-background: 255, 255, 255;
     --blog-font: 39, 39, 39;
     --blog-font-selected: 255, 255, 255;
-    --blog-font-description: 141, 141, 141;
+    /* SDD-L06: was #8D8D8D, 2.06:1 on --blog-nav #CCCADB. #565656 is 4.56:1. */
+    --blog-font-description: 86, 86, 86;
     --blog-icons: 0, 0, 0;
-    --blog-border: 141, 141, 141, 0.2;
+    /* SDD-L06: was 141,141,141,0.2 which composites to ~#EEE, 1.22:1 on white. */
+    --blog-border: 118, 118, 118;
     --input-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="490" height="490"><path fill="none" stroke="rgba( 101, 99, 102)" stroke-width="36" stroke-linecap="round" d="m280,278a153,153 0 1,0-2,2l170,170m-91-117 110,110-26,26-110-110" /></svg>');
     --header-background: linear-gradient(
         to right,
@@ -110,8 +118,29 @@
     border-radius: 2px;
 }
 
+/**
+ * SDD-L06: this used to be `display: none`, which removed the only affordance telling a user that
+ * content continues below the fold and the only cue to scroll position — worst on the blog article
+ * body and the horizontally-scrolling header, where widgets sit off-screen with nothing indicating
+ * they exist. Styled thin instead of hidden, with a thumb that clears 3:1 against its track.
+ */
+* {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(var(--blog-border)) transparent;
+}
+
 ::-webkit-scrollbar {
-    display: none;
+    width: 8px;
+    height: 8px;
+}
+
+::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+    background-color: rgba(var(--blog-border));
+    border-radius: 4px;
 }
 
 html,
@@ -128,8 +157,11 @@ body {
     }
 }
 
+/* SDD-L06: was --blue-color, which is theme-independent and computes 2.31:1 on the dark
+   background — every in-content link in the blog and legal documents was near-invisible in dark
+   mode. --link-on-surface is theme-scoped: 7.20:1 light, 7.84:1 dark. */
 a {
-    color: rgba(var(--blue-color));
+    color: rgba(var(--link-on-surface));
     text-decoration: underline;
     font-weight: 600;
 }
@@ -180,4 +212,24 @@ div.ch-frame-title-bar .ch-editor-tab-active > div {
 
 div.dialog_dialog__mcyQq.dialog_open___BRYL div.ch-code-multiline-mark {
     background-color: rgba(255, 255, 255, 0.01) !important;
+}
+
+/**
+ * SDD-L06. There was no `prefers-reduced-motion` anywhere in the codebase: a full-viewport 100-piece
+ * confetti burst on /survey, an indefinitely spinning loader on every header widget, a news ticker
+ * that auto-scrolls, and transitions on the dock, dialogs and panels — none of it optional.
+ *
+ * `0.01ms` rather than `none` so animations still fire their end events and any logic keyed on
+ * `animationend` keeps working. The confetti is additionally gated in JS, because not rendering it is
+ * the only way to stop a canvas that paints on a timer rather than a CSS animation.
+ */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
 }


### PR DESCRIPTION
SDD-L06, phase 6 of 10 — the judgement half of the accessibility work. L05 covered structure and
operability; this covers everything a linter cannot see.

## Contrast, verified in a browser rather than reasoned about

| | Before | After |
|---|---|---|
| Sidebar text (light) | **2.06:1** | **4.56:1** |
| Aside controls (light) | **2.43:1** | **5.33:1** |
| Body links (dark) | **2.31:1** | **7.84:1** |
| Borders (dark) | **1.00:1** — the border did not exist | **3.13:1** |

`--dark-grey-color` and `--blog-font-description` are theme-scoped now, and the global `a` rule uses
`--link-on-surface` instead of the theme-independent `--blue-color`.

`navlist.module.css` referenced `var(--blog-color)` — **defined nowhere in the codebase**. The
declaration was dropped by the browser, so the selected-category colour had never actually been
verified by anyone.

## Dialog

A plain `<div>` on all eight pages: no role, no accessible name, no Escape.

It now carries `role="dialog"`, a name from its header (or an explicit `label`), Escape when there is
something to close, and `aria-modal` **only** in `modalMode` — most of these windows are not modal,
the Dock and menu bar stay usable behind them, and claiming otherwise would tell assistive tech the
rest of the page is inert. Focus is not trapped, for the same reason.

**The audit could not settle whether a closed window stayed reachable without a runtime check.** It
did: `dialog.module.css` hides a closed window with `transform: scale(0)`, which is purely visual, so
every closed window's buttons and links stayed in the tab order and the accessibility tree. `inert`
fixes that while leaving the scale transition intact, which `display: none` would not.

## The rest

- **DeploymentStatus** was an empty `<div>` conveying six states by hue alone, every one between
  1.01:1 and 2.93:1 against the light header gradient. Now `role="img"` with a name carrying the
  state, plus a per-state glyph so colour is not the only channel (1.4.1).
- **SearchInput** had no label, no `aria-label` and no `id`. A placeholder is not a label — it
  disappears on first keystroke and gives voice-control users nothing to say. Its default placeholder
  was also a hardcoded English `'Search'` that `ArticlePanel` rendered on every blog post in all three
  locales.
- **Survey radios** had `id`/`htmlFor` set to the answer text, which contains spaces and repeats
  across questions (`'Si'` in two, `'Lo desconozco'` in three) — so clicking a label could toggle a
  **different question's** radio. Now `fieldset`/`legend` with index-derived ids.
- **Motion**: there was no `prefers-reduced-motion` anywhere. Added a global block plus a JS gate for
  the confetti, because CSS cannot stop a canvas painting on a timer.
- **Scrollbars** were `display: none` globally, removing the only cue that content continues below the
  fold. Styled thin instead.
- **useDarkMode** now reads `matchMedia` on mount and persists an explicit choice. It previously only
  reacted to the OS changing *mid-session*.

## What I implemented, verified, and then deliberately reverted

Mounting `useDarkMode` in `_app` works — I confirmed `data-theme` resolves to `dark` from the OS
preference on a normal page. **I reverted it anyway.**

With the theme actually on, the dark palette renders a **white dialog surface under dark text
tokens**. `dialog.module.css` uses the theme-independent `--white-color`; changing it to
`--blog-background` was also tried and reverted, because:

- the element itself resolves the token correctly — verified as `30,30,30` in the browser,
- the only matching rule is the new one,
- and `background-color` **still** computes `rgb(255,255,255)`. I could not isolate why.

The dark theme has effectively never run in production (the hook only mounted on `/settings`), so
these are latent problems surfacing, not regressions. But turning on a half-working theme is worse
than leaving it off, so both changes are out and the surface problem is documented in the CSS where
whoever picks it up will find it.

**Light theme — what every visitor gets today, and what the audit measured — is fully verified.**

## Tests

Dialog role/name/`aria-modal`/`inert`/Escape; SearchInput accessible name and input purpose;
QuestionBlock radiogroup semantics plus a case proving a label click no longer routes to another
question's radio; `usePrefersReducedMotion` including listener cleanup.

One e2e query needed scoping by accessible name — giving `Dialog` a real role made
`getByRole('dialog')` ambiguous, which is the change working as intended.

**64 suites / 246 tests**, 17 e2e. `lint`, `tsc`, `audit:prod`, `coverage` and e2e all pass.

Note: the coverage gate caught this PR mid-work at 78.89% functions against an 80% threshold. The
tests above are the response — lowering the threshold to make it green is exactly what SDD-L01's
comment warns against.

## Remaining in this dimension

The tooltip triggers (8 of 10 header widgets expose a bare number with no reachable explanation) and
the Notification component's undismissable 7s timer are still open, along with the dark-theme surface
above.