### PR TITLE
fix: stop advertising a stylesheet as a page in the sitemap

### DIFF
--- a/src/helpers/__test__/fileWritter.test.ts
+++ b/src/helpers/__test__/fileWritter.test.ts
@@ -101,4 +101,34 @@ describe('createSiteMap', () => {
 
         expect(String(writeFileSync.mock.calls.at(-1)?.[0])).toMatch(/public\/sitemap\.xml$/);
     });
+
+    /*
+     * SDD-L10-T13. The production sitemap advertised `/error.module.css` in all three locales, each
+     * returning 404, because the top-level page scan excluded by *name* — anything absent from
+     * `NON_SITEMAP_PAGES` was treated as a route. `src/pages/error.module.css` is a CSS module
+     * colocated with a page, and `.replace('.tsx', '')` left its filename untouched on the way out.
+     *
+     * Submitting a 404 as a page is the same class of damage as SDD-L04's noindex legal pages: it
+     * spends crawl budget and reports back as an error in Search Console, which is what erodes trust
+     * in the file as a whole. Found by an external crawl, not by this suite.
+     *
+     * These assertions read the real `src/pages`, so a future colocated asset of any extension is
+     * caught here rather than in production.
+     */
+    it('should never advertise a colocated stylesheet as a page', async () => {
+        await createSiteMap([], ['en', 'es', 'gl']);
+
+        expect(written()).not.toContain('error.module.css');
+    });
+
+    it('should only advertise entries that could be pages', async () => {
+        await createSiteMap([], ['en']);
+
+        const locs = [...written().matchAll(/<loc>([^<]*)<\/loc>/g)].map((match) => match[1] ?? '');
+        // The extension is checked on the path, not the whole URL: a bare origin ends in the TLD
+        // and would otherwise read as a file.
+        const withFileExtension = locs.filter((loc) => /\.[a-z0-9]+$/i.test(new URL(loc).pathname));
+
+        expect(withFileExtension).toEqual([]);
+    });
 });

--- a/src/helpers/fileWritter.ts
+++ b/src/helpers/fileWritter.ts
@@ -86,6 +86,12 @@ export const createSiteMap = async (routes: SitemapRoute[], locales: string[]): 
     // No <lastmod> for evergreen pages: stamping the build date on every URL misleads crawlers
     const pages = fs
         .readdirSync(path.join(process.cwd(), '/src/pages'))
+        // SDD-L10-T13: include what is a page, then exclude the ones that must not ship. The filter
+        // used to be exclusion-only, so anything absent from NON_SITEMAP_PAGES became a URL —
+        // `error.module.css` sits in this directory beside the page that imports it, survived a
+        // `.replace('.tsx', '')` that does not match it, and was advertised in all three locales as
+        // a page returning 404. An allowlist by extension cannot be outgrown by a new asset type.
+        .filter((page) => page.endsWith('.tsx'))
         .filter((page) => !NON_SITEMAP_PAGES.has(page))
         .map((page) => {
             page = page.replace('.tsx', '');


### PR DESCRIPTION
The production sitemap lists `/error.module.css` in all three locales. All three return **404**.

```
https://xabierlameiro.com/error.module.css        404
https://xabierlameiro.com/es/error.module.css     404
https://xabierlameiro.com/gl/error.module.css     404
```

## Cause

`src/pages/error.module.css` is a CSS module colocated with the page that imports it — the only non-page file in that directory. The top-level page scan in `createSiteMap` excluded **by name**:

```ts
.filter((page) => !NON_SITEMAP_PAGES.has(page))
```

Anything absent from that set became a URL, and the `.replace('.tsx', '')` on the way out does not match a `.css` filename, so it was emitted verbatim.

## Fix

Include what *is* a page, then exclude what must not ship:

```ts
.filter((page) => page.endsWith('.tsx'))
.filter((page) => !NON_SITEMAP_PAGES.has(page))
```

An allowlist by extension cannot be outgrown by a new asset type. The blocklist had to be updated by whoever added the file, and nobody did.

## Why it matters

Submitting a 404 as a page is the same damage as SDD-L04's noindex legal pages: it spends crawl budget and comes back as an error in Search Console, which is what erodes trust in the whole file.

## Verification

- Two new assertions read the **real** `src/pages`, so a future colocated asset of any extension fails here rather than in production.
- Both were confirmed to fail before the fix and to fail again when the allowlist line is removed — a test that cannot fail proves nothing.
- Full suite: **338 tests, 70 suites, all passing**. `tsc --noEmit` and `eslint` clean.
- No need to update the committed `public/sitemap.xml`: it is regenerated at build and does not contain the bad entries (48 URLs vs the live 51 — the difference is exactly these three).

## Note, not addressed here

`src/helpers/fileWritter.ts` does not satisfy `prettier --check` on `master`, before and after this change, in three lines this PR does not touch. `.prettierrc` declares `plugins: []` alongside a `jsdocDescriptionTag` option left over from a plugin that is no longer installed, and no workflow runs a formatting check. Left alone to keep the diff to the bug.

> This PR was created with AI assistance.