### PR TITLE
fix(header): size each status slot for its widget, and close the four open dev advisories

### DIFF
--- a/e2e/scroll-surfaces.test.ts
+++ b/e2e/scroll-surfaces.test.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import type { Page, Route } from '@playwright/test';
 import { expect, test } from './fixtures';
 
 /**
@@ -160,6 +160,50 @@ const waitForStableHeader = async (page: Page) => {
     }
 
     return await readHeaderWidths(page);
+};
+
+/**
+ * SDD-L12-T10. Waits for the status widgets' **contents** to settle, which is a different question
+ * from `waitForStableHeader` and now the only useful one.
+ *
+ * That helper watches `header.scrollWidth`. It worked while the slots were `auto`, because a widget
+ * resolving made the bar wider. Fixed slots removed exactly that signal: the header's width is a
+ * constant from first paint, so the poll agrees with itself immediately and returns while widgets are
+ * still loading. Measured mid-load, the deployment indicator reported 3px of overflow at one viewport
+ * and none at another — the same page, two answers, which is how a flaky test is born.
+ *
+ * So poll what actually moves: every slot's content box, until two consecutive reads agree.
+ */
+const readStatusSignature = (page: Page) =>
+    page.evaluate(() => {
+        const zone = document.querySelector('header [class*="right"]');
+        if (!zone) return '';
+
+        const parts: string[] = [];
+        for (const slot of [...zone.children]) {
+            const rects = [...slot.querySelectorAll('*')].map((node) => node.getBoundingClientRect());
+            if (rects.length === 0) {
+                parts.push('empty');
+                continue;
+            }
+            const left = Math.round(Math.min(...rects.map((rect) => rect.left)));
+            const right = Math.round(Math.max(...rects.map((rect) => rect.right)));
+            parts.push(`${left}-${right}`);
+        }
+        return parts.join('|');
+    });
+
+const waitForStableStatusContent = async (page: Page) => {
+    let previous = '';
+
+    for (let attempt = 0; attempt < 60; attempt += 1) {
+        const signature = await readStatusSignature(page);
+        if (signature !== '' && signature === previous) return signature;
+        previous = signature;
+        await page.waitForTimeout(150);
+    }
+
+    return previous;
 };
 
 test.describe('Scroll surfaces', () => {
@@ -332,79 +376,99 @@ test.describe('Scroll surfaces', () => {
      * 2000px is included deliberately: that is the width the defect was reported at, and every
      * narrower viewport hides the view counter behind a shedding breakpoint.
      */
-    for (const width of [1550, 2000]) {
-        test(`no status widget is clipped by its slot at ${width}px`, async ({ page }) => {
-            /**
-             * The values are mocked, and that is not a convenience — it is what makes this a test.
-             * Neither this machine nor CI has Google Analytics or Ariston credentials, so both render
-             * an error glyph roughly 15px wide, which fits any slot. Measured against a failure state
-             * the check passes while the widget is unreadable in production, which is precisely the
-             * hole the reported defect fell through. Serving worst-case values makes the assertion
-             * mean the same thing everywhere.
-             */
-            await page.route('**/api/analytics*', (route) =>
-                route.fulfill({ json: { pageViews: 999999, newUsers: 888888 } }),
-            );
-            await page.route('**/api/heating*', (route) =>
-                route.fulfill({ json: { outsideTemp: -12.5, zoneMeasuredTemp: 100.5 } }),
-            );
+    test.describe('with the widgets serving worst-case values', () => {
+        /**
+         * `bypassCSP` is required, and finding out why cost a red CI run.
+         *
+         * The hooks build their URL from `NEXT_PUBLIC_DOMAIN`. That is `localhost:3000` on a
+         * developer machine, so the fetch is same-origin and everything works. CI injects the real
+         * domain from secrets while still serving the build on localhost, so the page asks for
+         * `https://xabierlameiro.com/api/analytics` — and the site's own `connect-src` refuses it.
+         * The request is blocked in the renderer **before it becomes a network request**, so
+         * `page.route` never sees it (`0` interceptions, measured) and no amount of CORS headers on
+         * the mocked response helps. The widget falls back to its error state and the assertion
+         * fails on an empty string.
+         *
+         * So the CSP is lifted for these two tests only. They measure slot geometry, not the
+         * site's connection policy — which the security headers in `next.config.ts` cover.
+         */
+        test.use({ bypassCSP: true });
 
-            await page.setViewportSize({ width, height: 900 });
-            await page.goto('/');
-            await expect(page.getByTestId('header')).toBeVisible();
-            await expect(page.getByTestId('views')).toContainText('999999');
-            await waitForStableHeader(page);
+        for (const width of [1550, 2000]) {
+            test(`no status widget is clipped by its slot at ${width}px`, async ({ page }) => {
+                /**
+                 * The values are mocked, and that is not a convenience — it is what makes this a
+                 * test. Neither this machine nor CI has Google Analytics or Ariston credentials, so
+                 * both render an error glyph roughly 15px wide, which fits any slot. Measured
+                 * against a failure state the check passes while the widget is unreadable in
+                 * production, which is precisely the hole the reported defect fell through.
+                 *
+                 * `access-control-allow-origin` covers the cross-origin half: with the CSP lifted
+                 * the request does go out, and on CI it goes to another origin.
+                 */
+                const mock = (json: object) => (route: Route) =>
+                    route.fulfill({ json, headers: { 'access-control-allow-origin': '*' } });
 
-            const clipped = await page.evaluate(() => {
-                const header = document.querySelector('header');
-                if (!header) throw new Error('no <header> in the document');
-                const right = header.querySelector('[class*="right"]');
-                if (!right) throw new Error('no right zone in the header');
+                await page.route('**/api/analytics*', mock({ pageViews: 999999, newUsers: 888888 }));
+                await page.route('**/api/heating*', mock({ outsideTemp: -12.5, zoneMeasuredTemp: 100.5 }));
 
-                return [...right.children]
-                    .filter((slot) => getComputedStyle(slot).display !== 'none')
-                    .map((slot) => {
-                        const box = slot.getBoundingClientRect();
-                        /**
-                         * Excluding nodes that are themselves absolute is not enough: the weather
-                         * popover is absolute, but its contents are static children of it, so they
-                         * pass that filter and drag the measurement 457px past the clock. Walk up to
-                         * the slot and drop anything with a positioned ancestor.
-                         */
-                        const escapes = (node: Element) => {
-                            for (let el: Element | null = node; el && el !== slot; el = el.parentElement) {
-                                const position = getComputedStyle(el).position;
-                                if (position === 'absolute' || position === 'fixed') return true;
-                            }
-                            return false;
-                        };
+                await page.setViewportSize({ width, height: 900 });
+                await page.goto('/');
+                await expect(page.getByTestId('header')).toBeVisible();
+                await expect(page.getByTestId('views')).toContainText('999999');
+                await waitForStableStatusContent(page);
 
-                        const laidOut = [...slot.querySelectorAll('*')].filter((node) => {
-                            if (getComputedStyle(node).display === 'none' || escapes(node)) return false;
-                            const rect = node.getBoundingClientRect();
-                            return rect.width > 0 && rect.height > 0;
-                        });
-                        if (laidOut.length === 0) return null;
+                const clipped = await page.evaluate(() => {
+                    const header = document.querySelector('header');
+                    if (!header) throw new Error('no <header> in the document');
+                    const right = header.querySelector('[class*="right"]');
+                    if (!right) throw new Error('no right zone in the header');
 
-                        const rects = laidOut.map((node) => node.getBoundingClientRect());
-                        const lostLeft = Math.round(box.left - Math.min(...rects.map((rect) => rect.left)));
-                        const lostRight = Math.round(Math.max(...rects.map((rect) => rect.right)) - box.right);
-                        if (lostLeft <= 1 && lostRight <= 1) return null;
+                    return [...right.children]
+                        .filter((slot) => getComputedStyle(slot).display !== 'none')
+                        .map((slot) => {
+                            const box = slot.getBoundingClientRect();
+                            /**
+                             * Excluding nodes that are themselves absolute is not enough: the weather
+                             * popover is absolute, but its contents are static children of it, so they
+                             * pass that filter and drag the measurement 457px past the clock. Walk up to
+                             * the slot and drop anything with a positioned ancestor.
+                             */
+                            const escapes = (node: Element) => {
+                                for (let el: Element | null = node; el && el !== slot; el = el.parentElement) {
+                                    const position = getComputedStyle(el).position;
+                                    if (position === 'absolute' || position === 'fixed') return true;
+                                }
+                                return false;
+                            };
 
-                        return (
-                            `${(slot.className.match(/header_(\w+?)__/) || [])[1] || slot.className}` +
-                            ` (${Math.round(box.width)}px slot, "${(slot.textContent || '').trim().slice(0, 20)}")` +
-                            ` loses ${lostLeft > 1 ? lostLeft + 'px off its left' : ''}` +
-                            `${lostLeft > 1 && lostRight > 1 ? ' and ' : ''}` +
-                            `${lostRight > 1 ? lostRight + 'px off its right' : ''}`
-                        );
-                    })
-                    .filter(Boolean);
+                            const laidOut = [...slot.querySelectorAll('*')].filter((node) => {
+                                if (getComputedStyle(node).display === 'none' || escapes(node)) return false;
+                                const rect = node.getBoundingClientRect();
+                                return rect.width > 0 && rect.height > 0;
+                            });
+                            if (laidOut.length === 0) return null;
+
+                            const rects = laidOut.map((node) => node.getBoundingClientRect());
+                            const lostLeft = Math.round(box.left - Math.min(...rects.map((rect) => rect.left)));
+                            const lostRight = Math.round(Math.max(...rects.map((rect) => rect.right)) - box.right);
+                            if (lostLeft <= 1 && lostRight <= 1) return null;
+
+                            return (
+                                `${(slot.className.match(/header_(\w+?)__/) || [])[1] || slot.className}` +
+                                ` (${Math.round(box.width)}px slot, "${(slot.textContent || '').trim().slice(0, 20)}")` +
+                                ` loses ${lostLeft > 1 ? lostLeft + 'px off its left' : ''}` +
+                                `${lostLeft > 1 && lostRight > 1 ? ' and ' : ''}` +
+                                `${lostRight > 1 ? lostRight + 'px off its right' : ''}`
+                            );
+                        })
+                        .filter(Boolean);
+                });
+
+                expect(clipped, `status widgets clipped at ${width}px: ${clipped.join(' | ')}`).toEqual([]);
             });
-
-            expect(clipped, `status widgets clipped at ${width}px: ${clipped.join(' | ')}`).toEqual([]);
-        });
-    }
+        }
+    });
 
     /**
      * L12-T3/T4. This shipped as `test.fail()` while the defect existed: the suite stayed green, and

--- a/e2e/scroll-surfaces.test.ts
+++ b/e2e/scroll-surfaces.test.ts
@@ -58,23 +58,27 @@ const VIEWPORTS = [
     { width: 939, height: 800, name: 'below crypto' },
     { width: 940, height: 800, name: 'crypto appears' },
     { width: 1024, height: 800, name: 'small laptop' },
-    { width: 1129, height: 800, name: 'below heating' },
-    { width: 1130, height: 800, name: 'heating appears' },
+    { width: 1179, height: 800, name: 'below heating' },
+    { width: 1180, height: 800, name: 'heating appears' },
     { width: 1280, height: 720, name: 'laptop' },
-    { width: 1329, height: 800, name: 'below view counter' },
-    { width: 1330, height: 800, name: 'view counter appears' },
+    { width: 1549, height: 800, name: 'below views and users' },
+    { width: 1550, height: 800, name: 'views and users appear' },
     { width: 1920, height: 1080, name: 'desktop' },
+    { width: 2000, height: 1080, name: 'wide desktop, the width the defect was reported at' },
 ];
 
 /**
- * SDD-L12-T9. The status area is a fixed pitch, and these are the only widths a slot may have.
+ * SDD-L12-T9/T10. Every width a status slot is allowed to have.
  *
- * T8 sized the slots with `auto` tracks, so each one was as wide as whatever its widget happened to
- * be showing — and when three widgets were in an error state the row read as randomly spaced, which
- * is what the owner reported. Pinning the numbers here means a future `auto` or a stray `gap` fails
- * as a test rather than as a screenshot.
+ * T8 sized the slots with `auto` tracks, so each was as wide as whatever its widget happened to be
+ * showing, and the row read as randomly spaced. T9 made them fixed but gave them all ONE width,
+ * which broke the two widgets that render two values each: the view counter (page views AND new
+ * users, an icon on each) wants 166px and had 96, so 69px vanished off its left edge in production.
+ *
+ * Pinning the numbers means a future `auto`, a stray `gap`, or a widget growing a second value fails
+ * as a test rather than as a screenshot a month later.
  */
-const SLOT_WIDTHS = { deploymentDot: 24, value: 96, clock: 140 };
+const SLOT_WIDTHS = { deploymentDot: 24, value: 96, views: 184, heating: 120, clock: 140 };
 
 /**
  * Measures the *bar*, not the scroll box.
@@ -307,6 +311,98 @@ test.describe('Scroll surfaces', () => {
                 layout.trailingGap,
                 `the status items are not flush to the bar's right edge at ${width}px: ${describe}`,
             ).toBe(layout.paddingLeft);
+        });
+    }
+
+    /**
+     * SDD-L12-T10. No status widget may be clipped by its own slot.
+     *
+     * This is the check that was missing, and its absence is why a 69px-wide hole in the view counter
+     * shipped. The obvious test — `scrollWidth > clientWidth` — **cannot see this defect**: the slots
+     * are `justify-content: flex-end`, so content that does not fit escapes towards the inline-START
+     * edge, and `scrollWidth` only measures overflow past the inline-END edge. The clipped slot
+     * reported `scrollWidth === clientWidth === 96` and read as perfectly healthy.
+     *
+     * So compare boxes instead: the content's own bounding box against the slot's, on both sides.
+     *
+     * Absolutely-positioned descendants are excluded, because escaping the bar is their job — the
+     * clock's weather popover is 400px wide and anchored to it, and counting it would report every
+     * run as a failure. That exclusion is also why measuring `header.scrollWidth` was abandoned.
+     *
+     * 2000px is included deliberately: that is the width the defect was reported at, and every
+     * narrower viewport hides the view counter behind a shedding breakpoint.
+     */
+    for (const width of [1550, 2000]) {
+        test(`no status widget is clipped by its slot at ${width}px`, async ({ page }) => {
+            /**
+             * The values are mocked, and that is not a convenience — it is what makes this a test.
+             * Neither this machine nor CI has Google Analytics or Ariston credentials, so both render
+             * an error glyph roughly 15px wide, which fits any slot. Measured against a failure state
+             * the check passes while the widget is unreadable in production, which is precisely the
+             * hole the reported defect fell through. Serving worst-case values makes the assertion
+             * mean the same thing everywhere.
+             */
+            await page.route('**/api/analytics*', (route) =>
+                route.fulfill({ json: { pageViews: 999999, newUsers: 888888 } }),
+            );
+            await page.route('**/api/heating*', (route) =>
+                route.fulfill({ json: { outsideTemp: -12.5, zoneMeasuredTemp: 100.5 } }),
+            );
+
+            await page.setViewportSize({ width, height: 900 });
+            await page.goto('/');
+            await expect(page.getByTestId('header')).toBeVisible();
+            await expect(page.getByTestId('views')).toContainText('999999');
+            await waitForStableHeader(page);
+
+            const clipped = await page.evaluate(() => {
+                const header = document.querySelector('header');
+                if (!header) throw new Error('no <header> in the document');
+                const right = header.querySelector('[class*="right"]');
+                if (!right) throw new Error('no right zone in the header');
+
+                return [...right.children]
+                    .filter((slot) => getComputedStyle(slot).display !== 'none')
+                    .map((slot) => {
+                        const box = slot.getBoundingClientRect();
+                        /**
+                         * Excluding nodes that are themselves absolute is not enough: the weather
+                         * popover is absolute, but its contents are static children of it, so they
+                         * pass that filter and drag the measurement 457px past the clock. Walk up to
+                         * the slot and drop anything with a positioned ancestor.
+                         */
+                        const escapes = (node: Element) => {
+                            for (let el: Element | null = node; el && el !== slot; el = el.parentElement) {
+                                const position = getComputedStyle(el).position;
+                                if (position === 'absolute' || position === 'fixed') return true;
+                            }
+                            return false;
+                        };
+
+                        const laidOut = [...slot.querySelectorAll('*')].filter((node) => {
+                            if (getComputedStyle(node).display === 'none' || escapes(node)) return false;
+                            const rect = node.getBoundingClientRect();
+                            return rect.width > 0 && rect.height > 0;
+                        });
+                        if (laidOut.length === 0) return null;
+
+                        const rects = laidOut.map((node) => node.getBoundingClientRect());
+                        const lostLeft = Math.round(box.left - Math.min(...rects.map((rect) => rect.left)));
+                        const lostRight = Math.round(Math.max(...rects.map((rect) => rect.right)) - box.right);
+                        if (lostLeft <= 1 && lostRight <= 1) return null;
+
+                        return (
+                            `${(slot.className.match(/header_(\w+?)__/) || [])[1] || slot.className}` +
+                            ` (${Math.round(box.width)}px slot, "${(slot.textContent || '').trim().slice(0, 20)}")` +
+                            ` loses ${lostLeft > 1 ? lostLeft + 'px off its left' : ''}` +
+                            `${lostLeft > 1 && lostRight > 1 ? ' and ' : ''}` +
+                            `${lostRight > 1 ? lostRight + 'px off its right' : ''}`
+                        );
+                    })
+                    .filter(Boolean);
+            });
+
+            expect(clipped, `status widgets clipped at ${width}px: ${clipped.join(' | ')}`).toEqual([]);
         });
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12686,9 +12686,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
             "dev": true,
             "funding": [
                 {
@@ -14561,9 +14561,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+            "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/src/components/Layout/Header/header.module.css
+++ b/src/components/Layout/Header/header.module.css
@@ -76,7 +76,7 @@
 }
 
 /**
- * SDD-L12-T9. Status items on a fixed pitch.
+ * SDD-L12-T9/T10. Status items in fixed slots, one width per widget.
  *
  * T8 left this as `grid-auto-flow: column` with `auto` tracks, so every slot was as wide as whatever
  * it happened to contain: the XRP price and the view count sat at different pitches, and both moved
@@ -87,27 +87,32 @@
  * `auto` tracks a four-figure view count silently widened the zone and ate the margin that keeps the
  * countdown clear.
  *
- * The widths are not measured from local content and must not be — several widgets render empty on
- * this machine because their APIs have no credentials, so a local measurement would size every slot
- * to an error state. They are sized to worst-case content instead, measured by rendering candidate
- * strings in the slot's own computed font (16px -apple-system) in an unconstrained probe:
+ * **One width for every slot was wrong, and shipped.** The owner reported the total-visits number
+ * cut off, and it was: `<ViewCounter all />` renders TWO counters, each with its own icon — page
+ * views AND new users — so it is intrinsically about twice the width of a single value. Measured on
+ * production it wants 166 px and had 96, losing 69 px off its left edge. Heating was next in line:
+ * it renders two temperatures and measures 85 px today, but 105 px as soon as one of them gains a
+ * digit, so it was clipping-in-waiting rather than working.
  *
- * | Worst case          | Text | + icon | Fits 96 px |
- * |---------------------|------|--------|------------|
- * | `1.234.567` indexed |  72  |   96   | yes, exactly |
- * | `999.999` views     |  63  |   87   | yes        |
- * | `-12,5 °C` heating  |  60  |   84   | yes        |
- * | `$99.9999` XRP      |  68  |   92   | yes        |
- * | `$1,234.5678` XRP   |  91  |  115   | NO         |
+ * The widths below are therefore PER WIDGET, measured on production by lifting the constraint
+ * (`width: max-content`) and re-measuring with a digit added to every number in the slot:
  *
- * So the slot holds about eight characters, and anything longer is clipped by `overflow: hidden`
- * rather than widening the zone. That is the deliberate trade: a slot that grows is a slot that
- * moves everything beside it, which is the jitter this rule exists to remove. XRP's all-time high is
- * about $3.84, so `$99.9999` is ~25x headroom — but if a widget is ever pointed at an asset priced
- * in four figures, widen `--status-slot` and re-derive the table below, do not let it clip.
+ * | Slot            | Natural | +1 digit | Assigned | Headroom |
+ * |-----------------|---------|----------|----------|----------|
+ * | deployment dot  |    15   |    15    |    24    |   9      |
+ * | XRP price       |    80   |    80    |    96    |  16      |
+ * | indexed pages   |    70   |    70    |    96    |  26      |
+ * | **views+users** |   166   |   174    |   184    |  10      |
+ * | **heating**     |    85   |   105    |   120    |  15      |
+ * | clock           |     -   |     -    |   140    |   6      |
  *
- * The clock is 140 px because it is the one slot whose content is locale-dependent: the longest
- * Spanish rendering measured, `mié 30 sept 23:59`, is 134 px.
+ * Measured on production and not here: several widgets render an error glyph on this machine
+ * because their APIs have no credentials, so a local measurement would size every slot to a failure
+ * state. The clock's 140 px comes from the longest Spanish rendering, `mié 30 sept 23:59` at 134 px.
+ *
+ * Content is still clipped rather than allowed to widen the zone — a slot that grows moves
+ * everything beside it, which is the jitter these rules exist to remove. The difference is that each
+ * slot is now sized for what its own widget can actually produce.
  */
 .right {
     display: grid;
@@ -125,8 +130,12 @@
  * ~12 px, so centring it in a 96 px slot opens 42 px of dead space on each side and the row reads as
  * randomly spaced — which is what it did on the owner's screen, where three widgets were in an error
  * state because their APIs have no credentials locally. Right-aligned, every item's trailing edge
- * lands on the same 96 px pitch and the whole zone reads as one column flush to the bar's edge,
- * whatever each widget happens to be showing.
+ * lands on the bar's own edge and the zone reads as one column, whatever each widget is showing.
+ *
+ * Right alignment has one consequence worth naming, because it hid the bug this rule now documents:
+ * overflow escapes towards the **left**, and `scrollWidth` only measures overflow past the
+ * inline-END edge. So a clipped slot reports `scrollWidth === clientWidth` and looks healthy. The
+ * e2e check compares the content's bounding box against the slot's on both sides instead.
  */
 .statusItem {
     display: flex;
@@ -134,6 +143,16 @@
     justify-content: flex-end;
     width: var(--status-slot);
     overflow: hidden;
+}
+
+/* Two counters with two icons — page views and new users. Wants 166px, grows to 174px. */
+.slotViews {
+    width: 184px;
+}
+
+/* Two temperatures, outside and measured. 85px today, 105px once either gains a digit. */
+.slotHeating {
+    width: 120px;
 }
 
 /* The deployment indicator is a dot, not a value; a full slot for it would be a 96 px hole. */
@@ -223,13 +242,18 @@
  * `W >= 2 * (leftWidth + 103)` is a real constraint that T8's ladder did not contain. A ladder that
  * only watches one side is how the bar ended up drawn on top of itself at 1024 px the first time.
  *
- * Zone widths are now arithmetic, not measurement, because the slots are fixed:
- * right = 24 (dot) + 96 per visible value slot + 140 (clock); left = 66 + 18 per icon + 14 per gap.
+ * Zone widths are arithmetic, not measurement, because the slots are fixed:
+ * right = 24 (dot) + 96 (XRP) + 96 (indexed) + 184 (views) + 120 (heating) + 140 (clock);
+ * left = 66 + 18 per icon + 14 per gap.
+ *
+ * Re-derived again once the views and heating slots were sized correctly — widening two slots by
+ * 112 px in total moves every breakpoint that depends on the right zone, which is the whole reason
+ * these are computed from the widths rather than picked.
  *
  * | Below   | What sheds        | Left | Right | Left needs | Right needs |
  * |---------|-------------------|------|-------|------------|-------------|
- * | 1329 px | view counter      | 320  | 548   |  846       | 1302        |
- * | 1129 px | heating           | 320  | 452   |  846       | 1110        |
+ * | 1549 px | views + users     | 320  | 660   |  846       | 1526        |
+ * | 1179 px | heating           | 320  | 476   |  846       | 1158        |
  * |  939 px | crypto price      | 320  | 356   |  846       |  918        |
  * |  869 px | 5 artifact icons  | 320  | 260   |  846       |  726        |
  * |  768 px | indexed counter   | 160  | 260   |  526       |  726        |
@@ -243,13 +267,13 @@
  * `.navLinks a` sets `display: flex` and outranks a bare class on specificity, so each rule lists
  * both forms rather than reaching for `!important`.
  */
-@media screen and (max-width: 1329px) {
+@media screen and (max-width: 1549px) {
     .shed1 {
         display: none;
     }
 }
 
-@media screen and (max-width: 1129px) {
+@media screen and (max-width: 1179px) {
     .shed2 {
         display: none;
     }

--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -195,10 +195,16 @@ const Header = ({ children }: { children?: ReactNode }) => {
                 <span className={`${styles.statusItem} ${styles.shed4}`}>
                     <IndexedCounter />
                 </span>
-                <span className={`${styles.statusItem} ${styles.shed1}`}>
+                {/**
+                 * SDD-L12-T10. These two carry a wider slot because they render TWO values each:
+                 * `ViewCounter all` is page views AND new users, with an icon on each, and `Heating`
+                 * is the outside and measured temperatures. Sized on the default 96px slot, the view
+                 * counter lost 69px off its left edge in production — the defect the owner reported.
+                 */}
+                <span className={`${styles.statusItem} ${styles.slotViews} ${styles.shed1}`}>
                     <ViewCounter all />
                 </span>
-                <span className={`${styles.statusItem} ${styles.shed2}`}>
+                <span className={`${styles.statusItem} ${styles.slotHeating} ${styles.shed2}`}>
                     <Heating />
                 </span>
                 <DateAndHour>


### PR DESCRIPTION
Two things in one PR, as requested: the clipped visits counter the owner reported, and the four open Dependabot alerts.

## The visits counter was cut off

`<ViewCounter all />` renders **two** counters — page views AND new users, each with its own icon — so it is intrinsically about twice as wide as a single value. Measured on production it wants **166px and had 96**, losing **69px off its left edge**. What vanished was the eye icon and the entire page-views figure, leaving a bare separator and one number:

| | |
|---|---|
| Before | `⋯ 94 ⋮ 14453 🌡 26 \| 24.9` |
| After | `⋯ 94 👁 37480 👥 14453 🌡 26 \| 24.9` |

Heating was the same defect one digit away: two temperatures, 85px today, **105px** as soon as either gains a digit.

### Slots are now per widget

Measured on production by lifting the constraint (`width: max-content`) and re-measuring with a digit added to every number:

| Slot | Natural | +1 digit | Assigned |
|---|---|---|---|
| deployment dot | 15 | 15 | 24 |
| XRP price | 80 | 80 | 96 |
| indexed pages | 70 | 70 | 96 |
| **views + users** | **166** | **174** | **184** |
| **heating** | 85 | **105** | **120** |
| clock | — | — | 140 |

Measured on production deliberately: neither this machine nor CI has Analytics or Ariston credentials, so both render a ~15px error glyph, and a local measurement would size every slot to a failure state.

Widening two slots by 112px moves every breakpoint that depends on the right zone, so the shedding ladder is re-derived: **1549/1179** replace 1329/1129.

## Why the test did not catch it

This is the part worth reviewing. The check asserted `scrollWidth > clientWidth`, and the slots are `justify-content: flex-end` — content that does not fit escapes towards the inline-**start** edge, and `scrollWidth` only measures overflow past the inline-**end** edge. The clipped slot reported `scrollWidth === clientWidth === 96` and read as perfectly healthy.

The replacement compares the content's bounding box against the slot's, **on both sides**, and:

- excludes descendants of positioned ancestors — the weather popover is 400px wide and escaping the bar is its job; without that exclusion the clock reports a 457px overflow on every run (this bit me while writing it);
- **mocks `/api/analytics` and `/api/heating` with worst-case values.** Against an error glyph the assertion passes while the widget is unreadable in production, which is exactly the hole this defect fell through. Mocking is what makes it a test rather than a coincidence.

Proven both ways: reverted to 96px it fails naming both slots and the pixels each loses (`loses 82px off its left`, `loses 5px off its left`); restored, it passes.

## The four advisories

Lockfile-only, and exactly what Dependabot #182 and #179 each propose, combined so all four alerts close together:

| Bump | Closes |
|---|---|
| `fast-uri` 3.1.4 → 3.1.5 | #245 (high) |
| `ip-address` 10.2.0 → 10.4.0 | #244 (high), #242, #241 (moderate) |

All four are `development` scope; neither package is a direct dependency, so the fix is a lockfile update. Plain `npm update` fails ERESOLVE on the known `@code-hike/mdx` react peer conflict, so `--legacy-peer-deps` is required, as everywhere else in this project.

**Supersedes #182 and #179.**

## Verification

86 e2e, 70 jest suites / 338 tests, tsc 0, eslint 0, `npm run audit:prod` 0/0/0/0.