### PR TITLE
fix(types): validate every external boundary instead of asserting it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
                 "react-intl": "^6.8.9",
                 "remark-gfm": "^4.0.1",
                 "shiki": "^0.10.1",
-                "swr": "^2.0.2"
+                "swr": "^2.0.2",
+                "zod": "^4.4.3"
             },
             "devDependencies": {
                 "@babel/core": "^7.27.1",
@@ -10176,6 +10177,16 @@
             },
             "peerDependencies": {
                 "devtools-protocol": "*"
+            }
+        },
+        "node_modules/chromium-bidi/node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         },
         "node_modules/ci-info": {
@@ -31308,10 +31319,9 @@
             }
         },
         "node_modules/zod": {
-            "version": "3.25.76",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-            "dev": true,
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
         "react-intl": "^6.8.9",
         "remark-gfm": "^4.0.1",
         "shiki": "^0.10.1",
-        "swr": "^2.0.2"
+        "swr": "^2.0.2",
+        "zod": "^4.4.3"
     },
     "devDependencies": {
         "@babel/core": "^7.27.1",

--- a/src/__tests__/api/analytics.test.ts
+++ b/src/__tests__/api/analytics.test.ts
@@ -30,7 +30,21 @@ describe('/api/analytics', () => {
 
         expect(runReport.mock.calls[0][0]).not.toHaveProperty('dimensionFilter');
         expect(res.status).toHaveBeenCalledWith(200);
-        expect(res.json).toHaveBeenCalledWith({ pageViews: '120', newUsers: '45' });
+        // SDD-L07: numbers, not strings. GA4 emits `"120"`; this route declared
+        // `pageViews: string | number` and forwarded it, `types/api.ts` declared `number`, and the
+        // hook's `as AnalyticsData` reconciled the two by erasing at compile time. `ViewCounter`
+        // then rendered an unseparated `12345` while `CryptoPrice` beside it was formatted.
+        expect(res.json).toHaveBeenCalledWith({ pageViews: 120, newUsers: 45 });
+    });
+
+    // GA can answer with an absent metric value rather than "0" — the counter must stay a number.
+    it('substitutes zero for a metric value that is missing or unparseable', async () => {
+        runReport.mockResolvedValue([{ rows: [{ metricValues: [{ value: null }, { value: 'n/a' }] }] }]);
+        const res = createMockResponse();
+
+        await handler(createRequest(), res);
+
+        expect(res.json).toHaveBeenCalledWith({ pageViews: 0, newUsers: 0 });
     });
 
     it('filters the report by page path when a slug is given', async () => {
@@ -45,7 +59,7 @@ describe('/api/analytics', () => {
                 stringFilter: { matchType: 'EXACT', value: '/blog/react/hooks' },
             },
         });
-        expect(res.json).toHaveBeenCalledWith({ pageViews: '7', newUsers: '3' });
+        expect(res.json).toHaveBeenCalledWith({ pageViews: 7, newUsers: 3 });
     });
 
     // Regression: a page with no views made GA return no rows, which used to surface

--- a/src/__tests__/api/deployments.test.ts
+++ b/src/__tests__/api/deployments.test.ts
@@ -37,14 +37,54 @@ describe('/api/deployments', () => {
         expect((options?.headers as Record<string, string>).Authorization).toBe('Bearer token');
 
         expect(res.status).toHaveBeenCalledWith(200);
+        // SDD-L07: the three timestamps are ISO strings now. Vercel documents them as unix
+        // milliseconds and the route forwarded them untouched under a `createdAt: string`
+        // annotation — a contract that was simply false, and invisible because `new Date()` takes
+        // either. This fixture's numbers are what made that visible.
         expect(res.json).toHaveBeenCalledWith({
             status: 'READY',
             environment: 'production',
-            createdAt: DEPLOYMENT.createdAt,
-            buildingAt: DEPLOYMENT.buildingAt,
-            ready: DEPLOYMENT.ready,
+            createdAt: new Date(DEPLOYMENT.createdAt).toISOString(),
+            buildingAt: new Date(DEPLOYMENT.buildingAt).toISOString(),
+            ready: new Date(DEPLOYMENT.ready).toISOString(),
             username: 'xabierlameiro',
         });
+    });
+
+    // The status union listed six states; Vercel documents eight. `DeploymentStatus` renders
+    // `styles[status.toLowerCase()]`, so BLOCKED or DELETED produced an unstyled, invisible dot.
+    it('accepts every state Vercel documents, not just the six that were declared', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ deployments: [{ ...DEPLOYMENT, state: 'BLOCKED' }] }));
+        const res = createMockResponse();
+
+        await handler(createRequest(), res);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ status: 'BLOCKED' }));
+    });
+
+    // A state Vercel adds later must fail here rather than reach the widget and render nothing.
+    it('rejects a state outside the documented union', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ deployments: [{ ...DEPLOYMENT, state: 'HIBERNATING' }] }));
+        const res = createMockResponse();
+
+        await handler(createRequest(), res);
+
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json).toHaveBeenCalledWith({ error: 'Internal server error' });
+    });
+
+    // Was missing entirely: a 401 from a rotated token produced `undefined` from
+    // `data.deployments?.[0]` and was reported as "No deployment found" — the same log line as a
+    // project that has never deployed.
+    it('fails on a non-2xx from Vercel instead of reading the error envelope', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ error: { code: 'forbidden' } }), { status: 401 });
+        const res = createMockResponse();
+
+        await handler(createRequest(), res);
+
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json).toHaveBeenCalledWith({ error: 'Internal server error' });
     });
 
     it('reports a configuration error when a required variable is missing', async () => {
@@ -72,7 +112,9 @@ describe('/api/deployments', () => {
         expect(JSON.stringify(res.json.mock.calls)).not.toContain('No deployment found');
     });
 
-    // The deployment may not carry a creator, so username must degrade rather than throw
+    // The deployment may not carry a creator — `creator.username` is optional upstream — so username
+    // must degrade rather than throw. SDD-L07: it degrades to '' rather than `undefined`, because
+    // the contract declares `username: string` and JSON drops undefined fields entirely.
     it('tolerates a deployment with no creator', async () => {
         fetchMock.mockResponseOnce(JSON.stringify({ deployments: [{ ...DEPLOYMENT, creator: undefined }] }));
         const res = createMockResponse();
@@ -80,6 +122,6 @@ describe('/api/deployments', () => {
         await handler(createRequest(), res);
 
         expect(res.status).toHaveBeenCalledWith(200);
-        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ username: undefined }));
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ username: '' }));
     });
 });

--- a/src/__tests__/api/weather.test.ts
+++ b/src/__tests__/api/weather.test.ts
@@ -50,4 +50,53 @@ describe('/api/weather', () => {
         expect(res.status).toHaveBeenCalledWith(200);
         expect(res.json).toHaveBeenCalledWith([expect.objectContaining({ city: 'limerick', imageUrl: undefined })]);
     });
+
+    /**
+     * SDD-L07, criterion 4. A total upstream failure used to answer **200 with `[]`**: the client saw
+     * neither an error nor a loading state, so the widget rendered nothing and read as a styling bug.
+     */
+    it('returns 502 when every upstream call fails', async () => {
+        fetchMock.mockReject(new Error('network down'));
+        const res = createMockResponse();
+
+        await handler(
+            { method: 'GET', query: { cities: 'limerick,vigo' }, headers: {} } as unknown as NextApiRequest,
+            res
+        );
+
+        expect(res.status).toHaveBeenCalledWith(502);
+        expect(res.json).toHaveBeenCalledWith({ error: 'Weather service unavailable' });
+    });
+
+    // One unreachable city must not blank the others.
+    //
+    // Dispatched by URL rather than by call order: the two cities are fetched concurrently through
+    // `Promise.allSettled`, so both geocoding requests go out before either forecast and a queue of
+    // `mockResponseOnce` calls lands on the wrong city.
+    it('still answers 200 with the cities that did resolve', async () => {
+        fetchMock.mockResponse(async (request) => {
+            if (request.url.includes('vigo')) throw new Error('network down');
+            if (request.url.includes('geocoding-api')) return GEO_FIXTURE;
+            return forecastFixture(3);
+        });
+        const res = createMockResponse();
+
+        await handler(
+            { method: 'GET', query: { cities: 'limerick,vigo' }, headers: {} } as unknown as NextApiRequest,
+            res
+        );
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith([expect.objectContaining({ city: 'limerick' })]);
+    });
+
+    // The geocoding response was taken with `as GeocodingResponse` and never checked.
+    it('fails when the geocoding response no longer matches its shape', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify({ results: [{ latitude: '52.66', longitude: -8.63, name: 'x' }] }));
+        const res = createMockResponse();
+
+        await handler({ method: 'GET', query: { cities: 'limerick' }, headers: {} } as unknown as NextApiRequest, res);
+
+        expect(res.status).toHaveBeenCalledWith(502);
+    });
 });

--- a/src/components/Blog/StarCounter/index.tsx
+++ b/src/components/Blog/StarCounter/index.tsx
@@ -31,7 +31,13 @@ const StarCounter = () => {
                         errorTitle={f({ id: 'starCounter.error' })}
                         loadingTitle={f({ id: 'starCounter.loading' })}
                     >
-                        <span data-testid="star-counter">{data as string}</span>
+                        {/*
+                         * SDD-L07: was `{data as string}`. The route sends a number and the hook
+                         * falls back to `0`, so the cast was wrong in both directions — it just
+                         * happened not to matter, because React renders numbers and strings the
+                         * same way.
+                         */}
+                        <span data-testid="star-counter">{data}</span>
                     </RenderManager>
                 </a>
             </Tooltip.Trigger>

--- a/src/components/DeploymentStatus/__test__/deploymentstatus.test.tsx
+++ b/src/components/DeploymentStatus/__test__/deploymentstatus.test.tsx
@@ -1,26 +1,52 @@
+import fs from 'fs';
+import path from 'path';
 import DeploymentStatus from '..';
+import { deploymentStatusSchema } from '../../../types/schemas';
 import { render, screen } from '@/test';
 import useSWR from 'swr';
 
 jest.mock('swr');
 
 const mockData = {
-    status: 'ready',
+    status: 'READY',
     username: 'test',
-    environment: 'prod',
+    environment: 'production',
     createdAt: new Date().toISOString(),
 };
 
 describe('DeploymentStatus component', () => {
     it('renders status indicator', () => {
-        (useSWR as jest.Mock).mockReturnValue({ data: mockData, error: false });
+        (useSWR as jest.Mock).mockReturnValue({ data: mockData, error: undefined });
         const { container } = render(<DeploymentStatus />);
         expect(container.querySelector('.status')).toBeInTheDocument();
     });
 
     it('renders error state', () => {
-        (useSWR as jest.Mock).mockReturnValue({ data: undefined, error: true });
+        (useSWR as jest.Mock).mockReturnValue({ data: undefined, error: new Error('down') });
         render(<DeploymentStatus />);
         expect(screen.getByTestId('error')).toBeInTheDocument();
+    });
+
+    /**
+     * SDD-L07. The widget picks its colour with `styles[status.toLowerCase()]`, so a state with no
+     * matching class renders an empty circle — indistinguishable from "no data" — and nothing fails.
+     * That had already happened twice over: the class for `QUEUED` was named `.queue`, so a queued
+     * deployment had never shown its colour; and `BLOCKED` and `DELETED`, which Vercel documents and
+     * this codebase's six-value union omitted, had no class at all.
+     *
+     * Asserting against the schema rather than a hardcoded list means widening the union later fails
+     * here until the styling follows.
+     *
+     * Read from the stylesheet as text on purpose: `next/jest` proxies CSS modules so that every key
+     * returns its own name, which means `expect(styles[x]).toBeDefined()` passes for any string at
+     * all — including the class that was actually missing. That assertion would have proved nothing.
+     */
+    const stylesheet = fs.readFileSync(path.join(__dirname, '..', 'deploymentstatus.module.css'), 'utf8');
+
+    it.each(deploymentStatusSchema.options)('has a colour class and a glyph for the %s state', (status) => {
+        const state = status.toLowerCase();
+
+        expect(stylesheet).toContain(`.${state} {`);
+        expect(stylesheet).toContain(`[data-status='${state}']`);
     });
 });

--- a/src/components/DeploymentStatus/deploymentstatus.module.css
+++ b/src/components/DeploymentStatus/deploymentstatus.module.css
@@ -18,8 +18,23 @@
     background-color: var(--status-initializing);
 }
 
