### PR TITLE
fix(security): move all three brace-expansion pins out of the new advisory range (SDD-L13-T1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2763,9 +2763,9 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2849,9 +2849,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5846,9 +5846,9 @@
             }
         },
         "node_modules/@sentry/node/node_modules/brace-expansion": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8273,9 +8273,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9574,9 +9574,9 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11966,9 +11966,9 @@
             }
         },
         "node_modules/eslint-plugin-sonarjs/node_modules/brace-expansion": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12189,9 +12189,9 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13456,9 +13456,9 @@
             }
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13686,9 +13686,9 @@
             }
         },
         "node_modules/googleapis-common/node_modules/brace-expansion": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -115,9 +115,9 @@
         "next": {
             "postcss": "^8.5.18"
         },
-        "brace-expansion@1": "1.1.16",
-        "brace-expansion@2": "2.1.2",
-        "brace-expansion@5": "5.0.8",
+        "brace-expansion@1": "1.1.18",
+        "brace-expansion@2": "2.1.4",
+        "brace-expansion@5": "5.0.9",
         "sharp": "^0.35.1"
     },
     "resolutions": {

--- a/scripts/audit-gate.ts
+++ b/scripts/audit-gate.ts
@@ -35,27 +35,25 @@ type AllowlistEntry = {
     reviewBy: string;
 };
 
-const ALLOWLIST: AllowlistEntry[] = [
-    {
-        id: 1124334,
-        ghsa: 'GHSA-mh99-v99m-4gvg',
-        package: 'brace-expansion',
-        reason:
-            'DoS via unbounded brace expansion (CWE-400/770, CVSS 7.5), range <=5.0.7. Reached only ' +
-            'as googleapis -> googleapis-common -> gaxios -> rimraf -> glob -> minimatch -> ' +
-            "brace-expansion. rimraf runs on googleapis' own cleanup paths; no request-controlled " +
-            'string reaches a glob pattern anywhere in this app (searchConsole.ts passes fixed ' +
-            'resource names, and api/indexed-pages.ts reads a fixed literal path), so the ' +
-            'expansion this advisory abuses is never fed attacker input. ' +
-            'No upstream fix: googleapis is already at its latest (173.0.0) and the vulnerable ' +
-            'chain sits below it. Forcing brace-expansion to ^5.0.8 via overrides was tried and ' +
-            'REJECTED — it clears the audit but breaks runtime, because minimatch@9 calls ' +
-            'brace_expansion_1.default() and 5.x dropped the default export ' +
-            '("TypeError: (0, brace_expansion_1.default) is not a function"). A green audit over ' +
-            'broken globbing is worse than a documented exception.',
-        reviewBy: '2026-10-26',
-    },
-];
+/**
+ * Empty, and the gate insists on it staying honest: it fails on an entry whose advisory no longer
+ * appears, because an allowlist that outlives its advisory hides the regression if it comes back.
+ *
+ * The `brace-expansion` entry (1124334, GHSA-mh99-v99m-4gvg) lived here until 2026-08-05 and is gone
+ * because the advisory is fixed, not waived. Keep the reasoning that replaced it, though, because it
+ * is why `package.json` pins that package **per major** rather than forcing one version across the
+ * tree: forcing `^5.0.8` clears the audit and breaks runtime, since minimatch@9 calls
+ * `brace_expansion_1.default()` and 5.x dropped the default export. Three separate pins, each moved
+ * within its own major, is the shape that satisfies both.
+ */
+/*
+ * `sonarjs/no-empty-collection` reads the three usages below as dead because the literal is empty
+ * today. Empty is this collection's correct resting state, not a defect: it is a register of
+ * deliberate exceptions, and the gate's own stale-entry check exists to drive it back to empty.
+ * Deleting the reads to satisfy the rule would delete the gate.
+ */
+/* eslint-disable sonarjs/no-empty-collection */
+const ALLOWLIST: AllowlistEntry[] = [];
 
 /**
  * The report version this gate's extraction logic is written against. npm has emitted 2 since npm 7


### PR DESCRIPTION
Unblocks every open PR. [#180](https://github.com/xabierlameiro/the-last-dance/pull/180) went red on the Linting job and the cause is not in that branch.

## What happened

**GHSA-rgw5-rvv9-x895** was published on **2026-08-03** and lands on all four major lines of `brace-expansion` at once:

| Line | Vulnerable | Patched | This project pinned |
|---|---|---|---|
| 1.x | `< 1.1.18` | 1.1.18 | **1.1.16** |
| 2.x | `>= 2.0.0 < 2.1.4` | 2.1.4 | **2.1.2** |
| 4.x/5.x | `>= 4.0.0 < 5.0.9` | 5.0.9 | **5.0.8** |

All three pins were inside a vulnerable range. Master's Quality Gate was last green on 2026-07-29, before publication, so nothing regressed — any PR opened after the 3rd fails the same way.

The gate also flagged its own allowlist entry as stale, which is the check working as designed.

## The fix

Each pin moves **within its own major**. That shape is deliberate and the reasoning is now kept in `audit-gate.ts` rather than lost with the deleted entry: forcing one version across the whole tree clears the audit and breaks runtime, because `minimatch@9` calls `brace_expansion_1.default()` and 5.x dropped the default export. Three pins, each moved inside its major, satisfies both.

The allowlist entry for the older advisory (1124334, GHSA-mh99-v99m-4gvg) is deleted — the advisory no longer appears in the audit, so it was hiding nothing and would have hidden a regression if it returned. `ALLOWLIST` is empty now, which is its correct resting state. `sonarjs/no-empty-collection` reads the three remaining uses as dead code and is disabled there with the reason attached, because satisfying the rule by deleting the reads would delete the gate.

## Verification

This is verified locally, which was not previously possible: `npm` could not run on the dev machine at all (`EPERM` on `~/.npm/_cacache`), and a writable `npm_config_cache` works around it without touching the broken directory.

- `npm run audit:prod` → **0 critical, 0 high, 0 moderate, 0 low**; gate passes
- `node_modules` resolves to 1.1.18 (×1), 2.1.4 (×2), 5.0.9 (×6)
- full `next build` completes clean — specifically **no** `brace_expansion_1.default is not a function`, the exact failure the old allowlist warned about
- tsc 0, eslint 0, 70 jest suites / 338 tests

Closes Dependabot #240. Finding `S-N1`, task `L13-T1`.