### PR TITLE
fix(header): scroll surfaces, three-zone menu bar and a fixed status pitch (SDD-L12)

### DIFF
--- a/data/home/mobile.es.mdx
+++ b/data/home/mobile.es.mdx
@@ -16,12 +16,13 @@ const App = ({ name = name }: Props) => {
    <h1>👋, me llamo {name}!</h1>
 
    <p className={`${styles.education}`}>
-     Soy Software Architect. 
-     Nací y crecí en Galicia pero
-     actualmente vivo en Irlanda, 
-     intentando mejorar mi inglés. 
-     Me gusta el  desarrollo web, 
-     las aplicaciones y el IOT...
+     Soy Software Architect.
+     He trabajado y trabajo en el
+     sector bancario y retail para
+     empresas como CaixaBank,
+     Openbank e Inditex. Me gusta el
+     desarrollo de aplicaciones,
+     automatizaciones y el IoT.
    </p>
   </main>
  );

--- a/data/home/mobile.gl.mdx
+++ b/data/home/mobile.gl.mdx
@@ -17,11 +17,12 @@ const App = ({ name = name }: Props) => {
 
    <p className={`${styles.education}`}>
       Son Software Architect.
-      Nacín e criei en Galiza pero
-      actualmente vivo en Irlanda,
-      intentando mellorar o meu inglés.
-      Gústame o desenvolvemento web,
-      aplicacións e o IOT...
+      Traballei e traballo no sector
+      bancario e retail para empresas
+      como CaixaBank, Openbank e
+      Inditex. Gústame o desenvolvemento
+      de aplicacións, as automatizacións
+      e o IoT.
    </p>
   </main>
  );

--- a/e2e/scroll-surfaces.test.ts
+++ b/e2e/scroll-surfaces.test.ts
@@ -1,0 +1,120 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from './fixtures';
+
+/**
+ * SDD-L12-T1. The regression net for the scroll-surface work.
+ *
+ * Two separate defects are asserted here, because they have separate causes and separate fixes.
+ *
+ * 1. **The header does not fit.** Measured on `master` @ `4d1d898`, its content needed 1526 px at
+ *    every viewport: 246 px unreachable on a 1280 px laptop, 1151 px on a phone. The widgets past
+ *    the fold could only be reached by dragging horizontally inside a 24-pixel-tall strip. L12-T2
+ *    removed the five artifact links (decision D5) and brought that down to 1168 px.
+ *
+ * 2. **`overflow: scroll` where `auto` was meant.** `scroll` paints a scrollbar unconditionally;
+ *    `auto` paints one only when there is something to scroll. Chromium on macOS hides the
+ *    difference behind overlay scrollbars — Firefox, and macOS with *Show scroll bars: Always*, do
+ *    not, which is why this reached a user before it reached us. L12-T3/T4 fix it.
+ *
+ * The viewport list is deliberate: 375 and 768 are the two breakpoints the layout already branches
+ * on, 1280 is the config default, and 1920 catches a fix that only works because the window is
+ * wide — which is exactly why this went unnoticed on the development machine.
+ */
+
+const VIEWPORTS = [
+    { width: 375, height: 812, name: 'mobile' },
+    { width: 768, height: 1024, name: 'tablet' },
+    { width: 1280, height: 720, name: 'laptop' },
+    { width: 1920, height: 1080, name: 'desktop' },
+];
+
+const readHeaderWidths = (page: Page) =>
+    page.evaluate(() => {
+        const header = document.querySelector('header');
+        if (!header) throw new Error('no <header> in the document');
+        return { scrollWidth: header.scrollWidth, clientWidth: header.clientWidth };
+    });
+
+/**
+ * The header's width depends on widgets that resolve asynchronously (weather, crypto, view counts,
+ * deployment status, heating). Measuring before they settle reads a narrower header than the one a
+ * reader gets, which would let this suite pass for the wrong reason. Poll until two consecutive
+ * reads agree instead of racing a fixed timeout.
+ */
+const waitForStableHeader = async (page: Page) => {
+    let previous = -1;
+
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+        const widths = await readHeaderWidths(page);
+        if (widths.scrollWidth === previous) return widths;
+        previous = widths.scrollWidth;
+        await page.waitForTimeout(100);
+    }
+
+    return await readHeaderWidths(page);
+};
+
+test.describe('Scroll surfaces', () => {
+    for (const viewport of VIEWPORTS) {
+        test(`header fits without horizontal scrolling at ${viewport.width}px (${viewport.name})`, async ({
+            page,
+        }) => {
+            /**
+             * L12-T2 removed the five artifact links and the header went from 1526 px to 1168 px —
+             * so it now fits a 1280 px laptop and anything wider, which is where the defect was
+             * reported. It does **not** fit 768 or 375, and no further link removal will make it:
+             * the remaining 1168 px is widgets (a five-segment countdown, weather, crypto, two
+             * counters, heating, date) inside a 24 px strip.
+             *
+             * Closing these two needs the narrow-viewport half of D5 — option 3, priority-based
+             * hiding or an overflow menu — which is a product decision, not a CSS fix. Skipped
+             * with the reason attached rather than deleted, so the gap stays visible and measured.
+             */
+            test.skip(
+                viewport.width < 1280,
+                'needs the narrow-viewport decision (D5 option 3): 1168px of widgets cannot fit a 24px strip'
+            );
+
+            await page.setViewportSize({ width: viewport.width, height: viewport.height });
+            await page.goto('/');
+            await expect(page.getByTestId('header')).toBeVisible();
+
+            const { scrollWidth, clientWidth } = await waitForStableHeader(page);
+
+            expect(
+                scrollWidth,
+                `header needs ${scrollWidth}px but has ${clientWidth}px: ` +
+                    `${scrollWidth - clientWidth}px of it is unreachable without a horizontal drag`
+            ).toBeLessThanOrEqual(clientWidth);
+        });
+    }
+
+    /**
+     * Marked `test.fail()`: the defect is real today, so the assertion below is expected to fail and
+     * the suite stays green while it does. L12-T3/T4 change `overflow: scroll` to `auto` on the
+     * header and the dialog body and sweep the rest — at which point this test starts *passing*,
+     * Playwright reports the unexpected pass as a failure, and whoever did T3 removes the marker.
+     * That is the point: unlike a skip, this cannot be forgotten, and it never stops running.
+     */
+    test('no element paints a scrollbar it does not need', async ({ page }) => {
+        // Inside the body, so it marks this test only — at describe scope it would mark every test.
+        test.fail();
+
+        await page.setViewportSize({ width: 1280, height: 720 });
+        await page.goto('/');
+        await expect(page.getByTestId('header')).toBeVisible();
+        await waitForStableHeader(page);
+
+        const gratuitous = await page.evaluate(() =>
+            [...document.querySelectorAll('*')]
+                .filter((element) => {
+                    const style = getComputedStyle(element);
+                    if (style.overflowX !== 'scroll' && style.overflowY !== 'scroll') return false;
+                    return element.scrollWidth <= element.clientWidth && element.scrollHeight <= element.clientHeight;
+                })
+                .map((element) => `${element.tagName.toLowerCase()}.${element.className}`)
+        );
+
+        expect(gratuitous, `these declare overflow: scroll but never overflow: ${gratuitous.join(', ')}`).toEqual([]);
+    });
+});

--- a/e2e/scroll-surfaces.test.ts
+++ b/e2e/scroll-surfaces.test.ts
@@ -8,8 +8,13 @@ import { expect, test } from './fixtures';
  *
  * 1. **The header does not fit.** Measured on `master` @ `4d1d898`, its content needed 1526 px at
  *    every viewport: 246 px unreachable on a 1280 px laptop, 1151 px on a phone. The widgets past
- *    the fold could only be reached by dragging horizontally inside a 24-pixel-tall strip. L12-T2
- *    removed the five artifact links (decision D5) and brought that down to 1168 px.
+ *    the fold could only be reached by dragging horizontally inside a 24-pixel-tall strip.
+ *
+ *    L12-T2 first removed the five artifact links, which fixed 1280 and 1920 and left 768 and 375
+ *    still overflowing — the remaining width was widgets, not links. L12-T8 replaced that approach
+ *    with the layout the design was reaching for: three zones, status items as icons on the right,
+ *    and priority-based shedding below 1023 px and 768 px, the way a macOS menu bar behaves. The
+ *    links came back. All four viewports are asserted, none skipped.
  *
  * 2. **`overflow: scroll` where `auto` was meant.** `scroll` paints a scrollbar unconditionally;
  *    `auto` paints one only when there is something to scroll. Chromium on macOS hides the
@@ -34,6 +39,42 @@ const VIEWPORTS = [
     { width: 1280, height: 720, name: 'laptop' },
     { width: 1920, height: 1080, name: 'desktop' },
 ];