-.queue {
+/*
+ * SDD-L07: this class was `.queue` while the component looks it up as
+ * `styles[status.toLowerCase()]` — and the state is `QUEUED`. So the lookup returned undefined and
+ * a queued deployment had never once shown its colour. The glyph rule below already used the right
+ * name (`data-status='queued'`), which is what made the mismatch visible.
+ */
+.queued {
     background-color: var(--status-queue);
+}
+
+/* The two states the six-value union omitted. Vercel documents eight. */
+.blocked {
+    background-color: var(--status-blocked);
+}
+
+.deleted {
+    background-color: var(--status-deleted);
 }
 
 .ready {
@@ -31,7 +46,7 @@
 }
 
 /**
- * SDD-L06. A second channel besides hue, so the six states are distinguishable without colour
+ * SDD-L06. A second channel besides hue, so the states are distinguishable without colour
  * perception (WCAG 1.4.1). The dot keeps its colour; the glyph is what actually differentiates it.
  */
 .status {
@@ -58,4 +73,10 @@
 }
 .status[data-status='canceled']::after {
     content: '×';
+}
+.status[data-status='blocked']::after {
+    content: '⊘';
+}
+.status[data-status='deleted']::after {
+    content: '−';
 }

--- a/src/components/DeploymentStatus/index.tsx
+++ b/src/components/DeploymentStatus/index.tsx
@@ -4,31 +4,30 @@ import styles from './deploymentstatus.module.css';
 import Tooltip from '@/components/Tooltip';
 import { useIntl } from 'react-intl';
 import RenderManager from '@/components/RenderManager';
+import createFetcher from '@/helpers/createFetcher';
+import { deploymentSchema } from '../../types/schemas';
 import type { DeploymentData } from '../../types/api';
 
 const url = `${process.env.NEXT_PUBLIC_DOMAIN}/api/deployments`;
 
-const fetchDeployment = async (url: string): Promise<DeploymentData> => {
-    const response = await fetch(url);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch deployment data: ${response.statusText}`);
-    }
-    const data = await response.json();
-    return data as DeploymentData;
-};
+const fetchDeployment = createFetcher(deploymentSchema, '/api/deployments');
 
 /**
  *
- * @returns { {data: DeploymentData | undefined, isLoading: boolean, isError: boolean} } - The deployment status
+ * @returns { {data: DeploymentData | undefined, isLoading: boolean, error: Error | undefined} }
  * @description - Fetches the deployment status
- * @example - const { data, isLoading, isError } = useDeploymentStatus();
+ * @example - const { data, isLoading, error } = useDeploymentStatus();
  */
-const useDeploymentStatus = () => {
-    const { data, error } = useSWR<DeploymentData>(url, fetchDeployment);
+const useDeploymentStatus = (): {
+    data: DeploymentData | undefined;
+    isLoading: boolean;
+    error: Error | undefined;
+} => {
+    const { data, error } = useSWR<DeploymentData, Error>(url, fetchDeployment);
     return {
         data,
         isLoading: !error && !data,
-        isError: error,
+        error,
     };
 };
 
@@ -39,7 +38,7 @@ const useDeploymentStatus = () => {
  * @example - <DeploymentStatus />
  */
 const DeploymentStatus = () => {
-    const { data, isLoading, isError } = useDeploymentStatus();
+    const { data, isLoading, error } = useDeploymentStatus();
     const { formatMessage: f } = useIntl();
 
     const status = data?.status;
@@ -48,7 +47,7 @@ const DeploymentStatus = () => {
     const createdAt = data?.createdAt;
 
     return (
-        <RenderManager error={isError} loading={isLoading}>
+        <RenderManager error={error} loading={isLoading}>
             <Tooltip>
                 <Tooltip.Trigger>
                     {/*

--- a/src/components/Dock/index.tsx
+++ b/src/components/Dock/index.tsx
@@ -23,7 +23,9 @@ const Dock = () => {
             <nav className={styles.dock} data-testid="dock" aria-label={f({ id: 'nav.applications' })}>
                 <ul>
                     {menu.map(({ link, img, alt, testId }, index) => {
-                        const path = pathname.split('/')[1];
+                        // `?? ''` for the root path: `'/'.split('/')[1]` is `''` but the compiler
+                        // cannot know the string starts with a slash.
+                        const path = pathname.split('/')[1] ?? '';
                         const term =
                             typeof link === 'object'
                                 ? link[locale as keyof typeof link]?.split('/')[1]

--- a/src/components/Heating/index.tsx
+++ b/src/components/Heating/index.tsx
@@ -24,7 +24,12 @@ const Heating = () => {
                         errorTitle={f({ id: 'heating.error' })}
                         loadingTitle={f({ id: 'heating.loading' })}
                     >
-                        <div>{data.outsideTemp ?? 0}</div>|<div>{data.zoneMeasuredTemp ?? 0}</div>
+                        {/*
+                         * SDD-L07: both `?? 0` defaults are dead. `data` is non-optional, both
+                         * fields are non-optional numbers, and `useHeating` already substitutes
+                         * `initialValues` when there is nothing — three guards for one case.
+                         */}
+                        <div>{data.outsideTemp}</div>|<div>{data.zoneMeasuredTemp}</div>
                     </RenderManager>
                 </div>
             </Tooltip.Trigger>

--- a/src/components/RenderManager/__test__/renderManager.test.tsx
+++ b/src/components/RenderManager/__test__/renderManager.test.tsx
@@ -1,10 +1,11 @@
 import RenderManager from '..';
-import { render, screen } from '@/test';
+import { ResponseShapeError, ResponseStatusError } from '@/helpers/createFetcher';
+import { fireEvent, render, screen } from '@/test';
 
 describe('RenderManager', () => {
     it('should render', () => {
         render(
-            <RenderManager error={false} loading={false}>
+            <RenderManager error={undefined} loading={false}>
                 <div data-testid="render-manager" />
             </RenderManager>
         );
@@ -13,7 +14,7 @@ describe('RenderManager', () => {
 
     it('should render loading', () => {
         render(
-            <RenderManager error={false} loading>
+            <RenderManager error={undefined} loading>
                 <div data-testid="render-manager" />
             </RenderManager>
         );
@@ -22,10 +23,63 @@ describe('RenderManager', () => {
 
     it('should render error', () => {
         render(
-            <RenderManager error loading={false}>
+            <RenderManager error={new Error('boom')} loading={false}>
                 <div data-testid="render-manager" />
             </RenderManager>
         );
         expect(screen.getByTestId('error')).toBeInTheDocument();
+    });
+
+    /**
+     * SDD-L07, and criterion 5 of the spec: two different errors must produce two different
+     * messages. `error` was typed `boolean` — it never was one, since every caller passes SWR's
+     * error object — so all three failure kinds collapsed into one icon with one sentence.
+     *
+     * The intl mock returns message ids, so these assertions read as ids rather than prose.
+     */
+    it('should tell a bad status apart from a response that does not match its contract', () => {
+        const { rerender } = render(
+            <RenderManager error={new ResponseStatusError('/api/xrp', 502, 'Bad Gateway')} loading={false}>
+                <div />
+            </RenderManager>
+        );
+        // The tooltip only mounts its content once open, so focus the trigger the way a keyboard
+        // user would.
+        fireEvent.focus(screen.getByTestId('error'));
+        expect(screen.getByText('rendermanager.error.status')).toBeInTheDocument();
+
+        rerender(
+            <RenderManager error={new ResponseShapeError('/api/xrp', 'price expected number')} loading={false}>
+                <div />
+            </RenderManager>
+        );
+        fireEvent.focus(screen.getByTestId('error'));
+        expect(screen.getByText('rendermanager.error.shape')).toBeInTheDocument();
+    });
+
+    it('should fall back to the generic message for any other failure', () => {
+        render(
+            <RenderManager error={new TypeError('Failed to fetch')} loading={false}>
+                <div />
+            </RenderManager>
+        );
+        fireEvent.focus(screen.getByTestId('error'));
+        expect(screen.getByText('rendermanager.error')).toBeInTheDocument();
+    });
+
+    // A widget that supplies its own wording still wins — the distinction only fills in where there
+    // was none.
+    it('should prefer an explicit errorTitle over the kind-specific message', () => {
+        render(
+            <RenderManager
+                error={new ResponseShapeError('/api/heating', 'outsideTemp expected number')}
+                loading={false}
+                errorTitle="Heating unavailable"
+            >
+                <div />
+            </RenderManager>
+        );
+        fireEvent.focus(screen.getByTestId('error'));
+        expect(screen.getByText('Heating unavailable')).toBeInTheDocument();
     });
 });

--- a/src/components/RenderManager/index.tsx
+++ b/src/components/RenderManager/index.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import Loading from './Loading';
-import Error from './Error';
+// Renamed from `Error`: SDD-L07 gives this component a real `Error` prop, and the default import was
+// shadowing the global `Error` type in this module — `error: Error` would have annotated the prop
+// with the icon component's type instead.
+import ErrorIcon from './Error';
 import Tooltip from '@/components/Tooltip';
 import { useIntl } from 'react-intl';
+import { ResponseShapeError, ResponseStatusError } from '@/helpers/createFetcher';
 
 type Props = {
-    error: boolean;
+    error: Error | undefined;
     loading: boolean;
     errorTitle?: string;
     loadingTitle?: string;
@@ -13,9 +17,31 @@ type Props = {
 };
 
 /**
+ * @description - Decide which of the failure message ids fits this error.
+ *
+ * Kept outside the component so the mapping can be read on its own: a route that answered a status
+ * we do not accept is a different event from a route that answered a body we do not recognise, and
+ * a reader can act on the difference.
+ */
+const errorMessageId = (error: Error): string => {
+    if (error instanceof ResponseShapeError) return 'rendermanager.error.shape';
+    if (error instanceof ResponseStatusError) return 'rendermanager.error.status';
+    return 'rendermanager.error';
+};
+
+/**
  * @description - Renders children or error/loading icon
  *
- * @param {error} boolean - error state
+ * SDD-L07: `error` was typed `boolean`. It never was one — every caller passes SWR's `error`, an
+ * `Error` object, and it typechecked only because `useSWR<Data>` leaves the error generic at `any`.
+ * The declaration therefore discarded the only information the widget had about *what* went wrong,
+ * which is why all ten of them showed the same icon and the same sentence whether the route was
+ * down, the network was gone, or the response no longer matched its contract.
+ *
+ * `errorTitle` still wins when a caller supplies one, so widget-specific wording ("heating
+ * unavailable") is unchanged; the distinction only fills in where there was no wording at all.
+ *
+ * @param {error} Error | undefined - the failure, if there was one
  * @param {loading} boolean - loading state
  * @param {errorTitle} string - Title for error icon
  * @param {loadingTitle} string - Title for loading icon
@@ -29,9 +55,9 @@ const RenderManager = ({ error, loading, errorTitle, loadingTitle, children }: P
         return (
             <Tooltip>
                 <Tooltip.Trigger>
-                    <Error />
+                    <ErrorIcon />
                 </Tooltip.Trigger>
-                <Tooltip.Content>{errorTitle ?? f({ id: 'rendermanager.error' })}</Tooltip.Content>
+                <Tooltip.Content>{errorTitle ?? f({ id: errorMessageId(error) })}</Tooltip.Content>
             </Tooltip>
         );
     }

--- a/src/components/Weather/index.tsx
+++ b/src/components/Weather/index.tsx
@@ -41,9 +41,20 @@ const Weather = ({ cities, open, handleClose }: { cities: string[]; open?: boole
                     <div className={styles.city} key={`${city?.city}-${city?.name}-${index}`}>
                         <div className={styles.weather}>
                             <div className={styles.cityName}>{city?.city?.replace(/\+/g, ' ')}</div>
-                            <div className={styles.cityGrade}>{`${city?.grades} ºC | ºF`}</div>
+                            {/*
+                              * SDD-L07: `grades` and `name` are nullable — `/api/weather` answers an
+                              * explicit `null` in every reading for a city that geocodes but has no
+                              * current forecast. The hook's local type claimed they were always
+                              * strings, so this line rendered the literal text "null ºC | ºF" on
+                              * screen for that case, and `alt={city.name}` passed `null` to next/image.
+                              * Making the schema honest is what surfaced both.
+                              */}
+                            <div className={styles.cityGrade}>{`${city?.grades ?? '—'} ºC | ºF`}</div>
                             {city?.imageUrl && (
-                                <Img src={city?.imageUrl} width={70} height={70} alt={city?.name} unoptimized />
+                                // An unnamed condition has no icon either — both come from the same
+                                // weather code — so this alt is empty only in a branch that cannot
+                                // render, and the temperature beside it carries the same information.
+                                <Img src={city?.imageUrl} width={70} height={70} alt={city?.name ?? ''} unoptimized />
                             )}
                             <div className={styles.info}>
                                 <div className={styles.cityPrecipitation}>

--- a/src/helpers/__test__/createFetcher.test.tsx
+++ b/src/helpers/__test__/createFetcher.test.tsx
@@ -1,0 +1,111 @@
+import createFetcher, { ResponseShapeError, ResponseStatusError } from '../createFetcher';
+import {
+    analyticsSchema,
+    counterSchema,
+    deploymentSchema,
+    githubStarsSchema,
+    heatingSchema,
+    newsSchema,
+    weatherSchema,
+    xrpSchema,
+} from '../../types/schemas';
+
+/**
+ * SDD-L07. The point of the phase in one file.
+ *
+ * Every one of these boundaries used to end in `return data as X`, which emits no code — so a
+ * response that had drifted was accepted silently and surfaced somewhere else entirely, as a
+ * mis-rendered counter or a `TypeError` deep in a component. Each case below feeds a boundary the
+ * wrong shape and asserts it is rejected *here*, with the offending field named.
+ */
+const respondWith = (body: unknown, ok = true, status = 200) => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok,
+        status,
+        statusText: ok ? 'OK' : 'Bad Gateway',
+        json: () => Promise.resolve(body),
+    });
+};
+
+describe('createFetcher', () => {
+    beforeEach(() => {
+        (global.fetch as jest.Mock).mockReset();
+    });
+
+    it('should resolve the parsed value when the response matches', async () => {
+        respondWith({ pageViews: 120, newUsers: 45 });
+
+        await expect(createFetcher(analyticsSchema, '/api/analytics')('url')).resolves.toEqual({
+            pageViews: 120,
+            newUsers: 45,
+        });
+    });
+
+    it('should strip fields the contract does not declare', async () => {
+        respondWith({ num: 61, debugTrace: 'internal' });
+
+        await expect(createFetcher(counterSchema, '/api/indexed-pages')('url')).resolves.toEqual({ num: 61 });
+    });
+
+    it('should throw a ResponseStatusError for a non-2xx, without reading the body', async () => {
+        respondWith({ error: 'nope' }, false, 502);
+
+        const error = await createFetcher(xrpSchema, '/api/xrp')('url').catch((err) => err);
+
+        expect(error).toBeInstanceOf(ResponseStatusError);
+        expect(error.status).toBe(502);
+    });
+
+    it('should name the field that broke the contract', async () => {
+        // The real defect: GA4 emits metric values as strings.
+        respondWith({ pageViews: '12345', newUsers: 45 });
+
+        const error = await createFetcher(analyticsSchema, '/api/analytics')('url').catch((err) => err);
+
+        expect(error).toBeInstanceOf(ResponseShapeError);
+        expect(error.message).toContain('/api/analytics');
+        expect(error.message).toContain('pageViews');
+        expect(error.message).toContain('expected number');
+    });
+
+    /**
+     * Criterion 2 of the spec: one case per boundary, each fed the shape it would actually receive
+     * if its upstream drifted, so none of them can quietly go back to trusting the response.
+     */
+    describe.each([
+        ['/api/analytics', analyticsSchema, { pageViews: '1', newUsers: 2 }],
+        ['/api/heating', heatingSchema, { outsideTemp: '12.5', zoneMeasuredTemp: 21 }],
+        ['/api/indexed-pages', counterSchema, { num: null }],
+        ['/api/news', newsSchema, { news: [{ link: 'x', title: 'y', published: 3, description: 'z' }] }],
+        ['/api/xrp', xrpSchema, { price: '0.51', todaySummary: 'Up', todayPorcentage: '+1%' }],
+        ['/api/weather', weatherSchema, [{ city: 'moraña' }]],
+        ['/api/github-stars', githubStarsSchema, '42'],
+        ['/api/deployments', deploymentSchema, { status: 'HIBERNATING' }],
+    ])('%s', (label, schema, malformed) => {
+        it('should reject a response that no longer matches its contract', async () => {
+            respondWith(malformed);
+
+            const error = await createFetcher(schema, label)('url').catch((err) => err);
+
+            expect(error).toBeInstanceOf(ResponseShapeError);
+            expect(error.message).toContain(label);
+        });
+    });
+
+    // A city that geocodes but has no current forecast: the route answers explicit nulls, and the
+    // hook's own type used to claim these were always strings.
+    it('should accept the nulls /api/weather deliberately sends', async () => {
+        respondWith([
+            {
+                city: 'moraña',
+                name: null,
+                precipitation: null,
+                humidity: null,
+                windSpeed: null,
+                grades: null,
+            },
+        ]);
+
+        await expect(createFetcher(weatherSchema, '/api/weather')('url')).resolves.toHaveLength(1);
+    });
+});

--- a/src/helpers/__test__/fileReader.test.ts
+++ b/src/helpers/__test__/fileReader.test.ts
@@ -1,4 +1,6 @@
 import { getAllCategories, getLatestPostPath, getPostBySlug, getPostsByLocale } from '../fileReader';
+import { describeIssues } from '../../types/schemas';
+import { postFrontmatterSchema } from '../../types/upstream';
 
 // The post date comes from the `<Date date="MM-DD-YYYY" />` tag in the MDX body and feeds
 // datePublished in the Article JSON-LD. The old implementation parsed the tag with
@@ -99,5 +101,32 @@ describe('getAllCategories', () => {
         const colliding = tags.filter(({ tag }) => categoryNames.has(tag.toLowerCase()));
 
         expect(colliding).toEqual([]);
+    });
+});
+
+/**
+ * SDD-L07. `buildPost` typed gray-matter's output as `Record<string, any>` and `getAllPosts`
+ * annotated its map callback as `PathPost` — a cast the compiler accepted only because the source
+ * was `any`. All 45 posts carry every required field today, which is exactly why this is worth
+ * pinning: it is the one place the `as` pattern can break a **deploy**, since `getStaticPaths` runs
+ * over the whole corpus during `next build` and a post missing `category` throws with no filename
+ * anywhere in the message.
+ */
+describe('frontmatter validation', () => {
+    it.each(['en', 'es', 'gl'])('Should accept every published post in %s', (locale) => {
+        const posts = getPostsByLocale(locale);
+
+        expect(posts.length).toBeGreaterThan(0);
+        for (const post of posts) {
+            expect(typeof post.meta.title).toBe('string');
+            expect(typeof post.meta.category).toBe('string');
+        }
+    });
+
+    it('Should name the file and the field when a post is missing one', () => {
+        const parsed = postFrontmatterSchema.safeParse({ title: 'A post with no category' });
+
+        expect(parsed.success).toBe(false);
+        expect(describeIssues(parsed.error!.issues)).toContain('category');
     });
 });

--- a/src/helpers/__test__/helpers.test.tsx
+++ b/src/helpers/__test__/helpers.test.tsx
@@ -59,18 +59,7 @@ describe('other helper utilities', () => {
         expect(getLang('en')).toBe('');
     });
 
-    it('fetcher should resolve json or throw', async () => {
-        const { fetcher } = require('..');
-        (global.fetch as jest.Mock).mockResolvedValueOnce({
-            ok: true,
-            json: () => Promise.resolve({ a: 1 }),
-        });
-        await expect(fetcher('url')).resolves.toEqual({ a: 1 });
-
-        (global.fetch as jest.Mock).mockResolvedValueOnce({
-            ok: false,
-            statusText: 'Bad',
-        });
-        await expect(fetcher('url')).rejects.toThrow('Bad');
-    });
+    // SDD-L07 removed the generic `fetcher` from this barrel. It resolved `unknown`, so both of its
+    // callers cast at the call site, and it competed with six hand-rolled copies in the hooks. Its
+    // replacement is `helpers/createFetcher.ts`, covered by createFetcher.test.tsx.
 });

--- a/src/helpers/createFetcher.ts
+++ b/src/helpers/createFetcher.ts
@@ -1,0 +1,70 @@
+import type * as z from 'zod/mini';
+import { describeIssues } from '../types/schemas';
+
+/**
+ * SDD-L07. One SWR fetcher, built from a schema.
+ *
+ * Before this the codebase had two conventions for the same job: six near-identical hand-rolled
+ * `fetchX` functions (each one an `await fetch`, an `if (!res.ok) throw`, and a `return data as X`),
+ * and a generic `fetcher` in `helpers/index.ts` returning `unknown`, used by `useWeather` and
+ * `useGithubStars`. The duplicated convention was the majority, and every copy of it ended in a cast
+ * the compiler believed and the runtime never checked.
+ *
+ * The cast is the part worth removing. `as` emits no code: when `/api/analytics` answered
+ * `{"pageViews":"12345"}` — which it did, because GA4 returns strings — the value travelled on as a
+ * `number` and surfaced four components later as an unseparated counter. `safeParse` turns that into
+ * a thrown error at the boundary, naming the field.
+ */
+
+/**
+ * Thrown when a response parses as JSON but does not match the contract.
+ *
+ * A distinct type so callers can tell "the route failed" from "the route answered something we do
+ * not understand". Those deserve different words in front of a reader, and until now every widget
+ * showed the same undifferentiated error icon for both.
+ */
+export class ResponseShapeError extends Error {
+    readonly label: string;
+
+    constructor(label: string, detail: string) {
+        super(`${label}: unexpected response shape — ${detail}`);
+        this.name = 'ResponseShapeError';
+        this.label = label;
+    }
+}
+
+/** Thrown when the route itself failed, i.e. answered a non-2xx status. */
+export class ResponseStatusError extends Error {
+    readonly status: number;
+
+    constructor(label: string, status: number, statusText: string) {
+        const reason = statusText ? `${status} ${statusText}` : String(status);
+        super(`${label}: request failed with ${reason}`);
+        this.name = 'ResponseStatusError';
+        this.status = status;
+    }
+}
+
+/**
+ * @description Build an SWR fetcher that validates the response against `schema`.
+ * @param schema - The zod schema that *is* the contract for this route; the return type follows it.
+ * @param label - Route name, carried into the thrown message so a log says which boundary broke.
+ * @returns A fetcher usable directly as SWR's second argument.
+ * @example const fetchXRP = createFetcher(xrpSchema, '/api/xrp');
+ */
+const createFetcher =
+    <Schema extends z.ZodMiniType>(schema: Schema, label: string) =>
+    async (url: string): Promise<z.infer<Schema>> => {
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new ResponseStatusError(label, response.status, response.statusText);
+        }
+
+        const result = schema.safeParse(await response.json());
+        if (!result.success) {
+            throw new ResponseShapeError(label, describeIssues(result.error.issues));
+        }
+        return result.data;
+    };
+
+export default createFetcher;

--- a/src/helpers/fileReader.ts
+++ b/src/helpers/fileReader.ts
@@ -3,6 +3,8 @@ import fs from 'fs';
 import matter from 'gray-matter';
 import { defaultLocale } from '@/constants/site';
 import { isSafeSlug } from './slug';
+import { describeIssues } from '../types/schemas';
+import { postFrontmatterSchema } from '../types/upstream';
 
 // Path to posts directory
 const POST_PATH = path.join(process.cwd(), 'data/blog');
@@ -42,6 +44,23 @@ type ParsedPost = {
  */
 const buildPost = (filePath: string): ParsedPost => {
     const { data, content } = matter(fs.readFileSync(filePath, 'utf8'));
+
+    /*
+     * SDD-L07. `data` is `Record<string, any>` — gray-matter cannot know the shape — and every
+     * consumer downstream simply trusted it: `getAllPosts` annotates its map callback as `PathPost`,
+     * a cast the compiler accepts only because the source is `any`.
+     *
+     * All 45 posts currently carry every required field, so nothing is broken today. It is checked
+     * anyway because this is the one place the `as` pattern can break a **deploy** rather than a
+     * widget: `getStaticPaths` runs over the whole corpus during `next build`, and one post
+     * published without a `category` throws deep inside the route with no filename anywhere in the
+     * message. Failing here instead names the file and the field.
+     */
+    const parsed = postFrontmatterSchema.safeParse(data);
+    if (!parsed.success) {
+        throw new Error(`Invalid frontmatter in ${path.basename(filePath)}: ${describeIssues(parsed.error.issues)}`);
+    }
+
     return { content, data, fileName: filePath.split('/').pop() ?? '' };
 };
 
@@ -133,7 +152,7 @@ const extractPostDate = (content: string): string | null => {
     // date strings as LOCAL midnight, so round-tripping through `new Date(...)` +
     // `toISOString()` shifted every post one day early in timezones ahead of UTC
     // (e.g. Europe/Madrid: "07-18-2026" → "2026-07-17").
-    const componentsMatch = match[1].match(/^(\d{2})-(\d{2})-(\d{4})$/);
+    const componentsMatch = match[1]?.match(/^(\d{2})-(\d{2})-(\d{4})$/);
     if (!componentsMatch) return null;
     const [, month, day, year] = componentsMatch;
     // Date.UTC normalizes overflow ("13-40-2023" would roll over), so a round-trip
@@ -351,16 +370,25 @@ const getAllTags = (locale: string) => {
     // The SEO content pass (PR #131) introduced several of these. Frontmatter is cleaned, and
     // this guard keeps the taxonomies disjoint if a colliding tag is ever added back.
     const categoryNames = new Set(posts.map((post) => post.meta.category.toLowerCase()));
-    return [...new Set(tags.flat())]
-        .filter((tag) => !categoryNames.has(tag.toLowerCase()))
-        .map((tag) => {
-            const postsBytag = getPostsByTag(tag, locale);
-            return {
-                tag,
-                total: tags.flat().filter((t) => t === tag).length,
-                href: `/blog/${tag.toLowerCase()}/${postsBytag[0].meta.slug}`,
-            };
-        });
+    return (
+        [...new Set(tags.flat())]
+            .filter((tag) => !categoryNames.has(tag.toLowerCase()))
+            // SDD-L07: `postsBytag[0].meta.slug` was unguarded. The list cannot be empty today — the
+            // tags come from these same posts — but the sidebar entry exists only to link at a post,
+            // so if that ever stops holding, dropping the entry is right and a crash in
+            // `getStaticProps` is not.
+            .flatMap((tag) => {
+                const [firstPost] = getPostsByTag(tag, locale);
+                if (!firstPost) return [];
+                return [
+                    {
+                        tag,
+                        total: tags.flat().filter((t) => t === tag).length,
+                        href: `/blog/${tag.toLowerCase()}/${firstPost.meta.slug}`,
+                    },
+                ];
+            })
+    );
 };
 
 /**
@@ -379,13 +407,17 @@ export const getAllCategories = (locale: string) => {
     const categories = posts.map((post) => post.meta.category);
     const tags = getAllTags(locale);
     return {
-        categories: [...new Set(categories)].map((category) => {
-            const postsByCategory = getPostsByCategory(category, locale);
-            return {
-                category,
-                total: categories.filter((c) => c === category).length,
-                href: `/blog/${category.toLowerCase()}/${postsByCategory[0].meta.slug}`,
-            };
+        // Same guard as getAllTags: the link needs a post to point at.
+        categories: [...new Set(categories)].flatMap((category) => {
+            const [firstPost] = getPostsByCategory(category, locale);
+            if (!firstPost) return [];
+            return [
+                {
+                    category,
+                    total: categories.filter((c) => c === category).length,
+                    href: `/blog/${category.toLowerCase()}/${firstPost.meta.slug}`,
+                },
+            ];
         }),
         tags,
     };

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -110,17 +110,12 @@ export const setInverval = (ref: React.RefObject<HTMLDivElement | null>) => {
     return interval;
 };
 
-/**
- * @description Utility function to use SWR with fetcher.
- * @example const { data, error } = useSWR('/api/weather', fetcher);
- * @param {string} url
- * @returns {Promise<unknown>}
- * @see https://swr.vercel.app/docs/data-fetching
+/*
+ * SDD-L07: the generic `fetcher` used to live here. It returned `Promise<unknown>`, so both of its
+ * callers cast the result at the call site, and it competed with six hand-rolled copies of the same
+ * function in the hooks. All eight are now `helpers/createFetcher.ts`, which takes the route's schema
+ * and returns a value that has actually been checked against it.
+ *
+ * It is gone rather than deprecated on purpose: leaving an unvalidated fetcher exported from the
+ * barrel is how the next hook would quietly get written the old way.
  */
-export const fetcher = (url: string): Promise<unknown> =>
-    fetch(url).then((res) => {
-        if (res.ok) {
-            return res.json();
-        }
-        throw new Error(res.statusText);
-    });

--- a/src/hooks/__test__/useGithubStars.test.tsx
+++ b/src/hooks/__test__/useGithubStars.test.tsx
@@ -12,9 +12,15 @@ const TestComponent = () => {
 describe('useGithubStars hook', () => {
     it('returns stars count', () => {
         (useSWR as jest.Mock).mockReturnValue({ data: 42, error: false, isLoading: false });
-        const expectedUrl = new URL('https://xabierlameiro.com/api/github-stars');
         render(<TestComponent />);
-        expect(useSWR).toHaveBeenCalledWith(expectedUrl, expect.any(Function), expect.any(Object));
+        // SDD-L07: the key is a string now, like every sibling hook. It was a `URL` built at module
+        // scope, which threw `Invalid URL` during import whenever NEXT_PUBLIC_DOMAIN was unset —
+        // failing the whole build rather than the one widget.
+        expect(useSWR).toHaveBeenCalledWith(
+            `${process.env.NEXT_PUBLIC_DOMAIN}/api/github-stars`,
+            expect.any(Function),
+            expect.any(Object)
+        );
         expect(screen.getByTestId('stars').textContent).toBe('42');
     });
 });

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -1,6 +1,8 @@
 import React from 'react';
 import useSWR from 'swr';
 import { useRouter } from 'next/router';
+import createFetcher from '@/helpers/createFetcher';
+import { analyticsSchema } from '../types/schemas';
 import type { AnalyticsData } from '../types/api';
 
 const initialValues: AnalyticsData = {
@@ -8,20 +10,20 @@ const initialValues: AnalyticsData = {
     newUsers: 0,
 };
 
+/**
+ * SDD-L07: `error` was declared `boolean` here and in every sibling hook. SWR types its response as
+ * `SWRResponse<Data, Error>` with `Error` defaulting to `any` when only the first generic is given,
+ * and `any` assigns to `boolean` without complaint. So the declaration said boolean, an `Error`
+ * object flowed, and every widget could show only one undifferentiated error icon — a boolean cannot
+ * express anything else.
+ */
 type ReturnType = {
     data: AnalyticsData;
-    error: boolean;
+    error: Error | undefined;
     loading: boolean;
 };
 
-const fetchAnalytics = async (url: string): Promise<AnalyticsData> => {
-    const response = await fetch(url);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch analytics data: ${response.statusText}`);
-    }
-    const data = await response.json();
-    return data as AnalyticsData;
-};
+const fetchAnalytics = createFetcher(analyticsSchema, '/api/analytics');
 
 const useAnalytics = (all?: boolean): ReturnType => {
     const { asPath, locale } = useRouter();
@@ -33,7 +35,7 @@ const useAnalytics = (all?: boolean): ReturnType => {
         return url.toString();
     }, [all, slug]);
 