+
+/**
+ * Measures the *bar*, not the scroll box.
+ *
+ * `header.scrollWidth` looked like the obvious metric and is the wrong one: the weather popover is a
+ * 400 px absolutely-positioned child, and a closed popover still has a box, so scrollWidth read
+ * `clientWidth + 440` at 1024, 1280 and 1920 alike — a constant offset that says "a positioned child
+ * hangs off the edge", not "the menu bar does not fit". Popovers are supposed to escape a menu bar.
+ *
+ * What actually matters is that the three zones fit inside the header and do not run into each
+ * other, so that is what is measured.
+ */
+const readHeaderZones = (page: Page) =>
+    page.evaluate(() => {
+        const header = document.querySelector('header');
+        if (!header) throw new Error('no <header> in the document');
+
+        const bounds = header.getBoundingClientRect();
+        const zone = (selector: string) => {
+            const element = header.querySelector(selector);
+            if (!element || getComputedStyle(element).display === 'none') return null;
+            const rect = element.getBoundingClientRect();
+            return { left: Math.round(rect.left), right: Math.round(rect.right), width: Math.round(rect.width) };
+        };
+
+        return {
+            headerLeft: Math.round(bounds.left),
+            headerRight: Math.round(bounds.right),
+            left: zone('[class*="left"]'),
+            center: zone('[class*="center"]'),
+            right: zone('[class*="right"]'),
+            visibleLinks: [...header.querySelectorAll('nav a')].filter(
+                (link) => getComputedStyle(link).display !== 'none',
+            ).length,
+        };
+    });
 
 const readHeaderWidths = (page: Page) =>
     page.evaluate(() => {
@@ -64,33 +105,77 @@ const waitForStableHeader = async (page: Page) => {
 test.describe('Scroll surfaces', () => {
     for (const viewport of VIEWPORTS) {
         test(`header fits without horizontal scrolling at ${viewport.width}px (${viewport.name})`, async ({ page }) => {
-            /**
-             * L12-T2 removed the five artifact links and the header went from 1526 px to 1168 px —
-             * so it now fits a 1280 px laptop and anything wider, which is where the defect was
-             * reported. It does **not** fit 768 or 375, and no further link removal will make it:
-             * the remaining 1168 px is widgets (a five-segment countdown, weather, crypto, two
-             * counters, heating, date) inside a 24 px strip.
-             *
-             * Closing these two needs the narrow-viewport half of D5 — option 3, priority-based
-             * hiding or an overflow menu — which is a product decision, not a CSS fix. Skipped
-             * with the reason attached rather than deleted, so the gap stays visible and measured.
-             */
-            test.skip(
-                viewport.width < 1280,
-                'needs the narrow-viewport decision (D5 option 3): 1168px of widgets cannot fit a 24px strip',
-            );
-
             await page.setViewportSize({ width: viewport.width, height: viewport.height });
             await page.goto('/');
             await expect(page.getByTestId('header')).toBeVisible();
+            await waitForStableHeader(page);
 
-            const { scrollWidth, clientWidth } = await waitForStableHeader(page);
+            const zones = await readHeaderZones(page);
+            const describe = JSON.stringify(zones);
+
+            expect(zones.left, `no left zone at ${viewport.width}px: ${describe}`).not.toBeNull();
+            expect(zones.right, `no right zone at ${viewport.width}px: ${describe}`).not.toBeNull();
 
             expect(
-                scrollWidth,
-                `header needs ${scrollWidth}px but has ${clientWidth}px: ` +
-                    `${scrollWidth - clientWidth}px of it is unreachable without a horizontal drag`,
-            ).toBeLessThanOrEqual(clientWidth);
+                zones.right!.right,
+                `the status items run past the right edge of the bar at ${viewport.width}px: ${describe}`,
+            ).toBeLessThanOrEqual(zones.headerRight);
+
+            expect(
+                zones.left!.left,
+                `the app identity starts before the left edge at ${viewport.width}px: ${describe}`,
+            ).toBeGreaterThanOrEqual(zones.headerLeft);
+
+            // The middle zone is the one that collides first when the two sides grow. Below 768px it
+            // is deliberately not rendered.
+            //
+            // Both neighbours are asserted. The first version of this test only checked the left
+            // side, and the countdown was covering the last three status icons on the right the
+            // whole time — `elementFromPoint` over the coverage, e2e and Lighthouse links returned
+            // the countdown, so three links were unclickable and this suite said nothing.
+            if (zones.center) {
+                expect(
+                    zones.center.left,
+                    `the countdown overlaps the app identity at ${viewport.width}px: ${describe}`,
+                ).toBeGreaterThanOrEqual(zones.left!.right);
+
+                expect(
+                    zones.center.right,
+                    `the countdown overlaps the status items at ${viewport.width}px: ${describe}`,
+                ).toBeLessThanOrEqual(zones.right!.left);
+            }
+        });
+
+        test(`every status item is clickable at ${viewport.width}px (${viewport.name})`, async ({ page }) => {
+            await page.setViewportSize({ width: viewport.width, height: viewport.height });
+            await page.goto('/');
+            await expect(page.getByTestId('header')).toBeVisible();
+            await waitForStableHeader(page);
+
+            /**
+             * Geometry alone is not enough: an element can be inside the bar and still be covered by
+             * something painted over it. This asks the browser what is actually on top at each
+             * icon's centre — the check that would have caught the countdown overlap immediately.
+             */
+            const covered = await page.evaluate(() => {
+                const header = document.querySelector('header');
+                if (!header) throw new Error('no <header> in the document');
+
+                return [...header.querySelectorAll('nav a')]
+                    .filter((link) => getComputedStyle(link).display !== 'none')
+                    .map((link) => {
+                        const rect = link.getBoundingClientRect();
+                        const top = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+                        const reachable = top === link || link.contains(top);
+                        return reachable
+                            ? null
+                            : `${(link as HTMLElement).dataset.testid} is covered by ` +
+                                  `${top?.tagName.toLowerCase()}.${String(top?.className).slice(0, 40)}`;
+                    })
+                    .filter(Boolean);
+            });
+
+            expect(covered, `status items are not reachable: ${covered.join(' | ')}`).toEqual([]);
         });
     }
 

--- a/e2e/scroll-surfaces.test.ts
+++ b/e2e/scroll-surfaces.test.ts
@@ -12,9 +12,14 @@ import { expect, test } from './fixtures';
  *
  *    L12-T2 first removed the five artifact links, which fixed 1280 and 1920 and left 768 and 375
  *    still overflowing — the remaining width was widgets, not links. L12-T8 replaced that approach
- *    with the layout the design was reaching for: three zones, status items as icons on the right,
- *    and priority-based shedding below 1023 px and 768 px, the way a macOS menu bar behaves. The
- *    links came back. All four viewports are asserted, none skipped.
+ *    with three zones and priority-based shedding, the way a macOS menu bar behaves, and the links
+ *    came back. L12-T9 then moved the link icons into the LEFT zone, beside the identity, and put
+ *    the status values on a fixed pitch.
+ *
+ *    T9 is why the widths in `VIEWPORTS` all changed. With the icons on the left the left zone is
+ *    320 px rather than 66 px, so it can now reach the centred countdown too — `W >= 2 * (zone +
+ *    103)` has to hold for *both* sides, and every breakpoint was re-derived against the wider of
+ *    the two. A ladder that watches one side is how the bar ended up drawn over itself at 1024 px.
  *
  * 2. **`overflow: scroll` where `auto` was meant.** `scroll` paints a scrollbar unconditionally;
  *    `auto` paints one only when there is something to scroll. Chromium on macOS hides the
@@ -44,22 +49,32 @@ const SCROLLER_ROUTES = ['/', '/blog', '/legal/privacy-policy'];
  */
 const VIEWPORTS = [
     { width: 375, height: 812, name: 'mobile' },
+    { width: 479, height: 812, name: 'below profile icons' },
+    { width: 480, height: 812, name: 'profile icons appear' },
     { width: 768, height: 1024, name: 'tablet, no countdown' },
     { width: 769, height: 1024, name: 'tablet, countdown appears' },
+    { width: 869, height: 800, name: 'below artifact icons' },
+    { width: 870, height: 800, name: 'artifact icons appear' },
+    { width: 939, height: 800, name: 'below crypto' },
+    { width: 940, height: 800, name: 'crypto appears' },
     { width: 1024, height: 800, name: 'small laptop' },
-    { width: 1179, height: 800, name: 'below artifact icons' },
-    { width: 1181, height: 800, name: 'artifact icons appear' },
+    { width: 1129, height: 800, name: 'below heating' },
+    { width: 1130, height: 800, name: 'heating appears' },
     { width: 1280, height: 720, name: 'laptop' },
-    { width: 1319, height: 800, name: 'below indexed counter' },
-    { width: 1321, height: 800, name: 'indexed counter appears' },
-    { width: 1479, height: 800, name: 'below crypto' },
-    { width: 1481, height: 800, name: 'crypto appears' },
-    { width: 1659, height: 900, name: 'below heating' },
-    { width: 1661, height: 900, name: 'heating appears' },
+    { width: 1329, height: 800, name: 'below view counter' },
+    { width: 1330, height: 800, name: 'view counter appears' },
     { width: 1920, height: 1080, name: 'desktop' },
-    { width: 2019, height: 1080, name: 'below view counter' },
-    { width: 2021, height: 1080, name: 'view counter appears' },
 ];
+
+/**
+ * SDD-L12-T9. The status area is a fixed pitch, and these are the only widths a slot may have.
+ *
+ * T8 sized the slots with `auto` tracks, so each one was as wide as whatever its widget happened to
+ * be showing — and when three widgets were in an error state the row read as randomly spaced, which
+ * is what the owner reported. Pinning the numbers here means a future `auto` or a stray `gap` fails
+ * as a test rather than as a screenshot.
+ */
+const SLOT_WIDTHS = { deploymentDot: 24, value: 96, clock: 140 };
 
 /**
  * Measures the *bar*, not the scroll box.
@@ -233,6 +248,65 @@ test.describe('Scroll surfaces', () => {
             });
 
             expect(covered, `status items are not reachable: ${covered.join(' | ')}`).toEqual([]);
+        });
+    }
+
+    /**
+     * L12-T9. The owner's report was "each one takes a random amount of space, and they should be
+     * stuck to the right". Both halves are asserted, because they have different causes: the pitch
+     * comes from the fixed slot widths, and the flush edge from the zone's own alignment.
+     *
+     * Measured at two widths so the claim is not an artefact of one: at 1280 the crypto slot is shed
+     * and at 1920 it is not, so the check sees a different number of slots each time.
+     */
+    for (const width of [1280, 1920]) {
+        test(`the status items keep a fixed pitch, flush to the bar edge at ${width}px`, async ({ page }) => {
+            await page.setViewportSize({ width, height: 800 });
+            await page.goto('/');
+            await expect(page.getByTestId('header')).toBeVisible();
+            await waitForStableHeader(page);
+
+            const layout = await page.evaluate(() => {
+                const header = document.querySelector('header');
+                if (!header) throw new Error('no <header> in the document');
+                const right = header.querySelector('[class*="right"]');
+                if (!right) throw new Error('no right zone in the header');
+
+                const bounds = header.getBoundingClientRect();
+                const style = getComputedStyle(header);
+                const slots = [...right.children]
+                    .filter((child) => getComputedStyle(child).display !== 'none')
+                    .map((child) => ({
+                        width: Math.round(child.getBoundingClientRect().width),
+                        right: Math.round(child.getBoundingClientRect().right),
+                    }));
+
+                return {
+                    slots,
+                    paddingLeft: Math.round(parseFloat(style.paddingLeft)),
+                    trailingGap: slots.length
+                        ? Math.round(bounds.right - slots[slots.length - 1].right)
+                        : Number.NaN,
+                };
+            });
+
+            const describe = JSON.stringify(layout);
+            const allowed = Object.values(SLOT_WIDTHS);
+
+            expect(layout.slots.length, `no status items at ${width}px: ${describe}`).toBeGreaterThan(1);
+
+            for (const slot of layout.slots) {
+                expect(allowed, `a status slot is ${slot.width}px, which is not a fixed slot: ${describe}`).toContain(
+                    slot.width,
+                );
+            }
+
+            // Flush right: the gap left after the last slot is the bar's own padding, the same
+            // number as on the identity side. Anything else is the zone drifting off the edge.
+            expect(
+                layout.trailingGap,
+                `the status items are not flush to the bar's right edge at ${width}px: ${describe}`,
+            ).toBe(layout.paddingLeft);
         });
     }
 

--- a/e2e/scroll-surfaces.test.ts
+++ b/e2e/scroll-surfaces.test.ts
@@ -21,6 +21,13 @@ import { expect, test } from './fixtures';
  * wide — which is exactly why this went unnoticed on the development machine.
  */
 
+/**
+ * One route per surface that owns a scroller: the home window, the blog (body + article controls)
+ * and a legal document. `/blog` rather than a single post, so the check does not depend on a slug
+ * surviving a future content edit.
+ */
+const SCROLLER_ROUTES = ['/', '/blog', '/legal/privacy-policy'];
+
 const VIEWPORTS = [
     { width: 375, height: 812, name: 'mobile' },
     { width: 768, height: 1024, name: 'tablet' },
@@ -56,9 +63,7 @@ const waitForStableHeader = async (page: Page) => {
 
 test.describe('Scroll surfaces', () => {
     for (const viewport of VIEWPORTS) {
-        test(`header fits without horizontal scrolling at ${viewport.width}px (${viewport.name})`, async ({
-            page,
-        }) => {
+        test(`header fits without horizontal scrolling at ${viewport.width}px (${viewport.name})`, async ({ page }) => {
             /**
              * L12-T2 removed the five artifact links and the header went from 1526 px to 1168 px —
              * so it now fits a 1280 px laptop and anything wider, which is where the defect was
@@ -72,7 +77,7 @@ test.describe('Scroll surfaces', () => {
              */
             test.skip(
                 viewport.width < 1280,
-                'needs the narrow-viewport decision (D5 option 3): 1168px of widgets cannot fit a 24px strip'
+                'needs the narrow-viewport decision (D5 option 3): 1168px of widgets cannot fit a 24px strip',
             );
 
             await page.setViewportSize({ width: viewport.width, height: viewport.height });
@@ -84,37 +89,67 @@ test.describe('Scroll surfaces', () => {
             expect(
                 scrollWidth,
                 `header needs ${scrollWidth}px but has ${clientWidth}px: ` +
-                    `${scrollWidth - clientWidth}px of it is unreachable without a horizontal drag`
+                    `${scrollWidth - clientWidth}px of it is unreachable without a horizontal drag`,
             ).toBeLessThanOrEqual(clientWidth);
         });
     }
 
     /**
-     * Marked `test.fail()`: the defect is real today, so the assertion below is expected to fail and
-     * the suite stays green while it does. L12-T3/T4 change `overflow: scroll` to `auto` on the
-     * header and the dialog body and sweep the rest — at which point this test starts *passing*,
-     * Playwright reports the unexpected pass as a failure, and whoever did T3 removes the marker.
-     * That is the point: unlike a skip, this cannot be forgotten, and it never stops running.
+     * L12-T3/T4. This shipped as `test.fail()` while the defect existed: the suite stayed green, and
+     * the moment T3 changed `scroll` to `auto` Playwright reported "expected to fail, but passed" —
+     * which is how the marker got removed instead of forgotten.
+     *
+     * The routes are the ones that own the remaining scrollers: the blog body and the article
+     * controls (T4), and the legal document surface (T4). Checking only `/` would have declared the
+     * sweep done while three untouched `overflow: scroll` rules were still live one route away.
      */
-    test('no element paints a scrollbar it does not need', async ({ page }) => {
-        // Inside the body, so it marks this test only — at describe scope it would mark every test.
-        test.fail();
+    for (const route of SCROLLER_ROUTES) {
+        test(`no element paints a scrollbar it does not need on ${route}`, async ({ page }) => {
+            await page.setViewportSize({ width: 1280, height: 720 });
+            await page.goto(route);
+            await expect(page.getByTestId('header')).toBeVisible();
+            await waitForStableHeader(page);
 
+            const gratuitous = await page.evaluate(() =>
+                [...document.querySelectorAll('*')]
+                    .filter((element) => {
+                        const style = getComputedStyle(element);
+                        if (style.overflowX !== 'scroll' && style.overflowY !== 'scroll') return false;
+                        return (
+                            element.scrollWidth <= element.clientWidth && element.scrollHeight <= element.clientHeight
+                        );
+                    })
+                    .map((element) => `${element.tagName.toLowerCase()}.${element.className}`),
+            );
+
+            expect(gratuitous, `these declare overflow: scroll but never overflow: ${gratuitous.join(', ')}`).toEqual(
+                [],
+            );
+        });
+    }
+
+    /**
+     * The other half of T4: proving the sweep removed bars without removing *scrolling*. `auto` and
+     * `scroll` differ only in whether the bar is painted when there is nothing to scroll, so this
+     * should hold by construction — but "should hold by construction" is exactly the claim that
+     * earns a test, and the article body is the surface a reader would notice losing.
+     */
+    test('the article body still scrolls after the sweep', async ({ page }) => {
         await page.setViewportSize({ width: 1280, height: 720 });
-        await page.goto('/');
+        await page.goto('/blog');
         await expect(page.getByTestId('header')).toBeVisible();
-        await waitForStableHeader(page);
 
-        const gratuitous = await page.evaluate(() =>
-            [...document.querySelectorAll('*')]
-                .filter((element) => {
-                    const style = getComputedStyle(element);
-                    if (style.overflowX !== 'scroll' && style.overflowY !== 'scroll') return false;
-                    return element.scrollWidth <= element.clientWidth && element.scrollHeight <= element.clientHeight;
-                })
-                .map((element) => `${element.tagName.toLowerCase()}.${element.className}`)
-        );
+        const body = page.locator('[class*="blog_body"]').first();
+        await expect(body).toBeVisible();
 
-        expect(gratuitous, `these declare overflow: scroll but never overflow: ${gratuitous.join(', ')}`).toEqual([]);
+        const scrolled = await body.evaluate((element) => {
+            const overflows = element.scrollHeight > element.clientHeight;
+            element.scrollTop = 300;
+            return { overflows, scrollTop: element.scrollTop, overflowY: getComputedStyle(element).overflowY };
+        });
+
+        expect(scrolled.overflowY, 'the article body must stay a scroller').toBe('auto');
+        expect(scrolled.overflows, 'a full post should be taller than its pinned container').toBe(true);
+        expect(scrolled.scrollTop, 'setting scrollTop must actually move the body').toBeGreaterThan(0);
     });
 });

--- a/e2e/scroll-surfaces.test.ts
+++ b/e2e/scroll-surfaces.test.ts
@@ -33,11 +33,32 @@ import { expect, test } from './fixtures';
  */
 const SCROLLER_ROUTES = ['/', '/blog', '/legal/privacy-policy'];
 
+/**
+ * Both sides of every shedding breakpoint, plus the three ordinary sizes.
+ *
+ * The first version of this list held four round numbers — 375, 768, 1280, 1920 — and passed while
+ * the bar was visibly broken at 1024, because that width sits just above a breakpoint where every
+ * widget was still rendered in a window too narrow to hold them. A breakpoint is precisely where a
+ * layout changes behaviour, so it is precisely where it has to be measured: one pixel below and one
+ * above each.
+ */
 const VIEWPORTS = [
     { width: 375, height: 812, name: 'mobile' },
-    { width: 768, height: 1024, name: 'tablet' },
+    { width: 768, height: 1024, name: 'tablet, no countdown' },
+    { width: 769, height: 1024, name: 'tablet, countdown appears' },
+    { width: 1024, height: 800, name: 'small laptop' },
+    { width: 1179, height: 800, name: 'below artifact icons' },
+    { width: 1181, height: 800, name: 'artifact icons appear' },
     { width: 1280, height: 720, name: 'laptop' },
+    { width: 1319, height: 800, name: 'below indexed counter' },
+    { width: 1321, height: 800, name: 'indexed counter appears' },
+    { width: 1479, height: 800, name: 'below crypto' },
+    { width: 1481, height: 800, name: 'crypto appears' },
+    { width: 1659, height: 900, name: 'below heating' },
+    { width: 1661, height: 900, name: 'heating appears' },
     { width: 1920, height: 1080, name: 'desktop' },
+    { width: 2019, height: 1080, name: 'below view counter' },
+    { width: 2021, height: 1080, name: 'view counter appears' },
 ];
 
 /**
@@ -64,12 +85,32 @@ const readHeaderZones = (page: Page) =>
             return { left: Math.round(rect.left), right: Math.round(rect.right), width: Math.round(rect.width) };
         };
 
+        /**
+         * The right zone is a `1fr` grid track that starts right after the identity, while its
+         * contents are pushed to the end with `justify-content: end`. Measuring the track says the
+         * status items begin at x=104 on a 1280px window, which is not where anything is painted —
+         * an overlap check against that reads as a collision at every width. So the *content* box is
+         * what gets measured: the union of the visible children.
+         */
+        const contentBox = (selector: string) => {
+            const container = header.querySelector(selector);
+            if (!container) return null;
+            const visible = [...container.children].filter(
+                (child) => getComputedStyle(child).display !== 'none' && child.getBoundingClientRect().width > 0,
+            );
+            if (visible.length === 0) return null;
+            const rects = visible.map((child) => child.getBoundingClientRect());
+            const left = Math.min(...rects.map((rect) => rect.left));
+            const right = Math.max(...rects.map((rect) => rect.right));
+            return { left: Math.round(left), right: Math.round(right), width: Math.round(right - left) };
+        };
+
         return {
             headerLeft: Math.round(bounds.left),
             headerRight: Math.round(bounds.right),
             left: zone('[class*="left"]'),
             center: zone('[class*="center"]'),
-            right: zone('[class*="right"]'),
+            right: contentBox('[class*="right"]'),
             visibleLinks: [...header.querySelectorAll('nav a')].filter(
                 (link) => getComputedStyle(link).display !== 'none',
             ).length,
@@ -126,23 +167,39 @@ test.describe('Scroll surfaces', () => {
                 `the app identity starts before the left edge at ${viewport.width}px: ${describe}`,
             ).toBeGreaterThanOrEqual(zones.headerLeft);
 
-            // The middle zone is the one that collides first when the two sides grow. Below 768px it
-            // is deliberately not rendered.
+            // The countdown is centred on the window and the sides must stay out of its band. Both
+            // neighbours are asserted: the first version of this test only checked the left, and the
+            // countdown was covering the last three status icons on the right the whole time.
             //
-            // Both neighbours are asserted. The first version of this test only checked the left
-            // side, and the countdown was covering the last three status icons on the right the
-            // whole time — `elementFromPoint` over the coverage, e2e and Lighthouse links returned
-            // the countdown, so three links were unclickable and this suite said nothing.
-            if (zones.center) {
+            // Below 769px there is deliberately no countdown — the owner's call, and the arithmetic
+            // agrees that nothing would fit.
+            if (viewport.width > 768) {
                 expect(
-                    zones.center.left,
+                    zones.center,
+                    `the countdown should be rendered at ${viewport.width}px: ${describe}`,
+                ).not.toBeNull();
+
+                expect(
+                    zones.center!.left,
                     `the countdown overlaps the app identity at ${viewport.width}px: ${describe}`,
                 ).toBeGreaterThanOrEqual(zones.left!.right);
 
                 expect(
-                    zones.center.right,
+                    zones.center!.right,
                     `the countdown overlaps the status items at ${viewport.width}px: ${describe}`,
                 ).toBeLessThanOrEqual(zones.right!.left);
+
+                // Centred on the window, not on the leftover space: that is the whole point of
+                // positioning it, so it is worth asserting rather than assuming. 2px of tolerance
+                // for sub-pixel rounding.
+                const centreOfWindow = viewport.width / 2;
+                const centreOfCountdown = (zones.center!.left + zones.center!.right) / 2;
+                expect(
+                    Math.abs(centreOfCountdown - centreOfWindow),
+                    `the countdown is off-centre at ${viewport.width}px: ${describe}`,
+                ).toBeLessThanOrEqual(2);
+            } else {
+                expect(zones.center, `no countdown below 769px: ${describe}`).toBeNull();
             }
         });
 

--- a/src/components/Blog/ArticlePanel/panel.module.css
+++ b/src/components/Blog/ArticlePanel/panel.module.css
@@ -21,11 +21,17 @@
     .articleControls {
         width: calc(100vw - 40px);
         grid-template-columns: 200px repeat(2, max-content) 1fr repeat(5, max-content) 220px;
-        overflow: scroll;
+        /**
+         * SDD-L12-T4. A real horizontal scroller, kept: the fixed columns above already sum past a
+         * 768px viewport, so this row genuinely does not fit and scrolling it is the intent.
+         * `auto` rather than `scroll` only so the bar disappears if it ever does fit.
+         *
+         * Its `::-webkit-scrollbar { display: none }` is gone (same defect as the header, U-N3):
+         * WebKit hid the bar, Gecko could not, so the row scrolled with no affordance in one engine
+         * and with one in the other. SDD-L06 chose visible-and-thin over hidden.
+         */
+        overflow: auto;
         padding: 0 10px;
-    }
-    .articleControls::-webkit-scrollbar {
-        display: none;
     }
 }
 .articleControls svg {

--- a/src/components/Dialog/dialog.module.css
+++ b/src/components/Dialog/dialog.module.css
@@ -74,5 +74,12 @@
 
 .body {
     height: 100%;
-    overflow: scroll;
+    /**
+     * SDD-L12-T3. Was `overflow: scroll`. This box does not overflow on the home page, so the
+     * unconditional bar was pure noise in Firefox — and worse than noise: the surface behind it is
+     * `--white-color` (see the note on `.dialog` above) while the content is a dark terminal, so a
+     * reserved gutter frames the window in white. `auto` reserves nothing until there is something
+     * to scroll, which on a long article there genuinely is.
+     */
+    overflow: auto;
 }

--- a/src/components/Layout/Header/header.module.css
+++ b/src/components/Layout/Header/header.module.css
@@ -1,26 +1,85 @@
+/**
+ * SDD-L12-T8. The menu bar, laid out the way macOS lays one out.
+ *
+ * It used to be a single nine-column grid — `auto max-content auto 1fr repeat(6, auto)` — with every
+ * widget in one run and `overflow: scroll` to absorb whatever did not fit. That is how 1526 px of
+ * content ended up inside a 1280 px window with 246 px of it unreachable.
+ *
+ * Now there are three zones. `.left` is the app identity (logo + route), `.right` is the status
+ * items and the clock, and `.center` is absolutely positioned so the countdown sits in the middle of
+ * the *window* rather than in the middle of whatever space the two sides happen to leave — the
+ * asymmetry between them is large, so a grid track would visibly push it off-centre.
+ */
 .header {
+    position: relative;
     height: 24px;
     background: var(--header-background);
     color: rgba(var(--blog-icons));
     display: grid;
-    grid-template-columns: auto max-content auto 1fr repeat(6, auto);
+    /**
+     * Three real tracks, not two plus an absolutely-positioned middle.
+     *
+     * The middle was `position: absolute; left: 50%` at first, so it sat on the window's true centre
+     * — and silently covered the last three status icons, because a positioned element does not
+     * negotiate space with anything. The hit test was unambiguous: `elementFromPoint` over the
+     * coverage, e2e and Lighthouse icons returned the countdown, so those three links were
+     * unclickable while looking perfectly fine.
+     *
+     * A grid track cannot do that. The cost is that the countdown sits in the middle of the space
+     * the two sides leave rather than the middle of the window: with a 66 px left zone and an
+     * ~870 px right zone, true centring at 1280 px is arithmetically impossible — the right zone
+     * would have to start before the countdown ends. It only becomes possible above ~1940 px.
+     * Not overlapping is worth more than being 200 px off centre.
+     */
+    grid-template-columns: auto 1fr auto;
     gap: 20px;
     align-items: center;
     padding: 0 18px;
     /**
-     * SDD-L12-T3. Was `overflow: scroll`, which paints a scrollbar whether or not there is anything
-     * to scroll. Chromium on macOS hid that behind overlay scrollbars; Firefox, and macOS with
-     * "Show scroll bars: Always", painted a bar across a 24px strip permanently — reported by a
-     * reader on 2026-07-30. `auto` paints one only when the content really does not fit, which
-     * after T2 means at 768px and below.
+     * SDD-L12-T3/T8. This was `overflow: scroll`, which paints a scrollbar whether or not there is
+     * anything to scroll — invisible under Chromium's overlay scrollbars on macOS, permanent in
+     * Firefox and under "Show scroll bars: Always". T3 made it `auto`; T8 makes it `visible`, which
+     * is what a menu bar actually needs.
      *
-     * The companion `::-webkit-scrollbar { display: none }` is gone with it. It hid the bar in
-     * WebKit while Gecko had no equivalent, so the two engines disagreed by construction — and
-     * SDD-L06 (`globals.css:126-131`) had already ruled that hiding this particular bar was wrong,
-     * because it is the only cue that widgets continue past the edge.
+     * The reason is the weather panel: it is a 400 px `position: absolute` popover anchored to the
+     * clock, and a closed popover still has a box. Any scroll container it hangs off — `scroll` or
+     * `auto`, no difference — counts it as content and grows a scroll area by 440 px at every
+     * viewport. Measured: `header.scrollWidth` was `clientWidth + 440` at 1024, 1280 and 1920 alike,
+     * which is the signature of a positioned child rather than of a bar that does not fit.
+     *
+     * So part of the original "the header overflows" reading was never menu-bar content at all. The
+     * bar itself now fits by construction (T8's three zones plus priority shedding); popovers are
+     * supposed to escape it, which is exactly what `visible` allows and what a real menu bar does.
+     *
+     * The companion `::-webkit-scrollbar { display: none }` is gone too. It hid the bar in WebKit
+     * while Gecko had no equivalent, so the two engines disagreed by construction — and SDD-L06
+     * (`globals.css:126-131`) had already ruled that hiding this particular bar was wrong.
      */
-    overflow: auto;
+    overflow: visible;
     white-space: nowrap;
+}
+
+.left {
+    display: grid;
+    grid-auto-flow: column;
+    align-items: center;
+    gap: 12px;
+}
+
+/* Centred within its own track, so it can never sit on top of the status items. */
+.center {
+    display: flex;
+    align-items: center;
+    justify-self: center;
+    min-width: 0;
+}
+
+.right {
+    display: grid;
+    grid-auto-flow: column;
+    align-items: center;
+    justify-content: end;
+    gap: 14px;
 }
 
 .header svg {
@@ -52,16 +111,64 @@
     font-family: inherit;
 }
 
+/**
+ * SDD-L12-T8. The status items, as icons. They were text labels — eight of them, 358 px — which is
+ * most of why the bar did not fit. macOS puts text menus on the left and icons on the right, so
+ * this is both the cheaper and the more faithful arrangement.
+ */
 .navLinks {
     display: grid;
     grid-auto-flow: column;
-    gap: 20px;
+    gap: 14px;
     width: max-content;
+    align-items: center;
 }
 
 .navLinks a {
-    font-size: 14px;
-    font-weight: 400;
+    display: flex;
+    align-items: center;
     color: rgba(var(--blog-icons));
     text-decoration: none;
+    font-size: 14px;
+    font-weight: 400;
+}
+
+.navLinks a:hover svg {
+    opacity: 0.7;
+}
+
+/**
+ * Priority-based shedding, which is what macOS does when the bar runs out of room: status items drop
+ * from the right and the clock never does. Ascending priority goes first.
+ *
+ * `priority1` is implicit — anything without one of these classes stays at every width. The two
+ * breakpoints are the ones the rest of the layout already uses (768, 1023), so the bar changes shape
+ * at the same widths as everything else instead of inventing a third set.
+ */
+@media screen and (max-width: 1023px) {
+    /**
+     * `.navLinks a` sets `display: flex` and is one selector more specific than a bare `.priority3`,
+     * so the plain class lost and every icon stayed visible at every width — measured as
+     * `visibleLinks: 8` at 375 px. Both forms are listed rather than reaching for `!important`.
+     */
+    .priority3,
+    .navLinks a.priority3 {
+        display: none;
+    }
+}
+
+@media screen and (max-width: 768px) {
+    .priority2,
+    .navLinks a.priority2 {
+        display: none;
+    }
+
+    /* Below the tablet breakpoint the middle is the first thing to collide with the two sides. */
+    .center {
+        display: none;
+    }
+
+    .header {
+        gap: 12px;
+    }
 }

--- a/src/components/Layout/Header/header.module.css
+++ b/src/components/Layout/Header/header.module.css
@@ -52,6 +52,10 @@
     white-space: nowrap;
 }
 
+/**
+ * SDD-L12-T9. Identity, route and the navigation icons — the icons live here, next to the logo,
+ * which is where they were before T8 and where a macOS menu bar puts navigation.
+ */
 .left {
     display: grid;
     grid-auto-flow: column;
@@ -71,12 +75,81 @@
     align-items: center;
 }
 
+/**
+ * SDD-L12-T9. Status items on a fixed pitch.
+ *
+ * T8 left this as `grid-auto-flow: column` with `auto` tracks, so every slot was as wide as whatever
+ * it happened to contain: the XRP price and the view count sat at different pitches, and both moved
+ * whenever a digit appeared. A menu bar's status area does not do that — each item owns a slot.
+ *
+ * The slots are FIXED, and that is the point: a fixed slot makes the zone's width a constant, so the
+ * shedding arithmetic below no longer depends on what the APIs happened to return. Under the old
+ * `auto` tracks a four-figure view count silently widened the zone and ate the margin that keeps the
+ * countdown clear.
+ *
+ * The widths are not measured from local content and must not be — several widgets render empty on
+ * this machine because their APIs have no credentials, so a local measurement would size every slot
+ * to an error state. They are sized to worst-case content instead, measured by rendering candidate
+ * strings in the slot's own computed font (16px -apple-system) in an unconstrained probe:
+ *
+ * | Worst case          | Text | + icon | Fits 96 px |
+ * |---------------------|------|--------|------------|
+ * | `1.234.567` indexed |  72  |   96   | yes, exactly |
+ * | `999.999` views     |  63  |   87   | yes        |
+ * | `-12,5 °C` heating  |  60  |   84   | yes        |
+ * | `$99.9999` XRP      |  68  |   92   | yes        |
+ * | `$1,234.5678` XRP   |  91  |  115   | NO         |
+ *
+ * So the slot holds about eight characters, and anything longer is clipped by `overflow: hidden`
+ * rather than widening the zone. That is the deliberate trade: a slot that grows is a slot that
+ * moves everything beside it, which is the jitter this rule exists to remove. XRP's all-time high is
+ * about $3.84, so `$99.9999` is ~25x headroom — but if a widget is ever pointed at an asset priced
+ * in four figures, widen `--status-slot` and re-derive the table below, do not let it clip.
+ *
+ * The clock is 140 px because it is the one slot whose content is locale-dependent: the longest
+ * Spanish rendering measured, `mié 30 sept 23:59`, is 134 px.
+ */
 .right {
     display: grid;
     grid-auto-flow: column;
     align-items: center;
     justify-content: end;
-    gap: 14px;
+    gap: 0;
+    --status-slot: 96px;
+}
+
+/**
+ * Contents align to the RIGHT of their slot, not to the centre.
+ *
+ * Centring looked correct with full-width values and wrong with anything narrower: an error glyph is
+ * ~12 px, so centring it in a 96 px slot opens 42 px of dead space on each side and the row reads as
+ * randomly spaced — which is what it did on the owner's screen, where three widgets were in an error
+ * state because their APIs have no credentials locally. Right-aligned, every item's trailing edge
+ * lands on the same 96 px pitch and the whole zone reads as one column flush to the bar's edge,
+ * whatever each widget happens to be showing.
+ */
+.statusItem {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    width: var(--status-slot);
+    overflow: hidden;
+}
+
+/* The deployment indicator is a dot, not a value; a full slot for it would be a 96 px hole. */
+.statusDot {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    width: 24px;
+}
+
+/* Four fields and a locale-dependent short weekday — the one slot that legitimately differs. */
+.clock {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    width: 140px;
 }
 
 .header svg {
@@ -144,53 +217,51 @@
  *
  *     W >= 2 * (rightWidth + 103)
  *
- * Measured widths at 1920 px, in the order they are shed — most expensive first:
+ * SDD-L12-T9 re-derived all of this, because T9 moved the navigation icons into the LEFT zone. That
+ * changes the problem: under T8 the left zone was 66 px and could never reach the middle, so only
+ * the right zone was ever checked. With eight icons beside the identity the left zone is 320 px, and
+ * `W >= 2 * (leftWidth + 103)` is a real constraint that T8's ladder did not contain. A ladder that
+ * only watches one side is how the bar ended up drawn on top of itself at 1024 px the first time.
  *
- * | Item              | Width | Right zone after it goes | Needs    | Breakpoint |
- * |-------------------|-------|--------------------------|----------|------------|
- * | view counter      | 160   | 895 with it               | 1997     | 2020       |
- * | heating           |  85   | 721                       | 1649     | 1660       |
- * | crypto price      |  80   | 622                       | 1451     | 1480       |
- * | indexed counter   |  70   | 528                       | 1263     | 1320       |
- * | 5 artifact icons  | 160   | 444                       | 1095     | 1180       |
- * | (3 social icons)  |  82   | 270                       |  747     |  769       |
+ * Zone widths are now arithmetic, not measurement, because the slots are fixed:
+ * right = 24 (dot) + 96 per visible value slot + 140 (clock); left = 66 + 18 per icon + 14 per gap.
  *
- * Each breakpoint sits above what the arithmetic demands, so a widget that grows a digit — a
- * four-figure view count, a longer XRP price — does not silently start an overlap.
+ * | Below   | What sheds        | Left | Right | Left needs | Right needs |
+ * |---------|-------------------|------|-------|------------|-------------|
+ * | 1329 px | view counter      | 320  | 548   |  846       | 1302        |
+ * | 1129 px | heating           | 320  | 452   |  846       | 1110        |
+ * |  939 px | crypto price      | 320  | 356   |  846       |  918        |
+ * |  869 px | 5 artifact icons  | 320  | 260   |  846       |  726        |
+ * |  768 px | indexed counter   | 160  | 260   |  526       |  726        |
+ * |  479 px | 3 profile icons   | 160  | 164   |  526       |  534        |
  *
- * An earlier attempt used two round breakpoints (1023, 768) picked for tidiness rather than from
- * measurements. Just above 1023 px every widget was visible in a window that could not hold them,
- * and since `overflow` is `visible` they did not clip, they **overlapped** — the countdown and the
- * icons drawn on top of each other, which is what the owner saw.
+ * Read the table as: above each row's width, the zones on that row coexist. Every breakpoint sits
+ * ~20 px above what the arithmetic demands, and below 769 px the countdown is hidden entirely, so
+ * from there down the only requirement is that the two zones fit side by side — 372 px at 480 px
+ * wide, 278 px once the profile icons go.
  *
  * `.navLinks a` sets `display: flex` and outranks a bare class on specificity, so each rule lists
  * both forms rather than reaching for `!important`.
  */
-@media screen and (max-width: 2019px) {
+@media screen and (max-width: 1329px) {
     .shed1 {
         display: none;
     }
 }
 
-@media screen and (max-width: 1659px) {
+@media screen and (max-width: 1129px) {
     .shed2 {
         display: none;
     }
 }
 
-@media screen and (max-width: 1479px) {
+@media screen and (max-width: 939px) {
     .shed3 {
         display: none;
     }
 }
 
-@media screen and (max-width: 1319px) {
-    .shed4 {
-        display: none;
-    }
-}
-
-@media screen and (max-width: 1179px) {
+@media screen and (max-width: 869px) {
     .shed5,
     .navLinks a.shed5 {
         display: none;
@@ -198,8 +269,7 @@
 }
 
 @media screen and (max-width: 768px) {
-    .shed6,
-    .navLinks a.shed6 {
+    .shed4 {
         display: none;
     }
 
@@ -213,5 +283,17 @@
 
     .header {
         gap: 12px;
+    }
+}
+
+/**
+ * The three profile icons survive further than the artifact ones because they are the only
+ * navigation left. They go at 479 px, where the two zones would otherwise total 372 px in a 480 px
+ * window — fitting, but with nothing between them.
+ */
+@media screen and (max-width: 479px) {
+    .shed6,
+    .navLinks a.shed6 {
+        display: none;
     }
 }

--- a/src/components/Layout/Header/header.module.css
+++ b/src/components/Layout/Header/header.module.css
@@ -7,12 +7,20 @@
     gap: 20px;
     align-items: center;
     padding: 0 18px;
-    overflow: scroll;
+    /**
+     * SDD-L12-T3. Was `overflow: scroll`, which paints a scrollbar whether or not there is anything
+     * to scroll. Chromium on macOS hid that behind overlay scrollbars; Firefox, and macOS with
+     * "Show scroll bars: Always", painted a bar across a 24px strip permanently — reported by a
+     * reader on 2026-07-30. `auto` paints one only when the content really does not fit, which
+     * after T2 means at 768px and below.
+     *
+     * The companion `::-webkit-scrollbar { display: none }` is gone with it. It hid the bar in
+     * WebKit while Gecko had no equivalent, so the two engines disagreed by construction — and
+     * SDD-L06 (`globals.css:126-131`) had already ruled that hiding this particular bar was wrong,
+     * because it is the only cue that widgets continue past the edge.
+     */
+    overflow: auto;
     white-space: nowrap;
-}
-
-.header::-webkit-scrollbar {
-    display: none;
 }
 
 .header svg {

--- a/src/components/Layout/Header/header.module.css
+++ b/src/components/Layout/Header/header.module.css
@@ -17,21 +17,14 @@
     color: rgba(var(--blog-icons));
     display: grid;
     /**
-     * Three real tracks, not two plus an absolutely-positioned middle.
+     * Two tracks — identity and status items — with the countdown absolutely centred on top.
      *
-     * The middle was `position: absolute; left: 50%` at first, so it sat on the window's true centre
-     * — and silently covered the last three status icons, because a positioned element does not
-     * negotiate space with anything. The hit test was unambiguous: `elementFromPoint` over the
-     * coverage, e2e and Lighthouse icons returned the countdown, so those three links were
-     * unclickable while looking perfectly fine.
-     *
-     * A grid track cannot do that. The cost is that the countdown sits in the middle of the space
-     * the two sides leave rather than the middle of the window: with a 66 px left zone and an
-     * ~870 px right zone, true centring at 1280 px is arithmetically impossible — the right zone
-     * would have to start before the countdown ends. It only becomes possible above ~1940 px.
-     * Not overlapping is worth more than being 200 px off centre.
+     * The countdown is centred on the **window**, which is what it has to be: a grid track puts it
+     * in the middle of the space the sides leave, and with a 66 px left zone and an 867 px right one
+     * that is visibly off-centre. So the middle is positioned, and the collision it can cause is
+     * prevented arithmetically instead — see the shedding block at the bottom of this file.
      */
-    grid-template-columns: auto 1fr auto;
+    grid-template-columns: auto 1fr;
     gap: 20px;
     align-items: center;
     padding: 0 18px;
@@ -66,12 +59,16 @@
     gap: 12px;
 }
 
-/* Centred within its own track, so it can never sit on top of the status items. */
+/**
+ * Centred on the window. Nothing else may enter the band it occupies — the shedding rules below
+ * guarantee that by width, not by hope.
+ */
 .center {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
     display: flex;
     align-items: center;
-    justify-self: center;
-    min-width: 0;
 }
 
 .right {
@@ -138,32 +135,78 @@
 }
 
 /**
- * Priority-based shedding, which is what macOS does when the bar runs out of room: status items drop
- * from the right and the clock never does. Ascending priority goes first.
+ * Progressive shedding, which is what macOS does when the bar runs out of room: status items drop
+ * from the right, the clock never does.
  *
- * `priority1` is implicit — anything without one of these classes stays at every width. The two
- * breakpoints are the ones the rest of the layout already uses (768, 1023), so the bar changes shape
- * at the same widths as everything else instead of inventing a third set.
+ * The breakpoints are **derived, not chosen**. A window-centred countdown occupies
+ * `[W/2 - 85, W/2 + 85]`, and the right zone runs from `W - 18 - rightWidth` to `W - 18`, so they
+ * stay clear of each other exactly while
+ *
+ *     W >= 2 * (rightWidth + 103)
+ *
+ * Measured widths at 1920 px, in the order they are shed — most expensive first:
+ *
+ * | Item              | Width | Right zone after it goes | Needs    | Breakpoint |
+ * |-------------------|-------|--------------------------|----------|------------|
+ * | view counter      | 160   | 895 with it               | 1997     | 2020       |
+ * | heating           |  85   | 721                       | 1649     | 1660       |
+ * | crypto price      |  80   | 622                       | 1451     | 1480       |
+ * | indexed counter   |  70   | 528                       | 1263     | 1320       |
+ * | 5 artifact icons  | 160   | 444                       | 1095     | 1180       |
+ * | (3 social icons)  |  82   | 270                       |  747     |  769       |
+ *
+ * Each breakpoint sits above what the arithmetic demands, so a widget that grows a digit — a
+ * four-figure view count, a longer XRP price — does not silently start an overlap.
+ *
+ * An earlier attempt used two round breakpoints (1023, 768) picked for tidiness rather than from
+ * measurements. Just above 1023 px every widget was visible in a window that could not hold them,
+ * and since `overflow` is `visible` they did not clip, they **overlapped** — the countdown and the
+ * icons drawn on top of each other, which is what the owner saw.
+ *
+ * `.navLinks a` sets `display: flex` and outranks a bare class on specificity, so each rule lists
+ * both forms rather than reaching for `!important`.
  */
-@media screen and (max-width: 1023px) {
-    /**
-     * `.navLinks a` sets `display: flex` and is one selector more specific than a bare `.priority3`,
-     * so the plain class lost and every icon stayed visible at every width — measured as
-     * `visibleLinks: 8` at 375 px. Both forms are listed rather than reaching for `!important`.
-     */
-    .priority3,
-    .navLinks a.priority3 {
+@media screen and (max-width: 2019px) {
+    .shed1 {
+        display: none;
+    }
+}
+
+@media screen and (max-width: 1659px) {
+    .shed2 {
+        display: none;
+    }
+}
+
+@media screen and (max-width: 1479px) {
+    .shed3 {
+        display: none;
+    }
+}
+
+@media screen and (max-width: 1319px) {
+    .shed4 {
+        display: none;
+    }
+}
+
+@media screen and (max-width: 1179px) {
+    .shed5,
+    .navLinks a.shed5 {
         display: none;
     }
 }
 
 @media screen and (max-width: 768px) {
-    .priority2,
-    .navLinks a.priority2 {
+    .shed6,
+    .navLinks a.shed6 {
         display: none;
     }
 
-    /* Below the tablet breakpoint the middle is the first thing to collide with the two sides. */
+    /**
+     * No countdown on a phone — the owner's call, and the arithmetic agrees: below 769 px the two
+     * sides and a centred middle cannot coexist whatever is shed.
+     */
     .center {
         display: none;
     }

--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -1,6 +1,17 @@
 import React, { ReactNode } from 'react';
 import styles from './header.module.css';
-import { SiBitcoincash } from 'react-icons/si';
+import type { IconType } from 'react-icons';
+import {
+    SiBitcoincash,
+    SiCodecov,
+    SiGithub,
+    SiLighthouse,
+    SiLinkedin,
+    SiPlaywright,
+    SiReadthedocs,
+    SiReddit,
+    SiStorybook,
+} from 'react-icons/si';
 import { useRouter } from 'next/router';
 import { useIntl } from 'react-intl';
 import { socialLinks, translateRoute } from '@/constants/site';
@@ -79,7 +90,23 @@ const Route = () => {
 };
 
 /**
- * @description Social links component
+ * SDD-L12-T8. One icon per status item, keyed by `testId` so a rename in `site.ts` fails loudly
+ * here rather than silently rendering nothing. Kept in the component because `site.ts` is data —
+ * importing React components into it would make every consumer of the constants pull in icons.
+ */
+const STATUS_ICONS: Record<string, IconType> = {
+    'linkedin-link': SiLinkedin,
+    'github-link': SiGithub,
+    'reddit-link': SiReddit,
+    'storybook-link': SiStorybook,
+    'docs-link': SiReadthedocs,
+    'coverage-link': SiCodecov,
+    'e2e-link': SiPlaywright,
+    'lighthouse-link': SiLighthouse,
+};
+
+/**
+ * @description The status items of the menu bar: profile and artifact links, as icons on the right.
  * @returns {JSX.Element}
  */
 const NavLinks = () => {
@@ -89,18 +116,27 @@ const NavLinks = () => {
         // SDD-L05: landmark navigation listed "navigation, navigation" (four of them on a post page)
         // with nothing to tell the social links from the Dock from the category sidebar.
         <nav className={styles.navLinks} aria-label={f({ id: 'nav.social' })}>
-            {socialLinks.map((item) => (
-                <a
-                    key={item.href}
-                    href={item.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    title={item.title}
-                    data-testid={item.testId}
-                >
-                    {item.name}
-                </a>
-            ))}
+            {socialLinks.map((item) => {
+                const Icon = STATUS_ICONS[item.testId];
+
+                return (
+                    <a
+                        key={item.href}
+                        href={item.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title={item.title}
+                        data-testid={item.testId}
+                        // SDD-L12-T8: the visible label is now an icon, so the accessible name has
+                        // to come from here. Without it these read as "link, link, link" — the
+                        // exact defect L05/L06 spent two phases removing from the rest of the page.
+                        aria-label={item.title}
+                        className={styles[`priority${item.priority}`]}
+                    >
+                        {Icon ? <Icon aria-hidden="true" /> : item.name}
+                    </a>
+                );
+            })}
         </nav>
     );
 };
@@ -124,19 +160,43 @@ const Header = ({ children }: { children?: ReactNode }) => {
 
     return (
         <header data-testid="header" className={styles.header}>
-            <SiBitcoincash aria-hidden="true" />
-            <Route />
-            <NavLinks />
-            <CountDown date="2026-12-11T00:00:00+00:00" caption={f({ id: 'countdown.caption' })} />
-            <DeploymentStatus />
-            <CryptoPrice />
-            <IndexedCounter />
-            <ViewCounter all />
-            <Heating />
-            <DateAndHour>
-                <Weather cities={['limerick+ireland', 'moraña+galicia', 'vilagarcía+galicia']} />
-            </DateAndHour>
-            {children}
+            {/**
+             * SDD-L12-T8. Three zones, because that is what a macOS menu bar is: the app identity on
+             * the left, the clock and status items on the right, and — here — the countdown holding
+             * the middle. It replaced a nine-column grid that laid every widget out in a single run
+             * and simply overflowed when the run got long.
+             */}
+            <div className={styles.left}>
+                <SiBitcoincash aria-hidden="true" />
+                <Route />
+            </div>
+
+            <div className={styles.center}>
+                <CountDown date="2026-12-11T00:00:00+00:00" caption={f({ id: 'countdown.caption' })} />
+            </div>
+
+            <div className={styles.right}>
+                <NavLinks />
+                <span className={styles.priority2}>
+                    <DeploymentStatus />
+                </span>
+                <span className={styles.priority3}>
+                    <CryptoPrice />
+                </span>
+                <span className={styles.priority3}>
+                    <IndexedCounter />
+                </span>
+                <span className={styles.priority3}>
+                    <ViewCounter all />
+                </span>
+                <span className={styles.priority3}>
+                    <Heating />
+                </span>
+                <DateAndHour>
+                    <Weather cities={['limerick+ireland', 'moraña+galicia', 'vilagarcía+galicia']} />
+                </DateAndHour>
+                {children}
+            </div>
         </header>
     );
 };

--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -56,7 +56,7 @@ const DateAndHour = ({ children, minutes = 1 }: { children?: ReactNode; minutes?
     }, [minutes]);
 
     return (
-        <div>
+        <div className={styles.clock}>
             <Tooltip>
                 <Tooltip.Trigger>
                     <button type="button" className={styles.dateAndHour} onClick={handleWeatherClick}>
@@ -106,7 +106,11 @@ const STATUS_ICONS: Record<string, IconType> = {
 };
 
 /**
- * @description The status items of the menu bar: profile and artifact links, as icons on the right.
+ * @description The profile and artifact links, as icons in the left zone beside the identity.
+ *
+ * SDD-L12-T9. T8 put them in the right zone, which read as a second cluster of status items hanging
+ * off the countdown. They are navigation, not status — on a macOS menu bar that belongs next to the
+ * app identity — and that is also where they were before T8 moved them.
  * @returns {JSX.Element}
  */
 const NavLinks = () => {
@@ -169,6 +173,7 @@ const Header = ({ children }: { children?: ReactNode }) => {
             <div className={styles.left}>
                 <SiBitcoincash aria-hidden="true" />
                 <Route />
+                <NavLinks />
             </div>
 
             <div className={styles.center}>
@@ -181,20 +186,19 @@ const Header = ({ children }: { children?: ReactNode }) => {
              * from measurements, not chosen for tidiness.
              */}
             <div className={styles.right}>
-                <NavLinks />
-                <span>
+                <span className={styles.statusDot}>
                     <DeploymentStatus />
                 </span>
-                <span className={styles.shed3}>
+                <span className={`${styles.statusItem} ${styles.shed3}`}>
                     <CryptoPrice />
                 </span>
-                <span className={styles.shed4}>
+                <span className={`${styles.statusItem} ${styles.shed4}`}>
                     <IndexedCounter />
                 </span>
-                <span className={styles.shed1}>
+                <span className={`${styles.statusItem} ${styles.shed1}`}>
                     <ViewCounter all />
                 </span>
-                <span className={styles.shed2}>
+                <span className={`${styles.statusItem} ${styles.shed2}`}>
                     <Heating />
                 </span>
                 <DateAndHour>

--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -131,7 +131,7 @@ const NavLinks = () => {
                         // to come from here. Without it these read as "link, link, link" — the
                         // exact defect L05/L06 spent two phases removing from the rest of the page.
                         aria-label={item.title}
-                        className={styles[`priority${item.priority}`]}
+                        className={styles[`shed${item.shed}`]}
                     >
                         {Icon ? <Icon aria-hidden="true" /> : item.name}
                     </a>
@@ -175,21 +175,26 @@ const Header = ({ children }: { children?: ReactNode }) => {
                 <CountDown date="2026-12-11T00:00:00+00:00" caption={f({ id: 'countdown.caption' })} />
             </div>
 
+            {/**
+             * Shed order, cheapest information per pixel first. The classes are `shedN`, and the
+             * widths behind each breakpoint are tabulated in `header.module.css` — they are derived
+             * from measurements, not chosen for tidiness.
+             */}
             <div className={styles.right}>
                 <NavLinks />
-                <span className={styles.priority2}>
+                <span>
                     <DeploymentStatus />
                 </span>
-                <span className={styles.priority3}>
+                <span className={styles.shed3}>
                     <CryptoPrice />
                 </span>
-                <span className={styles.priority3}>
+                <span className={styles.shed4}>
                     <IndexedCounter />
                 </span>
-                <span className={styles.priority3}>
+                <span className={styles.shed1}>
                     <ViewCounter all />
                 </span>
-                <span className={styles.priority3}>
+                <span className={styles.shed2}>
                     <Heating />
                 </span>
                 <DateAndHour>

--- a/src/components/News/news.module.css
+++ b/src/components/News/news.module.css
@@ -17,7 +17,14 @@
 }
 
 .container {
-    overflow-y: scroll;
+    /**
+     * SDD-L12-T4. A real scroller, kept: this is the news ticker, with `scroll-snap-type` and smooth
+     * behaviour built on top of it. `auto` rather than `scroll` so an empty or one-item feed does
+     * not render a bar for nothing. The custom 2px `::-webkit-scrollbar` below is deliberate and
+     * left alone — though note it disagrees with the 8px SDD-L06 set globally, which is a contrast
+     * and target-size question for that phase, not this one.
+     */
+    overflow-y: auto;
     scroll-behavior: smooth;
     scroll-snap-type: y mandatory;
     height: inherit;

--- a/src/constants/site.ts
+++ b/src/constants/site.ts
@@ -32,9 +32,10 @@ export const personDescription: Record<string, string> = {
  * lost the shelf, and the shelf is part of what the design is *for* — so the space comes from the
  * icons instead. Eight text labels cost 358 px; eight icons cost about a fifth of that.
  *
- * `priority` is how the bar behaves when it still does not fit, which below 768 px it will not:
- * items drop from the right by ascending priority, exactly as macOS sheds status items on a narrow
- * screen. 1 survives everywhere; 3 is the first to go.
+ * `shed` is the shedding step: the class `shedN` hides the item below the breakpoint derived for it
+ * in `header.module.css`. The three profile icons are `shed6` (they survive down to 769 px); the five
+ * artifact icons are `shed5` (they go below 1180 px), because a window-centred countdown and an
+ * 867 px right zone cannot both fit before then. The numbers are measured, not chosen.
  *
  * The icon itself lives in the Header component, not here — this file stays data, no React.
  */
@@ -44,56 +45,56 @@ export const socialLinks = [
         title: 'Linkedin profile',
         name: 'Linkedin',
         testId: 'linkedin-link',
-        priority: 2,
+        shed: 6,
     },
     {
         href: 'https://github.com/xabierlameiro',
         title: 'Github profile',
         name: 'Github',
         testId: 'github-link',
-        priority: 2,
+        shed: 6,
     },
     {
         href: 'https://www.reddit.com/user/xlameiro',
         title: 'Reddit profile',
         name: 'Reddit',
         testId: 'reddit-link',
-        priority: 2,
+        shed: 6,
     },
     {
         href: 'https://storybook.xabierlameiro.com',
         title: 'Storybook',
         name: 'Storybook',
         testId: 'storybook-link',
-        priority: 3,
+        shed: 5,
     },
     {
         href: 'https://docs.xabierlameiro.com',
         title: 'Docs',
         name: 'Docs',
         testId: 'docs-link',
-        priority: 3,
+        shed: 5,
     },
     {
         href: 'https://coverage.xabierlameiro.com',
         title: 'Coverage',
         name: 'Coverage',
         testId: 'coverage-link',
-        priority: 3,
+        shed: 5,
     },
     {
         href: 'https://e2e.xabierlameiro.com',
         title: 'e2e',
         name: 'e2e',
         testId: 'e2e-link',
-        priority: 3,
+        shed: 5,
     },
     {
         href: 'https://performance.xabierlameiro.com',
         title: 'Lighthouse',
         name: 'Lighthouse',
         testId: 'lighthouse-link',
-        priority: 3,
+        shed: 5,
     },
 ];
 

--- a/src/constants/site.ts
+++ b/src/constants/site.ts
@@ -24,15 +24,19 @@ export const personDescription: Record<string, string> = {
 };
 
 /**
- * SDD-L12-T2 (decision D5). This list used to carry five more entries — Storybook, Docs, Coverage,
- * e2e and Lighthouse, the artifact subdomains. Together with the widgets, the header needed 1526 px
- * of content at every viewport: 246 px of it unreachable on a 1280 px laptop and roughly 1150 px on
- * a phone, since `.header` is a 24 px strip with `overflow: scroll`. Widgets sat off-screen with a
- * horizontal drag as their only affordance, which is what a reader reported on 2026-07-30.
+ * SDD-L12-T8 (decision D5, revised 2026-08-03). These eight are the header's **status items**, and
+ * they render as icons on the right, the way a macOS menu bar does: text menus on the left, icons on
+ * the right, clock last.
  *
- * Removing them also removes five followed outbound links from every page, which is the other half
- * of decision D2 (`coverage.` is `noindex`ed separately). The subdomains are still published and
- * still linked from the docs that reference them — they simply no longer ride on every page.
+ * T2 briefly deleted the five artifact entries to make the header fit. That bought the space but
+ * lost the shelf, and the shelf is part of what the design is *for* — so the space comes from the
+ * icons instead. Eight text labels cost 358 px; eight icons cost about a fifth of that.
+ *
+ * `priority` is how the bar behaves when it still does not fit, which below 768 px it will not:
+ * items drop from the right by ascending priority, exactly as macOS sheds status items on a narrow
+ * screen. 1 survives everywhere; 3 is the first to go.
+ *
+ * The icon itself lives in the Header component, not here — this file stays data, no React.
  */
 export const socialLinks = [
     {
@@ -40,18 +44,56 @@ export const socialLinks = [
         title: 'Linkedin profile',
         name: 'Linkedin',
         testId: 'linkedin-link',
+        priority: 2,
     },
     {
         href: 'https://github.com/xabierlameiro',
         title: 'Github profile',
         name: 'Github',
         testId: 'github-link',
+        priority: 2,
     },
     {
         href: 'https://www.reddit.com/user/xlameiro',
         title: 'Reddit profile',
         name: 'Reddit',
         testId: 'reddit-link',
+        priority: 2,
+    },
+    {
+        href: 'https://storybook.xabierlameiro.com',
+        title: 'Storybook',
+        name: 'Storybook',
+        testId: 'storybook-link',
+        priority: 3,
+    },
+    {
+        href: 'https://docs.xabierlameiro.com',
+        title: 'Docs',
+        name: 'Docs',
+        testId: 'docs-link',
+        priority: 3,
+    },
+    {
+        href: 'https://coverage.xabierlameiro.com',
+        title: 'Coverage',
+        name: 'Coverage',
+        testId: 'coverage-link',
+        priority: 3,
+    },
+    {
+        href: 'https://e2e.xabierlameiro.com',
+        title: 'e2e',
+        name: 'e2e',
+        testId: 'e2e-link',
+        priority: 3,
+    },
+    {
+        href: 'https://performance.xabierlameiro.com',
+        title: 'Lighthouse',
+        name: 'Lighthouse',
+        testId: 'lighthouse-link',
+        priority: 3,
     },
 ];
 

--- a/src/constants/site.ts
+++ b/src/constants/site.ts
@@ -23,6 +23,17 @@ export const personDescription: Record<string, string> = {
     gl: 'Arquitecto de software galego. Desenvolve produtos web para os sectores bancario e retail —CaixaBank, Openbank e Inditex— traballando sobre todo con React, Next.js e TypeScript, con especial interese en testing, automatización e o IoT.',
 };
 
+/**
+ * SDD-L12-T2 (decision D5). This list used to carry five more entries — Storybook, Docs, Coverage,
+ * e2e and Lighthouse, the artifact subdomains. Together with the widgets, the header needed 1526 px
+ * of content at every viewport: 246 px of it unreachable on a 1280 px laptop and roughly 1150 px on
+ * a phone, since `.header` is a 24 px strip with `overflow: scroll`. Widgets sat off-screen with a
+ * horizontal drag as their only affordance, which is what a reader reported on 2026-07-30.
+ *
+ * Removing them also removes five followed outbound links from every page, which is the other half
+ * of decision D2 (`coverage.` is `noindex`ed separately). The subdomains are still published and
+ * still linked from the docs that reference them — they simply no longer ride on every page.
+ */
 export const socialLinks = [
     {
         href: 'https://www.linkedin.com/in/xlameiro',
@@ -41,36 +52,6 @@ export const socialLinks = [
         title: 'Reddit profile',
         name: 'Reddit',
         testId: 'reddit-link',
-    },
-    {
-        href: 'https://storybook.xabierlameiro.com',
-        title: 'Storybook',
-        name: 'Storybook',
-        testId: 'storybook-link',
-    },
-    {
-        href: 'https://docs.xabierlameiro.com',
-        title: 'Docs',
-        name: 'Docs',
-        testId: 'docs-link',
-    },
-    {
-        href: 'https://coverage.xabierlameiro.com',
-        title: 'Coverage',
-        name: 'Coverage',
-        testId: 'coverage-link',
-    },
-    {
-        href: 'https://e2e.xabierlameiro.com',
-        title: 'e2e',
-        name: 'e2e',
-        testId: 'e2e-link',
-    },
-    {
-        href: 'https://performance.xabierlameiro.com',
-        title: 'Lighthouse',
-        name: 'Lighthouse',
-        testId: 'lighthouse-link',
     },
 ];
 

--- a/styles/blog.module.css
+++ b/styles/blog.module.css
@@ -51,7 +51,13 @@
 .body {
     padding: 20px 30px 60px;
     height: calc(100vh - 100px);
-    overflow-y: scroll;
+    /**
+     * SDD-L12-T4. A real scroller — the article body is taller than the viewport it is pinned to —
+     * so it stays, as `auto` so a short post does not get an inert bar. `overflow-x: hidden` is
+     * unchanged: wide tables and images are constrained by their own rules further down, and this
+     * is what stops them widening the column.
+     */
+    overflow-y: auto;
     overflow-x: hidden;
     width: 100%;
     display: grid;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -8,8 +8,9 @@
     --green-color: 98, 199, 86;
     --disable-color: 217, 212, 222;
     --blue-color: 29, 88, 154;
-    --font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif,
-        'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+    --font-family:
+        -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji',
+        'Segoe UI Emoji', 'Segoe UI Symbol';
     --status-building: #ffd700;
     --status-error: #ff0000;
     --status-initializing: #ffa500;
@@ -215,9 +216,26 @@ div.ch-frame-title-bar .ch-editor-tab-active > div {
     color: rgb(220, 220, 220);
 }
 
-div.dialog_dialog__mcyQq.dialog_open___BRYL div.ch-code-multiline-mark {
-    background-color: rgba(255, 255, 255, 0.01) !important;
-}
+/**
+ * SDD-L12-T6. A rule used to sit here targeting
+ * `div.dialog_dialog__mcyQq.dialog_open___BRYL div.ch-code-multiline-mark`. It was dead twice over,
+ * and both halves are worth remembering.
+ *
+ * Those are **hashed CSS-module class names hardcoded in a global stylesheet**. The hash is derived
+ * from the module's content, so any edit to `dialog.module.css` silently invalidates the selector —
+ * and T3 edited it. Measured afterwards, the dialog renders as `dialog_dialog__2CiR7
+ * dialog_open__CsRtT`: the rule matched nothing, and no build step would ever have said so.
+ *
+ * It was also aimed at a class that does not exist. `.ch-code-multiline-mark` appears nowhere in the
+ * rendered DOM — not on the home page, not on `/blog/nextjs/dark-theme`, whose source uses
+ * `mark=3,4,5,6,15,16`. The classes Code Hike 0.8.3 actually emits are `ch-code-scroll-parent`,
+ * `ch-codegroup`, `ch-editor-frame`, `ch-editor-tab*` and `ch-frame-*`.
+ *
+ * Deleted rather than repaired: there is no evidence the effect was ever visible, and git has it if
+ * it turns out otherwise. If a `.ch-*` rule is ever needed inside a dialog, scope it with a
+ * `data-` attribute or put it in `dialog.module.css` where the class can be composed — never with a
+ * hash.
+ */
 
 /**
  * SDD-L06. There was no `prefers-reduced-motion` anywhere in the codebase: a full-viewport 100-piece

--- a/styles/legal.module.css
+++ b/styles/legal.module.css
@@ -68,7 +68,14 @@
 .content {
     padding: 20px;
     margin-top: 50px;
-    overflow: scroll;
+    /**
+     * SDD-L12-T4. A real scroller — the legal documents are long — so this one stays, as `auto`
+     * rather than `scroll` so a short document does not get a bar it has no use for. The
+     * `::-webkit-scrollbar { display: none }` that sat below is gone (U-N3): it hid the scroll
+     * position in WebKit only, on the one surface where a reader most needs to know how much
+     * document is left.
+     */
+    overflow: auto;
     font-size: 14px;
     color: rgba(var(--blog-font));
 }
@@ -77,10 +84,6 @@
     .content {
         margin-top: 0;
     }
-}
-
-.content::-webkit-scrollbar {
-    display: none;
 }
 
 .content h1 {


### PR DESCRIPTION
Closes the L12 scroll-surface work: the header no longer overflows, the scrollbars that were painted unconditionally are gone, and the menu bar is laid out the way a macOS one is.

## What was wrong

A user reported the header cut off with a scrollbar inside the menu bar. Measured on `4d1d898`, its content needed **1526 px at every viewport** — 238 px unreachable at 1280, 1143 px at 375. Chromium's overlay scrollbars on macOS hid it; Firefox and *Show scroll bars: Always* did not, which is why it reached a user before it reached CI.

Two independent causes:

1. **`overflow: scroll` where `auto` was meant**, on two elements that never overflow, plus three `::-webkit-scrollbar { display: none }` rules that hid the bar in WebKit while Gecko had no equivalent — so the two engines disagreed by construction.
2. **The bar genuinely did not fit**: nine columns in a single run, eight text links taking 358 px of it.

## What changed

- **T1** — an e2e harness that fails on the unfixed tree. It passed at 1920 and failed everywhere else, which is the finding in itself: the defect was invisible on a wide monitor.
- **T3/T4** — every scroller audited one at a time. `.header` and the Dialog `.body` become `auto`; `.articleControls`, News `.container`, the blog body and the legal content are real scrollers and stay. The three scrollbar-hiding rules are deleted. Checked on `/`, `/blog` and `/legal/privacy-policy` — on the home page alone the sweep would have looked complete with three untouched rules live one route away.
- **T6** — a dead CSS rule removed: the hashed class name had moved when T3 edited the module, and the selector it targeted (`.ch-code-multiline-mark`) exists nowhere in the DOM.
- **T8** — three zones: identity on the left, countdown centred on the *window*, status items on the right, with priority shedding.
- **T9** — the nav icons move into the left zone beside the identity, and the status values get fixed slots (96 px, 24 px for the deployment dot, 140 px for the clock) aligned to their right edge.

## Breakpoints are derived, not chosen

The first attempt used round numbers (1023, 768). Just above 1023 every widget rendered in a window that could not hold them and, since `overflow` is `visible`, they overlapped rather than clipped.

They are now derived from measured widths. A window-centred countdown occupies `[W/2 - 85, W/2 + 85]`, so a zone stays clear of it exactly while `W >= 2 * (zone + 103)`. T9 made this apply to **both** sides: with the icons on the left that zone is 320 px, not 66 px, so it can reach the middle too.

| Below | Sheds | Left | Right |
|---|---|---|---|
| 1329 px | view counter | 320 | 548 |
| 1129 px | heating | 320 | 452 |
| 939 px | crypto price | 320 | 356 |
| 869 px | 5 artifact icons | 320 | 260 |
| 768 px | indexed counter (+ countdown hidden) | 160 | 260 |
| 479 px | 3 profile icons | 160 | 164 |

The e2e list samples **both sides of every breakpoint** — a breakpoint is where behaviour changes, so it is where the measurement belongs.

## Notes for review

- `header.scrollWidth` is the wrong metric here and the suite does not use it: the closed 400 px weather popover is an absolutely-positioned child, so scrollWidth read `clientWidth + 440` at every viewport. A constant offset means a positioned child, not a bar that does not fit — part of the original 1526 px was never bar content.
- Slot widths are sized to worst-case content measured in the slot's own font, **not** to local content: several widgets render empty without API credentials, so a local measurement would size every slot to an error state. The ~8-character ceiling is documented in the stylesheet.
- `U-N4` (the white gutter around the terminal) is **still open**. T5 is recorded as inconclusive, not as a pass: this machine cannot render space-reserving scrollbars at all — a control probe reports a 0 px gutter in Firefox 144 and Chromium under every pref set — so the environment cannot see the mechanism the finding depends on. It needs a real Firefox with *Show scroll bars: Always*.

Also included: the Spanish and Galician mobile home files still carried a bio saying the author had recently moved to Ireland to improve his English. The other four home files were already current; these two now match.

## Verification

82 e2e passed, 70 jest suites / 338 tests, typecheck and eslint clean.