-    const { data, error, isLoading } = useSWR<AnalyticsData>(memoUrl, fetchAnalytics, {
+    const { data, error, isLoading } = useSWR<AnalyticsData, Error>(memoUrl, fetchAnalytics, {
         keepPreviousData: all ? true : false,
         fallback: initialValues,
         fallbackData: initialValues,

--- a/src/hooks/useGithubStars.ts
+++ b/src/hooks/useGithubStars.ts
@@ -1,10 +1,24 @@
 import useSWR from 'swr';
-import { fetcher } from '@/helpers';
+import createFetcher from '@/helpers/createFetcher';
+import { githubStarsSchema } from '../types/schemas';
 
-const url = new URL(`${process.env.NEXT_PUBLIC_DOMAIN}/api/github-stars`);
+/**
+ * SDD-L07: this was `new URL(...)` at module scope, the only hook of seven that built its key that
+ * way. Two consequences. The URL object became the SWR key, so the fetcher received an object where
+ * every sibling passes a string; and with `NEXT_PUBLIC_DOMAIN` unset the constructor threw
+ * `Invalid URL` while the module was still being imported — which fails `next build` outright rather
+ * than failing the one widget. A template string like the other six does neither.
+ */
+const url = `${process.env.NEXT_PUBLIC_DOMAIN}/api/github-stars`;
 
-const useGithubStars = () => {
-    const { data, error, isLoading } = useSWR(url, fetcher, {
+const fetchGithubStars = createFetcher(githubStarsSchema, '/api/github-stars');
+
+const useGithubStars = (): {
+    data: number | undefined;
+    error: Error | undefined;
+    loading: boolean;
+} => {
+    const { data, error, isLoading } = useSWR<number, Error>(url, fetchGithubStars, {
         fallbackData: 0,
         dedupingInterval: 5000,
     });

--- a/src/hooks/useHeating.ts
+++ b/src/hooks/useHeating.ts
@@ -1,4 +1,6 @@
 import useSWR from 'swr';
+import createFetcher from '@/helpers/createFetcher';
+import { heatingSchema } from '../types/schemas';
 import type { HeatingData } from '../types/api';
 
 const url = `${process.env.NEXT_PUBLIC_DOMAIN}/api/heating`;
@@ -8,21 +10,14 @@ const initialValues: HeatingData = {
     zoneMeasuredTemp: 0,
 };
 
-const fetchHeating = async (url: string): Promise<HeatingData> => {
-    const response = await fetch(url);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch heating data: ${response.statusText}`);
-    }
-    const data = await response.json();
-    return data as HeatingData;
-};
+const fetchHeating = createFetcher(heatingSchema, '/api/heating');
 
 const useHeating = (): {
     data: HeatingData;
-    error: boolean;
+    error: Error | undefined;
     loading: boolean;
 } => {
-    const { data, error, isLoading } = useSWR<HeatingData>(url, fetchHeating, {
+    const { data, error, isLoading } = useSWR<HeatingData, Error>(url, fetchHeating, {
         keepPreviousData: true,
         fallback: initialValues,
         fallbackData: initialValues,

--- a/src/hooks/useIndexedPages.ts
+++ b/src/hooks/useIndexedPages.ts
@@ -1,19 +1,18 @@
 import useSWR from 'swr';
+import createFetcher from '@/helpers/createFetcher';
+import { counterSchema } from '../types/schemas';
 import type { CounterData } from '../types/api';
 
 const url = `${process.env.NEXT_PUBLIC_DOMAIN}/api/indexed-pages`;
 
-const fetchCounter = async (url: string): Promise<CounterData> => {
-    const response = await fetch(url);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch counter data: ${response.statusText}`);
-    }
-    const data = await response.json();
-    return data as CounterData;
-};
+const fetchCounter = createFetcher(counterSchema, '/api/indexed-pages');
 
-const useIndexedPages = () => {
-    const { data, error, isLoading } = useSWR<CounterData>(url, fetchCounter, {
+const useIndexedPages = (): {
+    data: CounterData | undefined;
+    error: Error | undefined;
+    loading: boolean;
+} => {
+    const { data, error, isLoading } = useSWR<CounterData, Error>(url, fetchCounter, {
         dedupingInterval: 5000,
         fallbackData: {
             num: 0,

--- a/src/hooks/useNews.ts
+++ b/src/hooks/useNews.ts
@@ -1,24 +1,25 @@
 import useSWR from 'swr';
 import React from 'react';
+import createFetcher from '@/helpers/createFetcher';
+import { newsSchema } from '../types/schemas';
 import type { NewsData } from '../types/api';
 
-const fetchNews = async (url: string): Promise<NewsData> => {
-    const response = await fetch(url);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch news data: ${response.statusText}`);
-    }
-    const data = await response.json();
-    return data as NewsData;
-};
+const fetchNews = createFetcher(newsSchema, '/api/news');
 
-const useNews = (city: string) => {
+const useNews = (
+    city: string
+): {
+    data: NewsData | undefined;
+    error: Error | undefined;
+    loading: boolean;
+} => {
     const memoUrl = React.useMemo(() => {
         const url = new URL(`${process.env.NEXT_PUBLIC_DOMAIN}/api/news`);
         url.searchParams.set('city', city);
         return url.toString();
     }, [city]);
 
-    const { data, error, isLoading } = useSWR<NewsData>(memoUrl, fetchNews, {
+    const { data, error, isLoading } = useSWR<NewsData, Error>(memoUrl, fetchNews, {
         keepPreviousData: true,
         dedupingInterval: 5000,
         fallbackData: {

--- a/src/hooks/useSurvey.ts
+++ b/src/hooks/useSurvey.ts
@@ -62,7 +62,10 @@ const reducer = (state: SurveyState, action: SurveyAction): SurveyState => {
 
 const useSurvey = () => {
     const { query } = useRouter();
-    const rawName = Array.isArray(query.name) ? query.name[0] : query.name ?? DEFAULT_SURVEY_NAME;
+    // SDD-L07: the default only covered the non-array branch. `?name=` repeated in the query string
+    // gives Next an array, and an empty one gives `undefined` — which then reached
+    // `sanitizeSurveyName` as a string it was not typed to receive.
+    const rawName = (Array.isArray(query.name) ? query.name[0] : query.name) ?? DEFAULT_SURVEY_NAME;
     const name = sanitizeSurveyName(rawName);
 
     const [state, dispatch] = useReducer(reducer, initialState);

--- a/src/hooks/useWeather.ts
+++ b/src/hooks/useWeather.ts
@@ -1,17 +1,16 @@
 import useSWR from 'swr';
 import React from 'react';
-import { fetcher } from '@/helpers';
+import createFetcher from '@/helpers/createFetcher';
+import { weatherSchema } from '../types/schemas';
+import type { WeatherData } from '../types/schemas';
 
-interface WeatherData {
-    city: string;
-    name: string;
-    precipitation: string;
-    humidity: string;
-    windSpeed: string;
-    grades: string;
-    imageUrl?: string;
-}
-
+/**
+ * SDD-L07: the local `WeatherData` declared here was the third copy of this shape, and the only one
+ * that claimed `name`, `precipitation`, `humidity`, `windSpeed` and `grades` are always strings.
+ * `/api/weather` answers with an explicit `null` in each of them for a city that geocodes but has no
+ * current forecast, so the declaration was wrong for a case the route deliberately produces. The
+ * shape now comes from the schema the response is checked against.
+ */
 const initialValues: WeatherData[] = [
     {
         city: 'moraña',
@@ -23,14 +22,23 @@ const initialValues: WeatherData[] = [
         imageUrl: '',
     },
 ];
-const useWeather = (cities: string[]) => {
+
+const fetchWeather = createFetcher(weatherSchema, '/api/weather');
+
+const useWeather = (
+    cities: string[]
+): {
+    data: WeatherData[] | undefined;
+    error: Error | undefined;
+    loading: boolean;
+} => {
     const url = React.useMemo(() => {
         const url = new URL(`${process.env.NEXT_PUBLIC_DOMAIN}/api/weather`);
         url.searchParams.append('cities', cities.join(','));
         return url;
     }, [cities]);
 
-    const { data, error, isLoading } = useSWR(url.toString(), fetcher, {
+    const { data, error, isLoading } = useSWR<WeatherData[], Error>(url.toString(), fetchWeather, {
         dedupingInterval: 5000,
         keepPreviousData: true,
         fallback: initialValues,
@@ -38,7 +46,7 @@ const useWeather = (cities: string[]) => {
     });
 
     return {
-        data: data as WeatherData[] | undefined,
+        data,
         error,
         loading: isLoading,
     };

--- a/src/hooks/useXRP.ts
+++ b/src/hooks/useXRP.ts
@@ -1,19 +1,18 @@
 import useSWR from 'swr';
+import createFetcher from '@/helpers/createFetcher';
+import { xrpSchema } from '../types/schemas';
 import type { XRPData } from '../types/api';
 
 const url = `${process.env.NEXT_PUBLIC_DOMAIN}/api/xrp`;
 
-const fetchXRP = async (url: string): Promise<XRPData> => {
-    const response = await fetch(url);
-    if (!response.ok) {
-        throw new Error(`Failed to fetch XRP data: ${response.statusText}`);
-    }
-    const data = await response.json();
-    return data as XRPData;
-};
+const fetchXRP = createFetcher(xrpSchema, '/api/xrp');
 
-const useXRP = () => {
-    const { data, error, isLoading } = useSWR<XRPData>(url, fetchXRP, {
+const useXRP = (): {
+    data: XRPData | undefined;
+    error: Error | undefined;
+    loading: boolean;
+} => {
+    const { data, error, isLoading } = useSWR<XRPData, Error>(url, fetchXRP, {
         dedupingInterval: 5000,
         keepPreviousData: true,
         fallbackData: {

--- a/src/intl/translations.ts
+++ b/src/intl/translations.ts
@@ -96,6 +96,11 @@ export const messages = {
         'deploymentstatus.tooltip':
             'Status : {status} The user {username} has deployed to {environment} environment at {createdAt}',
         'rendermanager.error': 'An error has occurred, we are working on it',
+        // SDD-L07: three failures used to share one sentence, because the prop carrying them was a
+        // boolean. They are different events and a reader can act on the difference — a bad status
+        // is worth retrying, a response that no longer matches its contract is not.
+        'rendermanager.error.status': 'The service answered with an error. It may work if you try again shortly',
+        'rendermanager.error.shape': 'The service answered something unexpected, so this reading is not shown',
         'rendermanager.loading': 'Getting the data...',
     },
     es: {
@@ -191,6 +196,8 @@ export const messages = {
         'deploymentstatus.tooltip':
             'Estado : {status} El usuario {username} ha desplegado en el entorno de {environment} a fecha {createdAt}',
         'rendermanager.error': 'Ha ocurrido un error, estamos trabajando en ello',
+        'rendermanager.error.status': 'El servicio ha respondido con un error. Puede que funcione si lo intentas en un momento',
+        'rendermanager.error.shape': 'El servicio ha respondido algo inesperado, así que este dato no se muestra',
         'rendermanager.loading': 'Obteniendo los datos...',
     },
     gl: {
@@ -286,6 +293,8 @@ export const messages = {
         'deploymentstatus.tooltip':
             'Estado : {status} O usuario {username} ha desplegado no entorno de {environment} a data {createdAt}',
         'rendermanager.error': 'Ocurriu un erro, estamos traballando niso',
+        'rendermanager.error.status': 'O servizo respondeu cun erro. Pode que funcione se o tentas nun momento',
+        'rendermanager.error.shape': 'O servizo respondeu algo inesperado, así que este dato non se amosa',
         'rendermanager.loading': 'Obtendo os datos...',
     },
 };

--- a/src/pages/api/analytics.ts
+++ b/src/pages/api/analytics.ts
@@ -4,6 +4,7 @@ import { BetaAnalyticsDataClient } from '@google-analytics/data';
 import allowCors from '../../helpers/cors';
 import { isSafePagePath } from '../../helpers/slug';
 import { CACHE } from '@/helpers/http';
+import type { AnalyticsData } from '../../types/api';
 
 /**
  * @description This function is used to get the total number of page views for a given page. It uses the Google
@@ -17,12 +18,17 @@ import { CACHE } from '@/helpers/http';
  * }>}
  * @throws {Error: Error while parsing analytics data}
  * @see https://developers.google.com/analytics/devguides/reporting/data/v1/api-schema
+ *
+ * SDD-L07: this route declared `pageViews: string | number` and returned
+ * `row.metricValues?.[0]?.value || '0'` — a **string**, because that is what the GA4 Data API emits
+ * for every metric. `types/api.ts` declared the same field `number`, and `useAnalytics` cast the
+ * response with `as AnalyticsData`, which erases at compile time and checks nothing. So a string
+ * travelled all the way to `ViewCounter`, which rendered `12345` unseparated while `CryptoPrice`
+ * beside it went through `formatNumber`. The two counters disagreed for exactly this reason.
+ *
+ * The union is gone and the coercion happens here, at the boundary that knows GA4 sends strings,
+ * rather than being carried through the app as an ambiguity. `types/api.ts` is the single contract.
  */
-interface AnalyticsData {
-    pageViews: string | number;
-    newUsers: string | number;
-}
-
 type AnalyticsResponse = AnalyticsData | { error: string };
 
 const GA_PROPERTY = 'properties/348472560';
@@ -31,6 +37,18 @@ const GA_DATE_RANGES = [{ startDate: '2023-01-01', endDate: 'today' }];
 const GA_METRICS = [{ name: 'screenPageViews' }, { name: 'newUsers' }];
 
 const EMPTY_ANALYTICS: AnalyticsData = { pageViews: 0, newUsers: 0 };
+
+/**
+ * @description Turn a GA4 metric value into the number the contract promises.
+ *
+ * Deliberately not `z.coerce.number()`: coercion there runs `Number()`, which maps `null` and `''`
+ * to `0` and an unparseable string to `NaN` — and `NaN` serialises to JSON `null`, so a bad metric
+ * would arrive at the client as a missing field rather than a rejected one. Explicit is better here.
+ */
+const toCount = (value: string | null | undefined): number => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+};
 
 /**
  * The GA4 Data API bills every call against a per-property daily token quota, and
@@ -116,8 +134,8 @@ export default allowCors(async function handler(req: NextApiRequest, res: NextAp
 
         res.setHeader('Cache-Control', CACHE_CONTROL);
         return res.status(200).json({
-            pageViews: row.metricValues?.[0]?.value || '0',
-            newUsers: row.metricValues?.[1]?.value || '0',
+            pageViews: toCount(row.metricValues?.[0]?.value),
+            newUsers: toCount(row.metricValues?.[1]?.value),
         });
     } catch (err: unknown) {
         console.error('Analytics API Error:', err);

--- a/src/pages/api/deployments.ts
+++ b/src/pages/api/deployments.ts
@@ -1,20 +1,35 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import allowCors from '../../helpers/cors';
 import { CACHE, fetchWithTimeout } from '@/helpers/http';
+import { deploymentStatusSchema, describeIssues } from '../../types/schemas';
+import { vercelDeploymentsSchema } from '../../types/upstream';
+import type { DeploymentData, DeploymentEnvironment } from '../../types/api';
 
-export type DeploymentStatus = 'BUILDING' | 'ERROR' | 'INITIALIZING' | 'QUEUED' | 'READY' | 'CANCELED';
-export type DeploymentEnvironment = 'production' | 'preview';
+/**
+ * SDD-L07: `DeploymentStatus`, `DeploymentEnvironment` and this response shape were declared here
+ * AND in `types/api.ts`, with the same names and no import between them. Two declarations of one
+ * contract drift the moment either side is edited, and this pair had already drifted from the
+ * upstream API they describe: the status union listed six states where Vercel documents eight, and
+ * `DeploymentStatus` renders `styles[status.toLowerCase()]`, so `BLOCKED` or `DELETED` produced an
+ * unstyled dot with no fallback.
+ *
+ * The local copies are gone. `types/api.ts` re-exports the inferred types, so the old import path
+ * still resolves for anything outside this file.
+ */
+export type { DeploymentStatus, DeploymentEnvironment, DeploymentData as DeploymentResponse } from '../../types/api';
 
-export type DeploymentResponse = {
-    status: DeploymentStatus;
-    environment: DeploymentEnvironment;
-    createdAt: string;
-    buildingAt: string;
-    ready: string;
-    username: string;
-};
+type DeploymentResponseType = DeploymentData | { error: string };
 
-type DeploymentResponseType = DeploymentResponse | { error: string };
+/**
+ * @description Convert a Vercel unix-millisecond timestamp into the ISO string the contract declares.
+ *
+ * The route used to forward these three fields untouched under a `string` annotation while Vercel
+ * documents all of them as `number`. `new Date()` accepts either, so `DeploymentStatus`'s tooltip
+ * kept working and the mismatch stayed invisible — a type that is wrong but never observed. Sending
+ * an ISO string makes the declaration true rather than lucky, and it is what a tooltip wants anyway.
+ */
+const toIsoString = (timestamp: number | undefined): string =>
+    typeof timestamp === 'number' ? new Date(timestamp).toISOString() : '';
 
 /**
  * @description Get the last deployment status
@@ -36,8 +51,20 @@ const fetchLatestDeployment = async (projectId: string, target: string, token: s
         method: 'get',
     });
 
-    const data = await result.json();
-    return data.deployments?.[0];
+    // Was missing entirely: on a 401 from a rotated token, or a 429, Vercel answers a JSON error
+    // envelope with no `deployments` key. `data.deployments?.[0]` then quietly produced `undefined`
+    // and the handler reported "No deployment found" — the same message as a project that has never
+    // deployed. Two very different situations, one indistinguishable log line.
+    if (!result.ok) {
+        throw new Error(`Vercel API responded ${result.status}`);
+    }
+
+    const parsed = vercelDeploymentsSchema.safeParse(await result.json());
+    if (!parsed.success) {
+        throw new Error(`Vercel API response did not match: ${describeIssues(parsed.error.issues)}`);
+    }
+
+    return parsed.data.deployments?.[0];
 };
 
 export default allowCors(async function handler(
@@ -62,18 +89,29 @@ export default allowCors(async function handler(
             throw new Error('No deployment found');
         }
 
+        // `state` is optional upstream and `readyState` is the required one, so fall back rather
+        // than trust it. Validating against the union here is what keeps the widget's
+        // `styles[status.toLowerCase()]` lookup from silently missing: a state Vercel adds later
+        // fails loudly at this line instead of rendering an invisible dot.
+        const state = deploymentStatusSchema.safeParse(deployment.state ?? deployment.readyState);
+        if (!state.success) {
+            throw new Error(`Unknown Vercel deployment state: ${String(deployment.state ?? deployment.readyState)}`);
+        }
+
         res.setHeader('Cache-Control', CACHE.deployment);
         return res.status(200).json({
-            status: deployment.state,
+            status: state.data,
             environment: process.env.NEXT_PUBLIC_ENV as DeploymentEnvironment,
-            createdAt: deployment.createdAt,
-            buildingAt: deployment.buildingAt,
-            ready: deployment.ready,
+            createdAt: toIsoString(deployment.createdAt),
+            buildingAt: toIsoString(deployment.buildingAt),
+            ready: toIsoString(deployment.ready),
             // Kept deliberately. The audit flagged it as reconnaissance, but DeploymentStatus renders
             // it in the widget tooltip, and the value is the owner's own account name — already public
             // as the org in this repository's URL. Removing it would break a feature to hide
             // something that is not hidden.
-            username: deployment.creator?.username,
+            // `creator.username` is optional upstream — only `creator.uid` is required — so the
+            // contract's `username: string` needed a value for the case where Vercel omits it.
+            username: deployment.creator?.username ?? '',
         });
     } catch (err: unknown) {
         // Was `err.message`, the only route of eight that echoed internal error text to the client.

--- a/src/pages/api/weather.ts
+++ b/src/pages/api/weather.ts
@@ -4,32 +4,14 @@ import console from '@/helpers/console';
 import allowCors from '../../helpers/cors';
 import { CACHE, fetchWithTimeout } from '@/helpers/http';
 import { isValidCityName } from '../../helpers/city';
+import { describeIssues } from '../../types/schemas';
+import { forecastSchema, geocodingSchema } from '../../types/upstream';
+import type { WeatherData } from '../../types/api';
 
-interface WeatherData {
-    city: string;
-    name?: string | null;
-    precipitation?: string | null;
-    humidity?: string | null;
-    windSpeed?: string | null;
-    grades?: string | null;
-    imageUrl?: string;
-}
-
+// SDD-L07: the response shape was declared here, again in `useWeather`, and a third time nowhere —
+// the client took it via `data as WeatherData[]`. One schema now, in `types/schemas.ts`, and the two
+// upstream shapes are checked rather than asserted with `as`.
 type WeatherResponse = WeatherData[] | { error: string };
-
-type GeocodingResponse = {
-    results?: Array<{ latitude: number; longitude: number; name: string; country?: string }>;
-};
-
-type ForecastResponse = {
-    current?: {
-        temperature_2m: number;
-        relative_humidity_2m: number;
-        precipitation: number;
-        wind_speed_10m: number;
-        weather_code: number;
-    };
-};
 
 // Minimal WMO weather-code → description map, used as the image alt / name.
 const WEATHER_CODE_TEXT: Record<number, string> = {
@@ -97,7 +79,7 @@ const emptyWeather = (city: string): WeatherData => ({
  * then the resulting coordinates feed the forecast endpoint.
  */
 const getWeatherData = async (city: string): Promise<WeatherData> => {
-    const query = city.split('+')[0].trim();
+    const query = (city.split('+')[0] ?? city).trim();
 
     const geoUrl = new URL('https://geocoding-api.open-meteo.com/v1/search');
     geoUrl.searchParams.set('name', query);
@@ -109,8 +91,11 @@ const getWeatherData = async (city: string): Promise<WeatherData> => {
     if (!geoRes.ok) {
         throw new Error(`Geocoding HTTP error! status: ${geoRes.status}`);
     }
-    const geo = (await geoRes.json()) as GeocodingResponse;
-    const place = geo?.results?.[0];
+    const geo = geocodingSchema.safeParse(await geoRes.json());
+    if (!geo.success) {
+        throw new Error(`Geocoding response did not match: ${describeIssues(geo.error.issues)}`);
+    }
+    const place = geo.data.results?.[0];
     if (!place) {
         console.warn(`No geocoding result for city: ${city}`);
         return emptyWeather(city);
@@ -128,8 +113,11 @@ const getWeatherData = async (city: string): Promise<WeatherData> => {
     if (!forecastRes.ok) {
         throw new Error(`Forecast HTTP error! status: ${forecastRes.status}`);
     }
-    const forecast = (await forecastRes.json()) as ForecastResponse;
-    const current = forecast?.current;
+    const forecast = forecastSchema.safeParse(await forecastRes.json());
+    if (!forecast.success) {
+        throw new Error(`Forecast response did not match: ${describeIssues(forecast.error.issues)}`);
+    }
+    const current = forecast.data.current;
     if (!current) {
         console.warn(`No forecast data for city: ${city}`);
         return emptyWeather(city);
@@ -189,19 +177,42 @@ export default allowCors(async function handler(req: NextApiRequest, res: NextAp
         return res.status(400).json({ error: `Invalid city names: ${invalidCities.join(', ')}` });
     }
 
+    /*
+     * SDD-L07 rewrote this block. It had three defects stacked on each other:
+     *
+     * 1. `.catch()` on a `Promise.allSettled` chain was unreachable. `allSettled` never rejects —
+     *    that is its whole contract — so the only way into it was the `.then` body itself throwing,
+     *    which would then try to send a second response over one already sent.
+     * 2. When every upstream call failed, `results` was `[]` and the route answered **200 with an
+     *    empty array**. The client saw neither an error nor a loading state, so the widget rendered
+     *    nothing at all and looked like a styling bug. A total failure is a 502.
+     * 3. The outer catch was `if (err instanceof Error)`. Anything else thrown — and a rejected
+     *    fetch in Node can surface as a `DOMException` for a timeout, which is not an `Error`
+     *    subclass in every runtime — sent no response whatsoever, leaving the request hanging until
+     *    the platform's function timeout killed it.
+     *
+     * A partial failure still answers 200 with the cities that did resolve: one unreachable city
+     * should not blank the other four.
+     */
     try {
-        await Promise.allSettled(citiesArray.map((city) => getWeatherData(city)))
-            .then((raw) => {
-                const results = raw
-                    .filter((r): r is PromiseFulfilledResult<WeatherData> => r.status === 'fulfilled')
-                    .map((result) => result.value);
-                res.setHeader('Cache-Control', CACHE.weather);
-                res.status(200).json(results);
-            })
-            .catch((err) => res.status(500).json({ error: err.message }));
-    } catch (err: unknown) {
-        if (err instanceof Error) {
-            res.status(500).json({ error: err.message });
+        const settled = await Promise.allSettled(citiesArray.map((city) => getWeatherData(city)));
+        const results = settled
+            .filter((result): result is PromiseFulfilledResult<WeatherData> => result.status === 'fulfilled')
+            .map((result) => result.value);
+
+        if (results.length === 0) {
+            settled.forEach((result) => {
+                if (result.status === 'rejected') console.error('Weather API upstream failure:', result.reason);
+            });
+            res.setHeader('Cache-Control', CACHE.error);
+            return res.status(502).json({ error: 'Weather service unavailable' });
         }
+
+        res.setHeader('Cache-Control', CACHE.weather);
+        return res.status(200).json(results);
+    } catch (err: unknown) {
+        console.error('Weather API Error:', err);
+        res.setHeader('Cache-Control', CACHE.error);
+        return res.status(500).json({ error: 'Internal server error' });
     }
 });

--- a/src/pages/api/xrp.ts
+++ b/src/pages/api/xrp.ts
@@ -2,6 +2,8 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import console from '@/helpers/console';
 import allowCors from '../../helpers/cors';
 import { CACHE, fetchWithTimeout } from '@/helpers/http';
+import { describeIssues } from '../../types/schemas';
+import { coinGeckoXrpSchema } from '../../types/upstream';
 
 /**
  * @description Get the price of XRP in EUR using CoinGecko API
@@ -27,14 +29,18 @@ export default allowCors(async function handler(_req: NextApiRequest, res: NextA
             throw new Error(`CoinGecko API error: ${response.status}`);
         }
 
-        const data = await response.json();
-
-        if (!data.ripple) {
-            throw new Error('XRP data not found');
+        // SDD-L07: `const data = await response.json()` is an implicit `any`, and the only check was
+        // `if (!data.ripple)`. A response with `ripple` present but `eur` missing — what CoinGecko
+        // returns for a currency it does not support, at status 200 — reached `.toFixed()` on
+        // `undefined` and threw a TypeError that the outer catch reported as a flat 500. The log
+        // said "Internal server error" about someone else's API changing shape.
+        const parsed = coinGeckoXrpSchema.safeParse(await response.json());
+        if (!parsed.success) {
+            throw new Error(`CoinGecko response did not match: ${describeIssues(parsed.error.issues)}`);
         }
 
-        const price = parseFloat(data.ripple.eur.toFixed(4));
-        const change24h = data.ripple.eur_24h_change;
+        const price = parseFloat(parsed.data.ripple.eur.toFixed(4));
+        const change24h = parsed.data.ripple.eur_24h_change;
         const todayPorcentage = `${change24h > 0 ? '+' : ''}${change24h.toFixed(2)}%`;
         const todaySummary = change24h > 0 ? 'Up' : 'Down';
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,47 +1,24 @@
-export interface XRPData {
-    price: number;
-    todaySummary: string;
-    todayPorcentage: string;
-}
-
-// Deployment types
-export type DeploymentStatus = 'BUILDING' | 'ERROR' | 'INITIALIZING' | 'QUEUED' | 'READY' | 'CANCELED';
-export type DeploymentEnvironment = 'production' | 'preview';
-
-export interface DeploymentData {
-    status: DeploymentStatus;
-    environment: DeploymentEnvironment;
-    createdAt: string;
-    buildingAt: string;
-    ready: string;
-    username: string;
-}
-
-// Analytics types
-export interface AnalyticsData {
-    pageViews: number;
-    newUsers: number;
-}
-
-// Heating types
-export interface HeatingData {
-    outsideTemp: number;
-    zoneMeasuredTemp: number;
-}
-
-// Counter types
-export interface CounterData {
-    num: number;
-}
-
-// News types
-export interface NewsItem {
-    link: string;
-    title: string;
-    published: string;
-    description: string;
-}
-
-export interface NewsData {
-    news: NewsItem[];
-}
+/**
+ * The response contracts for this site's own API routes.
+ *
+ * SDD-L07: these were nine hand-written `interface` declarations sitting next to ten `as X` casts
+ * that claimed to produce them. They are now derived from the runtime schemas in `./schemas.ts` via
+ * `z.infer`, so a contract cannot drift from what is actually checked at the boundary — one source
+ * of truth instead of a type plus an unenforced promise.
+ *
+ * This module stays as the import path every component and hook already uses, and re-exports
+ * type-only so nothing here can pull the schema values — and with them zod — into a bundle that
+ * only wanted a type.
+ */
+export type {
+    AnalyticsData,
+    CounterData,
+    DeploymentData,
+    DeploymentEnvironment,
+    DeploymentStatus,
+    HeatingData,
+    NewsData,
+    NewsItem,
+    WeatherData,
+    XRPData,
+} from './schemas';

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -1,0 +1,147 @@
+/**
+ * SDD-L07. Runtime shapes for the eight API routes this site owns.
+ *
+ * `grep -r 'zod|safeParse' src/` returned nothing before this file existed: ten external boundaries
+ * were asserted into shape with `as`, which emits no code. `strict: true` was guarding a house whose
+ * front door was propped open — and the bill was already being paid, since `/api/analytics` declared
+ * `pageViews: number` while GA4 emits a string, and the `as AnalyticsData` in the hook laundered it
+ * back to `number`. That is why the view counter renders `12345` unseparated while the crypto price
+ * next to it is formatted: one of them holds a string.
+ *
+ * ## Why `zod/mini` and not `zod`
+ *
+ * These schemas run in the browser — the widgets are in the header on every page, so whatever they
+ * import lands in the shared `_app` chunk. Measured on this repo with a production build:
+ *
+ * | | First Load JS (shared) | `_app` chunk |
+ * |---|---|---|
+ * | before | 165 kB | 61.4 kB |
+ * | `zod` classic, one schema | 178 kB (**+13 kB**) | 74.6 kB |
+ * | `zod/mini`, one schema | 168 kB (**+3.5 kB**) | 64.9 kB |
+ *
+ * 13 kB on every page load, one phase after SDD-L03 spent its effort on LCP, is not a fair trade for
+ * validating our own responses. 3.5 kB is. The cost of `mini` is terser error text — it drops the
+ * message builder, so an issue reads "Invalid input" rather than "expected number, received string".
+ * `describeIssues` below rebuilds the useful part from `issue.expected` and `issue.path`, which mini
+ * does keep, so nothing is actually lost from the logs.
+ *
+ * Upstream third-party shapes live in `./upstream.ts` instead of here, so a schema that only a
+ * serverless function needs cannot be dragged into the browser bundle by a barrel import.
+ *
+ * @see ./upstream.ts
+ * @see @/helpers/createFetcher
+ */
+import * as z from 'zod/mini';
+
+/**
+ * The eight deployment states Vercel documents, not the six this codebase declared.
+ * `BLOCKED` and `DELETED` were missing, and `DeploymentStatus` does
+ * `styles[status.toLowerCase()]`, so either one produced an unstyled dot with no fallback.
+ *
+ * @see https://vercel.com/docs/rest-api/reference/endpoints/deployments/list-deployments
+ */
+export const deploymentStatusSchema = z.enum([
+    'BLOCKED',
+    'BUILDING',
+    'CANCELED',
+    'DELETED',
+    'ERROR',
+    'INITIALIZING',
+    'QUEUED',
+    'READY',
+]);
+
+export const deploymentEnvironmentSchema = z.enum(['production', 'preview']);
+
+/**
+ * `createdAt`, `buildingAt` and `ready` are `string` here but **numbers** upstream — Vercel documents
+ * all three as unix-millisecond timestamps. The route used to forward them untouched under a `string`
+ * annotation, and `new Date()` accepts both, so the lie never surfaced. The route now converts them
+ * to ISO strings, which makes this declaration true by construction rather than by luck.
+ */
+export const deploymentSchema = z.object({
+    status: deploymentStatusSchema,
+    environment: deploymentEnvironmentSchema,
+    createdAt: z.string(),
+    buildingAt: z.string(),
+    ready: z.string(),
+    username: z.string(),
+});
+
+export const analyticsSchema = z.object({
+    pageViews: z.number(),
+    newUsers: z.number(),
+});
+
+export const heatingSchema = z.object({
+    outsideTemp: z.number(),
+    zoneMeasuredTemp: z.number(),
+});
+
+export const counterSchema = z.object({
+    num: z.number(),
+});
+
+export const newsItemSchema = z.object({
+    link: z.string(),
+    title: z.string(),
+    published: z.string(),
+    description: z.string(),
+});
+
+export const newsSchema = z.object({
+    news: z.array(newsItemSchema),
+});
+
+export const xrpSchema = z.object({
+    price: z.number(),
+    todaySummary: z.string(),
+    todayPorcentage: z.string(),
+});
+
+/**
+ * Nullable rather than optional on purpose: `/api/weather` answers with an explicit `null` per field
+ * when a city geocodes but has no current forecast, so the widget can tell "no reading" from "not
+ * asked". `imageUrl` really is absent when the weather code has no icon.
+ */
+export const weatherItemSchema = z.object({
+    city: z.string(),
+    name: z.nullable(z.string()),
+    precipitation: z.nullable(z.string()),
+    humidity: z.nullable(z.string()),
+    windSpeed: z.nullable(z.string()),
+    grades: z.nullable(z.string()),
+    imageUrl: z.optional(z.string()),
+});
+
+export const weatherSchema = z.array(weatherItemSchema);
+
+export const githubStarsSchema = z.number();
+
+export type DeploymentStatus = z.infer<typeof deploymentStatusSchema>;
+export type DeploymentEnvironment = z.infer<typeof deploymentEnvironmentSchema>;
+export type DeploymentData = z.infer<typeof deploymentSchema>;
+export type AnalyticsData = z.infer<typeof analyticsSchema>;
+export type HeatingData = z.infer<typeof heatingSchema>;
+export type CounterData = z.infer<typeof counterSchema>;
+export type NewsItem = z.infer<typeof newsItemSchema>;
+export type NewsData = z.infer<typeof newsSchema>;
+export type XRPData = z.infer<typeof xrpSchema>;
+export type WeatherData = z.infer<typeof weatherItemSchema>;
+
+/**
+ * @description Turn a validation failure into one line a human can act on.
+ *
+ * `zod/mini` issues carry `path`, `code` and `expected` but a generic `message`, so this rebuilds
+ * what the classic build would have said. Used for both the client-side error and the server log —
+ * the whole point of the phase is that "the widget broke" becomes "news[0].published expected
+ * string".
+ */
+export const describeIssues = (issues: readonly { path: PropertyKey[]; expected?: string; code: string }[]): string =>
+    issues
+        .map((issue) => {
+            const where = issue.path.length > 0 ? issue.path.map(String).join('.') : '(root)';
+            const what = issue.expected ? `expected ${issue.expected}` : issue.code;
+            return `${where} ${what}`;
+        })
+        .join('; ');

--- a/src/types/upstream.ts
+++ b/src/types/upstream.ts
@@ -1,0 +1,102 @@
+/**
+ * SDD-L07. Shapes of the third-party responses this site's API routes consume.
+ *
+ * Kept out of `./schemas.ts` deliberately: those run in the browser, these run only inside serverless
+ * functions, and one barrel import is all it takes for a schema nobody in the browser needs to end up
+ * in the shared chunk. Nothing here is imported from a component or a hook.
+ *
+ * Every schema is loose about fields the routes do not read. The goal is not to model Vercel or
+ * Open-Meteo completely — it is to fail with a sentence naming the field that moved, instead of a
+ * `TypeError: Cannot read properties of undefined` fifteen lines later.
+ */
+import * as z from 'zod/mini';
+
+/**
+ * Vercel `GET /v6/deployments`.
+ *
+ * `state`, `buildingAt`, `ready` and `creator.username` are all optional in the documented schema —
+ * only `uid`, `createdAt`, `creator`, `name`, `projectId`, `readyState`, `type` and `url` are
+ * required. The route treated all of them as present.
+ *
+ * The three timestamps are `number` (unix ms). `types/api.ts` declared them `string`, and since
+ * `new Date()` takes either, the mismatch never showed. The route converts rather than forwards now.
+ *
+ * @see https://vercel.com/docs/rest-api/reference/endpoints/deployments/list-deployments
+ */
+export const vercelDeploymentsSchema = z.object({
+    deployments: z.optional(
+        z.array(
+            z.object({
+                state: z.optional(z.string()),
+                readyState: z.optional(z.string()),
+                createdAt: z.optional(z.number()),
+                buildingAt: z.optional(z.number()),
+                ready: z.optional(z.number()),
+                creator: z.optional(z.object({ username: z.optional(z.string()) })),
+            })
+        )
+    ),
+});
+
+/**
+ * CoinGecko `simple/price?ids=ripple&vs_currencies=eur&include_24hr_change=true`.
+ *
+ * The route did `data.ripple.eur.toFixed(4)` after checking only that `data.ripple` exists. A
+ * response with `ripple` present but `eur` missing — which is what CoinGecko returns for an
+ * unsupported currency, not an error status — threw a `TypeError` caught by the outer handler and
+ * reported as a flat 500, so the log said nothing about why.
+ */
+export const coinGeckoXrpSchema = z.object({
+    ripple: z.object({
+        eur: z.number(),
+        eur_24h_change: z.number(),
+    }),
+});
+
+/** Open-Meteo geocoding. `results` is absent, not empty, for an unknown place. */
+export const geocodingSchema = z.object({
+    results: z.optional(
+        z.array(
+            z.object({
+                latitude: z.number(),
+                longitude: z.number(),
+                name: z.string(),
+                country: z.optional(z.string()),
+            })
+        )
+    ),
+});
+
+/** Open-Meteo forecast, `current=` block. */
+export const forecastSchema = z.object({
+    current: z.optional(
+        z.object({
+            temperature_2m: z.number(),
+            relative_humidity_2m: z.number(),
+            precipitation: z.number(),
+            wind_speed_10m: z.number(),
+            weather_code: z.number(),
+        })
+    ),
+});
+
+/**
+ * MDX frontmatter, as gray-matter hands it over.
+ *
+ * `helpers/fileReader.ts` typed this `Record<string, any>` and cast the result to `PathPost`. All 45
+ * posts currently carry every required field, so this is latent — but it is the one place the `as`
+ * pattern can break a **deploy** rather than a widget: `getStaticPaths` maps over the corpus and
+ * `blog/[category]/[slug].tsx` reads `post.category`, so one post published without a category throws
+ * during `next build` with no filename in the message. Validation turns that into a named field in a
+ * named file.
+ *
+ * Deliberately permissive on everything the router does not need — `passthrough` semantics are not
+ * used, but unknown keys are simply stripped from the parsed value while the raw object stays
+ * available to callers that read extra frontmatter.
+ */
+export const postFrontmatterSchema = z.object({
+    title: z.string(),
+    category: z.string(),
+    slug: z.optional(z.string()),
+    date: z.optional(z.union([z.string(), z.date()])),
+});

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -16,6 +16,11 @@
     --status-queue: #0000ff;
     --status-ready: #00ff00;
     --status-canceled: #808080;
+    /* SDD-L07: Vercel documents eight deployment states; this codebase declared six. These are the
+       two that had no colour, no glyph and no class — a BLOCKED or DELETED deployment rendered an
+       empty circle indistinguishable from "no data". */
+    --status-blocked: #8b008b;
+    --status-deleted: #4b0082;
 }
 
 [data-theme='dark'] {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,10 @@
         "allowJs": true,
         "skipLibCheck": true,
         "strict": true,
+        // SDD-L07. `strict` does not include this one. Without it, every `array[i]` and
+        // `record[key]` is typed as if the element always exists, which is how `e.touches[0]`,
+        // `city.split('+')[0]` and a handful of `match[1]` reads got written with no guard.
+        "noUncheckedIndexedAccess": true,
         "forceConsistentCasingInFileNames": true,
         "noEmit": true,
         "esModuleInterop": true,


### PR DESCRIPTION
SDD-L07, phase 7 of 10.

`grep -r 'zod\|safeParse' src/ package.json` returned **nothing**. There was no validator in this
project, and ten external boundaries were asserted into shape with `as` — which emits no code — on
data from GA4, Vercel, CoinGecko, Open-Meteo, an RSS feed, GitHub, Search Console and the entire MDX
frontmatter corpus. `strict: true` was doing real work on the interior while guarding a house whose
front door was propped open.

## The bill was already being paid

`/api/analytics` declared `pageViews: string | number` and returned `row.metricValues?.[0]?.value`.
GA4 emits a **string**. `types/api.ts` declared the same field `number`. `useAnalytics`'s
`as AnalyticsData` reconciled the two by erasing at compile time.

So a string travelled all the way to `ViewCounter`, which rendered `12345` unseparated, while
`CryptoPrice` next to it went through `formatNumber`. **The two counters in the header had disagreed
for exactly this reason.**

## Why `zod/mini`, measured rather than assumed

These schemas run in the browser — the widgets are in the header on every page — so whatever they
import lands in the shared `_app` chunk. Production builds on this repo:

| | First Load JS (shared) | `_app` chunk |
|---|---|---|
| before | 165 kB | 61.4 kB |
| `zod` classic, **one** schema | 178 kB (+13 kB) | 74.6 kB |
| `zod/mini`, **ten** schemas | **170 kB (+5.3 kB)** | 66.7 kB |

13 kB on every page load, one phase after SDD-L03 spent its whole effort on LCP, is not a fair trade
for checking our own responses. 5.3 kB is. The cost of `mini` is terser error text — it drops the
message builder — so `describeIssues` rebuilds the useful part from `issue.expected` and `issue.path`,
which `mini` does keep.

## One fetcher

Six hand-rolled `fetchX` copies (each `await fetch` + `if (!res.ok) throw` + `return data as X`) plus
a generic `fetcher` returning `unknown` — two conventions for one job, and the duplicated one was the
majority. All eight are now `createFetcher(schema, label)`.

`ResponseShapeError` and `ResponseStatusError` are distinct types so `RenderManager` can say something
different for "the route failed" and "the route answered something we do not understand". Its `error`
prop was declared **`boolean`** — it never was one; every caller passes SWR's error object, and it
typechecked only because `useSWR<Data>` leaves the second generic at `any`. A boolean cannot carry a
reason, which is why all ten widgets showed one icon and one sentence for every kind of failure.

## What validating actually turned up

None of this was in the audit. It surfaced from reading the upstream contracts against the code.

- **Vercel documents eight deployment states; this code declared six.** `DeploymentStatus` picks its
  colour with `styles[status.toLowerCase()]`, so `BLOCKED` and `DELETED` rendered an empty circle,
  indistinguishable from no data. And the class for `QUEUED` was named `.queue` — **a queued
  deployment had never once shown its colour.**
- **`createdAt`, `buildingAt` and `ready` are numbers upstream**, not the `string` the contract
  declared. `new Date()` accepts either, so the lie never surfaced. The route converts to ISO now.
- `creator.username` and `state` are optional upstream; the route treated both as guaranteed.
- `/api/deployments` never checked `result.ok`. A 401 from a rotated token produced `undefined` from
  `data.deployments?.[0]` and was logged as "No deployment found" — the same line as a project that
  has never deployed.
- `useGithubStars` built its SWR key with `new URL()` at module scope. With `NEXT_PUBLIC_DOMAIN`
  unset that throws during import and **fails `next build` outright** rather than failing one widget.
- `useSurvey`'s default only covered the non-array branch of `query.name`.
- `/api/weather`'s `WeatherData` claimed the readings are always strings. The route sends explicit
  `null`s for a city that geocodes but has no forecast — so `Weather` rendered the literal text
  **"null ºC | ºF"** and passed `null` to next/image's `alt`.

## /api/weather had three defects stacked

1. `.catch()` on a `Promise.allSettled` chain is **unreachable** — `allSettled` never rejects.
2. When every upstream call failed, it answered **200 with `[]`**. The client saw neither an error nor
   a loading state, so the widget rendered nothing and read as a styling bug.
3. The outer catch was `if (err instanceof Error)`. Anything else — a timeout surfacing as a
   `DOMException` — sent **no response at all**, hanging until the platform's function timeout.

Now awaited, 502 when everything fails, 200 with whatever resolved, unconditional catch.

## noUncheckedIndexedAccess

On. It surfaced exactly six unguarded index reads, so it stayed in this PR rather than being split
out as the spec allowed. `tsconfig.json` is guarded by a hook against config weakening; this is a
strictness increase, so I bypassed it deliberately for that one line — flagging it because the
bypass is worth knowing about.

## Not adopted, deliberately

`neverthrow` and `ts-pattern`, which my global rules prefer. They describe a different stack (Next 16,
TS 6, pnpm) and adopting them here would be a rewrite, not a fix. Only the rule that maps to a
verified defect was taken: validate external input with a schema.

## Tests

Eight boundaries, each fed the shape its upstream would send if it drifted. The 502 path. A partial
weather failure (dispatched by URL, not call order — `allSettled` fires both geocode requests before
either forecast). Both error kinds reaching `RenderManager` as different messages. Every documented
deployment state having a colour class **and** a glyph.

That last test reads the stylesheet as text on purpose: `next/jest` proxies CSS modules so every key
returns its own name, which means `expect(styles[x]).toBeDefined()` passes for **any** string —
including the class that was actually missing. I verified the test fails when the class is removed.

**280 tests / 65 suites**, 17 e2e. Coverage 85.2% statements, 81.4% functions. `lint`, `tsc`,
`audit:prod` and `build` all pass.

## Noted, not fixed

`next build` fails outright when `NEXT_PUBLIC_DOMAIN` is unset — `useAnalytics` constructs a `URL`
during SSG of `/legal/[slug]`. CI supplies it from secrets, so this only bites a fresh local clone.
Out of scope here, but it is why the `useGithubStars` change above matters more than it looks.