### PR TITLE
fix(seo): repair the SERP title, canonical identity links and stale leak post

### DIFF
--- a/data/blog/nextjs-memory-leak/nextjs-memory-leak.en.mdx
+++ b/data/blog/nextjs-memory-leak/nextjs-memory-leak.en.mdx
@@ -5,9 +5,9 @@ author: 'Xabier Lameiro'
 category: 'Nextjs'
 tags: ['memory-leak', 'node', 'performance']
 locale: 'en'
-updated: '2026-07-22'
+updated: '2026-08-06'
 excerpt: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory · OOMKilled (exit code 137) · 504 FUNCTION_INVOCATION_TIMEOUT'
-description: 'Three open memory leaks in Next.js 15.5–16.3, how to tell which one you have from heap snapshots, and why on serverless a leak shows up as a 504 timeout.'
+description: 'The three Next.js memory leaks I measured and helped confirm, all fixed in 16.3.0: which one you have, how to prove it, and why serverless hides them as 504s.'
 image: '/posts/nextjs-memory-leak.png'
 alternate:
     [
@@ -16,7 +16,7 @@ alternate:
     ]
 faq:
     - question: 'Why does my Next.js server keep growing in memory?'
-      answer: 'As of July 2026 there are three open leaks in the framework itself (Next.js 15.5–16.3): the router LRU cache does not count its keys (issue 94890), the RSC render tree is retained per request when the client aborts the stream (issue 94919), and middleware timeouts are retained by the sandbox (issue 95094). Before auditing your own code, compare the heap curve against unique URLs, total traffic and specific routes: each leak has a distinct shape.'
+      answer: 'Between Next.js 15.5 and 16.2 there were three leaks in the framework itself: the router LRU cache did not count its keys (issue 94890), the RSC render tree was retained per request when the client aborted the stream (issue 94919), and middleware timeouts were retained by the sandbox (issue 95094). All three are fixed in 16.3.0, so check your version first. If you are pinned below it, compare the heap curve against unique URLs, total traffic and specific routes: each leak has a distinct shape.'
     - question: 'How do I take a heap snapshot of Next.js in production?'
       answer: 'Start the server with NODE_OPTIONS=--inspect, connect Chrome DevTools to the inspector port, and take two snapshots separated by traffic in the Memory tab; the Comparison view and the retainers show which object grows and what is holding it. For build-time issues, next build --experimental-debug-memory-usage dumps snapshots automatically and responds to the SIGUSR2 signal.'
     - question: 'Does --max-old-space-size fix a memory leak?'
@@ -35,11 +35,15 @@ faq:
 
 ## Quick answer
 
-If your self-hosted Next.js server grows until it dies with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` — or the container gets `OOMKilled` (exit code 137) — don't start by auditing your own code. As of July 2026 there are three documented memory leaks **open in the framework itself**, spanning Next.js 15.5 to 16.3:
+If your self-hosted Next.js server grows until it dies with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` — or the container gets `OOMKilled` (exit code 137) — don't start by auditing your own code. **Check your Next.js version first.** Between 15.5 and 16.2 there were three documented memory leaks in the framework itself, and all three are fixed in **16.3.0**:
 
--   **The router LRU cache doesn't count its keys** ([#94890](https://github.com/vercel/next.js/issues/94890)): a slow drift over days, proportional to the unique URLs you receive, not to your traffic.
--   **The RSC render tree is retained per request** ([#94919](https://github.com/vercel/next.js/issues/94919)): grows with traffic, much worse on Node 22/24 and when clients abort the connection mid-stream.
--   **Middleware `setTimeout` ids are registered forever** ([#95094](https://github.com/vercel/next.js/issues/95094)): stepwise growth tied to traffic that passes through middleware.
+-   **The router LRU cache didn't count its keys** ([#94890](https://github.com/vercel/next.js/issues/94890)): a slow drift over days, proportional to the unique URLs you receive, not to your traffic. Fixed by [#96229](https://github.com/vercel/next.js/pull/96229).
+-   **The RSC render tree was retained per request** ([#94919](https://github.com/vercel/next.js/issues/94919)): grows with traffic, much worse on Node 22/24 and when clients abort the connection mid-stream. Fixed by [#96173](https://github.com/vercel/next.js/pull/96173).
+-   **Middleware `setTimeout` ids were registered forever** ([#95094](https://github.com/vercel/next.js/issues/95094)): stepwise growth tied to traffic that passes through middleware. Fixed by [#96161](https://github.com/vercel/next.js/pull/96161).
+
+So the shortest fix is an upgrade. If you're pinned below 16.3.0 — and plenty of production apps are — the rest of this post is how to tell which of the three you're carrying, and how to prove it rather than guess.
+
+I measured two of them independently while they were still open and posted the numbers on the issues: [#94890 reproduced at a tenth of the reported load](https://github.com/vercel/next.js/issues/94890#issuecomment-5035231906), and [#95094 reproduced](https://github.com/vercel/next.js/issues/95094#issuecomment-5035131691) and then [re-measured against `16.3.0-canary.97` to confirm the fix held](https://github.com/vercel/next.js/issues/95094#issuecomment-5081146010). Everything below is that method, generalised.
 
 On serverless (Vercel) you'll almost never see the OOM: the instance recycles first. There, the same underlying problem surfaces as a `504 FUNCTION_INVOCATION_TIMEOUT` — it happened to this blog, and my numbers are below.
 
@@ -167,9 +171,9 @@ Two honest data points from measuring all three: #94890 reproduced with a tenth 
 
 My checklist after this trip:
 
-1. **Look at retainers, not hunches.** `LRUNode`, `reactServerStream` or the sandbox `TimeoutsManager` in the trace → it's one of the three framework leaks; add your data to the issue. Closures and structures from your own modules → it's yours.
+1. **Look at retainers, not hunches.** `LRUNode`, `reactServerStream` or the sandbox `TimeoutsManager` in the trace → it's one of the three framework leaks, so upgrade to 16.3.0. Closures and structures from your own modules → it's yours.
 2. **Correlate before you blame.** Heap tracking unique URLs → leak 1. Heap tracking traffic and aborts → leak 2. Steps with middleware → leak 3. One specific route driving the curve → almost certainly your code.
 3. **`--max-old-space-size` fixes nothing** — size the heap to your container so you don't die early, but a monotonic slope will eventually hit any limit.
 4. **On serverless, profile time instead of memory.** If you're seeing 504s, hunt for quadratic or repeated per-request work; my whole case is in the previous section.
 
-The versions cited are the ones in the reports (Next 15.5.11–16.3.0-canary.50, Node 20/22/24, July 2026); if you're reading this months later, check the three linked issues — with luck, one of them will be closed.
+**Update, August 2026.** All three issues are now closed and the fixes shipped in Next.js 16.3.0 — #95094 and #94919 landed in `16.3.0-canary.97` on 25 July, #94890 two days later. The measurements below were taken while they were still open, against the versions cited in the reports (Next 15.5.11–16.3.0-canary.50, Node 20/22/24). They stay here because the method outlives the bugs: the next leak will not have an issue number waiting for you, and the way you find it is the same.

--- a/data/blog/nextjs-memory-leak/nextjs-memory-leak.es.mdx
+++ b/data/blog/nextjs-memory-leak/nextjs-memory-leak.es.mdx
@@ -5,9 +5,9 @@ author: 'Xabier Lameiro'
 category: 'Nextjs'
 tags: ['memory-leak', 'node', 'performance']
 locale: 'es'
-updated: '2026-07-22'
+updated: '2026-08-06'
 excerpt: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory · OOMKilled (exit code 137) · 504 FUNCTION_INVOCATION_TIMEOUT'
-description: 'Tres fugas de memoria abiertas en Next.js 15.5–16.3, cómo identificar la tuya con heap snapshots y por qué en serverless la fuga se disfraza de un 504.'
+description: 'Las tres fugas de memoria de Next.js que medí y ayudé a confirmar, ya corregidas en 16.3.0: cuál tienes, cómo demostrarlo y por qué en serverless se disfrazan de 504.'
 image: '/posts/nextjs-memory-leak.png'
 alternate:
     [
@@ -16,7 +16,7 @@ alternate:
     ]
 faq:
     - question: '¿Por qué la memoria de mi servidor Next.js no para de crecer?'
-      answer: 'A julio de 2026 hay tres fugas abiertas en el propio framework (Next.js 15.5–16.3): la caché LRU del router no contabiliza sus claves (issue 94890), el árbol RSC queda retenido por request cuando el cliente corta el stream (issue 94919) y los timeouts del middleware quedan retenidos por el sandbox (issue 95094). Antes de auditar tu código, compara la curva de heap con las URLs únicas, el tráfico total y las rutas concretas: cada fuga tiene una forma distinta.'
+      answer: 'Entre Next.js 15.5 y 16.2 hubo tres fugas en el propio framework: la caché LRU del router no contabilizaba sus claves (issue 94890), el árbol RSC quedaba retenido por request cuando el cliente cortaba el stream (issue 94919) y los timeouts del middleware quedaban retenidos por el sandbox (issue 95094). Las tres están corregidas en 16.3.0, así que lo primero es mirar tu versión. Si estás clavado por debajo, compara la curva de heap con las URLs únicas, el tráfico total y las rutas concretas: cada fuga tiene una forma distinta.'
     - question: '¿Cómo hago un heap snapshot de Next.js en producción?'
       answer: 'Arranca el servidor con NODE_OPTIONS=--inspect, conecta Chrome DevTools al puerto del inspector y toma dos snapshots separados por tráfico en la pestaña Memory; la vista Comparison y los retainers dicen qué objeto crece y quién lo sujeta. Para la build, next build --experimental-debug-memory-usage vuelca snapshots automáticamente y responde a la señal SIGUSR2.'
     - question: '¿Sirve --max-old-space-size para arreglar una fuga de memoria?'
@@ -35,11 +35,15 @@ faq:
 
 ## Respuesta rápida
 
-Si tu servidor Next.js autoalojado crece en memoria hasta morir con `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` — o el contenedor cae con `OOMKilled` (exit code 137) — no empieces auditando tu código. A julio de 2026 hay tres fugas de memoria documentadas y **abiertas en el propio framework**, de Next.js 15.5 a 16.3:
+Si tu servidor Next.js autoalojado crece en memoria hasta morir con `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` — o el contenedor cae con `OOMKilled` (exit code 137) — no empieces auditando tu código. **Mira antes tu versión de Next.js.** Entre la 15.5 y la 16.2 hubo tres fugas de memoria documentadas en el propio framework, y las tres están corregidas en la **16.3.0**:
 
--   **La caché LRU del router no contabiliza sus claves** ([#94890](https://github.com/vercel/next.js/issues/94890)): deriva lenta durante días, proporcional a las URLs únicas que recibes, no a tu tráfico.
--   **El árbol RSC queda retenido por request** ([#94919](https://github.com/vercel/next.js/issues/94919)): crece con el tráfico, mucho peor en Node 22/24 y cuando el cliente corta la conexión a medio stream.
--   **Los `setTimeout` del middleware quedan registrados para siempre** ([#95094](https://github.com/vercel/next.js/issues/95094)): crecimiento a escalones ligado al tráfico que atraviesa el middleware.
+-   **La caché LRU del router no contabilizaba sus claves** ([#94890](https://github.com/vercel/next.js/issues/94890)): deriva lenta durante días, proporcional a las URLs únicas que recibes, no a tu tráfico. Corregida por la [#96229](https://github.com/vercel/next.js/pull/96229).
+-   **El árbol RSC quedaba retenido por request** ([#94919](https://github.com/vercel/next.js/issues/94919)): crece con el tráfico, mucho peor en Node 22/24 y cuando el cliente corta la conexión a medio stream. Corregida por la [#96173](https://github.com/vercel/next.js/pull/96173).
+-   **Los `setTimeout` del middleware quedaban registrados para siempre** ([#95094](https://github.com/vercel/next.js/issues/95094)): crecimiento a escalones ligado al tráfico que atraviesa el middleware. Corregida por la [#96161](https://github.com/vercel/next.js/pull/96161).
+
+Así que el arreglo más corto es actualizar. Si estás clavado por debajo de la 16.3.0 —y muchas apps en producción lo están—, el resto del post es cómo saber cuál de las tres llevas encima, y cómo demostrarlo en vez de suponerlo.
+
+Dos de ellas las medí de forma independiente mientras seguían abiertas, y publiqué los números en las issues: la [#94890 reproducida con una décima parte de la carga original](https://github.com/vercel/next.js/issues/94890#issuecomment-5035231906), y la [#95094 reproducida](https://github.com/vercel/next.js/issues/95094#issuecomment-5035131691) y después [vuelta a medir contra `16.3.0-canary.97` para confirmar que el arreglo aguantaba](https://github.com/vercel/next.js/issues/95094#issuecomment-5081146010). Todo lo que viene es ese método, generalizado.
 
 En serverless (Vercel) casi nunca lo verás como OOM: la instancia se recicla antes. Allí el mismo problema de fondo asoma como un `504 FUNCTION_INVOCATION_TIMEOUT` — me pasó en este blog y más abajo están mis números.
 
@@ -167,9 +171,9 @@ Dos datos honestos de medir las tres: #94890 reprodujo con una décima parte de 
 
 Mi checklist después de este viaje:
 
-1. **Mira los retenedores, no las corazonadas.** `LRUNode`, `reactServerStream` o el `TimeoutsManager` del sandbox en la traza → es una de las tres fugas del framework; súmate al issue con tus datos. Closures y estructuras de tus módulos → es tuyo.
+1. **Mira los retenedores, no las corazonadas.** `LRUNode`, `reactServerStream` o el `TimeoutsManager` del sandbox en la traza → es una de las tres fugas del framework, así que actualiza a la 16.3.0. Closures y estructuras de tus módulos → es tuyo.
 2. **Correlaciona antes de culpar.** Heap que sigue a las URLs únicas → fuga 1. Heap que sigue al tráfico y a los aborts → fuga 2. Escalones con middleware → fuga 3. Una ruta concreta que dispara la curva → casi seguro tu código.
 3. **`--max-old-space-size` no arregla nada** — dimensiona el heap a tu contenedor para no morir antes de tiempo, pero una pendiente monótona acabará chocando contra cualquier límite.
 4. **En serverless, perfila tiempo en vez de memoria.** Si ves 504, busca el trabajo cuadrático o repetido por request; mi caso entero está en el punto anterior.
 
-Las versiones citadas son las de los informes (Next 15.5.11–16.3.0-canary.50, Node 20/22/24, julio de 2026); si lees esto meses después, revisa los tres issues enlazados — con suerte, alguno estará cerrado.
+**Actualización, agosto de 2026.** Los tres issues están cerrados y los arreglos salieron en Next.js 16.3.0 — la #95094 y la #94919 entraron en `16.3.0-canary.97` el 25 de julio; la #94890, dos días después. Las medidas de aquí abajo se tomaron con las fugas aún abiertas, contra las versiones de los informes (Next 15.5.11–16.3.0-canary.50, Node 20/22/24). Se quedan porque el método sobrevive a los bugs: la próxima fuga no traerá un número de issue esperándote, y la forma de encontrarla es la misma.

--- a/data/blog/nextjs-memory-leak/nextjs-memory-leak.gl.mdx
+++ b/data/blog/nextjs-memory-leak/nextjs-memory-leak.gl.mdx
@@ -5,9 +5,9 @@ author: 'Xabier Lameiro'
 category: 'Nextjs'
 tags: ['memory-leak', 'node', 'performance']
 locale: 'gl'
-updated: '2026-07-22'
+updated: '2026-08-06'
 excerpt: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory · OOMKilled (exit code 137) · 504 FUNCTION_INVOCATION_TIMEOUT'
-description: 'Tres fugas de memoria abertas en Next.js 15.5–16.3, como identificar a túa con heap snapshots e por que en serverless a fuga se disfraza dun 504.'
+description: 'As tres fugas de memoria de Next.js que medín e axudei a confirmar, xa corrixidas na 16.3.0: cal tes, como demostralo e por que en serverless se disfrazan dun 504.'
 image: '/posts/nextjs-memory-leak.png'
 alternate:
     [
@@ -16,7 +16,7 @@ alternate:
     ]
 faq:
     - question: 'Por que a memoria do meu servidor Next.js non para de medrar?'
-      answer: 'A xullo de 2026 hai tres fugas abertas no propio framework (Next.js 15.5–16.3): a caché LRU do router non contabiliza as súas chaves (issue 94890), a árbore RSC queda retida por request cando o cliente corta o stream (issue 94919) e os timeouts do middleware quedan retidos polo sandbox (issue 95094). Antes de auditar o teu código, compara a curva de heap coas URLs únicas, o tráfico total e as rutas concretas: cada fuga ten unha forma distinta.'
+      answer: 'Entre Next.js 15.5 e 16.2 houbo tres fugas no propio framework: a caché LRU do router non contabilizaba as súas chaves (issue 94890), a árbore RSC quedaba retida por request cando o cliente cortaba o stream (issue 94919) e os timeouts do middleware quedaban retidos polo sandbox (issue 95094). As tres están corrixidas na 16.3.0, así que o primeiro é mirar a túa versión. Se estás cravado por debaixo, compara a curva de heap coas URLs únicas, o tráfico total e as rutas concretas: cada fuga ten unha forma distinta.'
     - question: 'Como fago un heap snapshot de Next.js en produción?'
       answer: 'Arranca o servidor con NODE_OPTIONS=--inspect, conecta Chrome DevTools ao porto do inspector e toma dous snapshots separados por tráfico na pestana Memory; a vista Comparison e os retainers din que obxecto medra e quen o suxeita. Para a build, next build --experimental-debug-memory-usage volca snapshots automaticamente e responde ao sinal SIGUSR2.'
     - question: 'Serve --max-old-space-size para arranxar unha fuga de memoria?'
@@ -35,11 +35,15 @@ faq:
 
 ## Resposta rápida
 
-Se o teu servidor Next.js autoaloxado medra en memoria ata morrer con `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` — ou o contedor cae con `OOMKilled` (exit code 137) — non empeces auditando o teu código. A xullo de 2026 hai tres fugas de memoria documentadas e **abertas no propio framework**, de Next.js 15.5 a 16.3:
+Se o teu servidor Next.js autoaloxado medra en memoria ata morrer con `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` — ou o contedor cae con `OOMKilled` (exit code 137) — non empeces auditando o teu código. **Mira antes a túa versión de Next.js.** Entre a 15.5 e a 16.2 houbo tres fugas de memoria documentadas no propio framework, e as tres están corrixidas na **16.3.0**:
 
--   **A caché LRU do router non contabiliza as súas chaves** ([#94890](https://github.com/vercel/next.js/issues/94890)): deriva lenta durante días, proporcional ás URLs únicas que recibes, non ao teu tráfico.
--   **A árbore RSC queda retida por request** ([#94919](https://github.com/vercel/next.js/issues/94919)): medra co tráfico, moito peor en Node 22/24 e cando o cliente corta a conexión a medio stream.
--   **Os `setTimeout` do middleware quedan rexistrados para sempre** ([#95094](https://github.com/vercel/next.js/issues/95094)): crecemento a chanzos ligado ao tráfico que atravesa o middleware.
+-   **A caché LRU do router non contabilizaba as súas chaves** ([#94890](https://github.com/vercel/next.js/issues/94890)): deriva lenta durante días, proporcional ás URLs únicas que recibes, non ao teu tráfico. Corrixida pola [#96229](https://github.com/vercel/next.js/pull/96229).
+-   **A árbore RSC quedaba retida por request** ([#94919](https://github.com/vercel/next.js/issues/94919)): medra co tráfico, moito peor en Node 22/24 e cando o cliente corta a conexión a medio stream. Corrixida pola [#96173](https://github.com/vercel/next.js/pull/96173).
+-   **Os `setTimeout` do middleware quedaban rexistrados para sempre** ([#95094](https://github.com/vercel/next.js/issues/95094)): crecemento a chanzos ligado ao tráfico que atravesa o middleware. Corrixida pola [#96161](https://github.com/vercel/next.js/pull/96161).
+
+Así que o arranxo máis curto é actualizar. Se estás cravado por debaixo da 16.3.0 —e moitas apps en produción estano—, o resto do post é como saber cal das tres levas enriba, e como demostralo en vez de supoñelo.
+
+Dúas delas medinas de forma independente mentres seguían abertas, e publiquei os números nos issues: a [#94890 reproducida cunha décima parte da carga orixinal](https://github.com/vercel/next.js/issues/94890#issuecomment-5035231906), e a [#95094 reproducida](https://github.com/vercel/next.js/issues/95094#issuecomment-5035131691) e despois [medida de novo contra `16.3.0-canary.97` para confirmar que o arranxo aguantaba](https://github.com/vercel/next.js/issues/95094#issuecomment-5081146010). Todo o que vén é ese método, xeneralizado.
 
 En serverless (Vercel) case nunca o verás como OOM: a instancia recíclase antes. Alí o mesmo problema de fondo asoma como un `504 FUNCTION_INVOCATION_TIMEOUT` — pasoume neste blog e máis abaixo están os meus números.
 
@@ -167,9 +171,9 @@ Dous datos honestos de medir as tres: #94890 reproduciu cunha décima parte da c
 
 A miña checklist despois desta viaxe:
 
-1. **Mira os retedores, non os presentimentos.** `LRUNode`, `reactServerStream` ou o `TimeoutsManager` do sandbox na traza → é unha das tres fugas do framework; súmate ao issue cos teus datos. Closures e estruturas dos teus módulos → é teu.
+1. **Mira os retedores, non os presentimentos.** `LRUNode`, `reactServerStream` ou o `TimeoutsManager` do sandbox na traza → é unha das tres fugas do framework, así que actualiza á 16.3.0. Closures e estruturas dos teus módulos → é teu.
 2. **Correlaciona antes de culpar.** Heap que segue as URLs únicas → fuga 1. Heap que segue o tráfico e os aborts → fuga 2. Chanzos con middleware → fuga 3. Unha ruta concreta que dispara a curva → case seguro o teu código.
 3. **`--max-old-space-size` non arranxa nada** — dimensiona o heap ao teu contedor para non morrer antes de tempo, pero unha pendente monótona acabará chocando contra calquera límite.
 4. **En serverless, perfila tempo en vez de memoria.** Se ves 504, busca o traballo cuadrático ou repetido por request; o meu caso enteiro está no punto anterior.
 
-As versións citadas son as dos informes (Next 15.5.11–16.3.0-canary.50, Node 20/22/24, xullo de 2026); se les isto meses despois, revisa os tres issues ligados — con sorte, algún estará pechado.
+**Actualización, agosto de 2026.** Os tres issues están pechados e os arranxos saíron en Next.js 16.3.0 — a #95094 e a #94919 entraron en `16.3.0-canary.97` o 25 de xullo; a #94890, dous días despois. As medidas de aquí abaixo tomáronse coas fugas aínda abertas, contra as versións dos informes (Next 15.5.11–16.3.0-canary.50, Node 20/22/24). Quedan porque o método sobrevive aos bugs: a próxima fuga non traerá un número de issue agardando por ti, e a forma de atopala é a mesma.

--- a/data/blog/npm-token/npm-token.en.mdx
+++ b/data/blog/npm-token/npm-token.en.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Fix "Failed to replace env in config: $\{NPM_TOKEN}" in npm and yarn'
+title: 'Fix "Failed to replace env in config: ${NPM_TOKEN}" in npm and yarn'
 slug: 'npm-token-solution-error'
 author: 'Xabier Lameiro'
 category: 'Error'

--- a/data/blog/npm-token/npm-token.gl.mdx
+++ b/data/blog/npm-token/npm-token.gl.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Solución ao erro "Failed to replace env in config: $\{NPM_TOKEN}" en npm e yarn'
+title: 'Solución ao erro "Failed to replace env in config: ${NPM_TOKEN}" en npm e yarn'
 slug: 'npm-token-solucion-erro'
 author: 'Xabier Lameiro'
 category: 'Error'

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -149,17 +149,17 @@
 
   <url>
     <loc>https://xabierlameiro.com/blog/nextjs/nextjs-memory-leak-in-production</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-08-06</lastmod>
   </url>
 
   <url>
     <loc>https://xabierlameiro.com/es/blog/nextjs/fuga-de-memoria-nextjs-en-produccion</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-08-06</lastmod>
   </url>
 
   <url>
     <loc>https://xabierlameiro.com/gl/blog/nextjs/fuga-de-memoria-nextjs-en-producion</loc>
-    <lastmod>2026-07-22</lastmod>
+    <lastmod>2026-08-06</lastmod>
   </url>
 
   <url>

--- a/src/constants/site.ts
+++ b/src/constants/site.ts
@@ -6,7 +6,7 @@ export const defaultLocale = 'en';
 export const author = 'Xabier Lameiro';
 export const authorAlternateName = 'Xabier Lameiro Cardama';
 export const socialNetworks = [
-    'https://www.linkedin.com/in/xlameiro',
+    'https://www.linkedin.com/in/xabierlameiro',
     'https://github.com/xabierlameiro',
     'https://www.reddit.com/user/xlameiro',
     'https://x.com/xlameirodev',
@@ -41,7 +41,7 @@ export const personDescription: Record<string, string> = {
  */
 export const socialLinks = [
     {
-        href: 'https://www.linkedin.com/in/xlameiro',
+        href: 'https://www.linkedin.com/in/xabierlameiro',
         title: 'Linkedin profile',
         name: 'Linkedin',
         testId: 'linkedin-link',

--- a/src/constants/survey.tsx
+++ b/src/constants/survey.tsx
@@ -55,7 +55,7 @@ const CONTACT = {
     phoneLabel: '603 018 268',
     email: 'xabier.lameiro@gmail.com',
     github: 'https://github.com/xabierlameiro',
-    linkedin: 'https://www.linkedin.com/in/xlameiro/',
+    linkedin: 'https://www.linkedin.com/in/xabierlameiro/',
     cv: '/xabierlameiro.com.pdf',
 };
 

--- a/src/intl/messages/en.ts
+++ b/src/intl/messages/en.ts
@@ -11,7 +11,7 @@ const en = {
     'blog.tags': 'Tags',
     language: 'English',
     'home.breadcrumb': 'Code',
-    'home.seo.title': 'Xabier Lameiro | Software Architect, microcomputing and networks Technician',
+    'home.seo.title': 'Xabier Lameiro | Software Architect · Next.js & React',
     'home.seo.description':
         "I'm a Software Architect with more than 8 years of experience working in the online banking sector, currently specialized in Nextjs and React. Passionate about technology and programming, I like to learn new things and share knowledge with the community.",
     'settings.seo.title': 'Customized language, theme and region preferences for a web application',

--- a/src/intl/messages/en.ts
+++ b/src/intl/messages/en.ts
@@ -18,7 +18,7 @@ const en = {
     'settings.seo.description':
         'Web page for user preferences settings for your experience on the web, allows you to change the language, theme and region',
     'settings.title': 'System Preferences',
-    'settings.desc': 'Software Architect, web applications, microcomputing and networks',
+    'settings.desc': 'Software Architect · Next.js & React',
     'settings.lang': 'Language & Region',
     'settings.langAlt': 'Language & Region Icon',
     'settings.lang.preferred': 'Preferred languages:',

--- a/src/intl/messages/es.ts
+++ b/src/intl/messages/es.ts
@@ -19,7 +19,7 @@ const es = {
     'settings.seo.description':
         'Pagina web de configuración de preferencias de usuario para su experiencia en la web, permite cambiar el idioma, el tema y la región',
     'settings.title': 'Preferencias del sistema',
-    'settings.desc': 'Software Architect, aplicaciones web, microinformática y redes',
+    'settings.desc': 'Software Architect · Next.js y React',
     'settings.lang': 'Idioma y Región',
     'settings.langAlt': 'Icono de Idioma y Región',
     'settings.lang.preferred': 'Idiomas preferidos:',

--- a/src/intl/messages/es.ts
+++ b/src/intl/messages/es.ts
@@ -10,7 +10,7 @@ const es = {
     'blog.readtime': '{readTime, plural, one {# minuto de tiempo de lectura} other {# minutos de tiempo de lectura}}',
     'blog.breadcrumb': 'Notas',
     language: 'Español',
-    'home.seo.title': 'Xabier Lameiro | Software Architect, técnico en microinformática y redes',
+    'home.seo.title': 'Xabier Lameiro | Software Architect · Next.js y React',
     'home.seo.description':
         'Software Architect con más de 8 años de experiencia trabajando en el sector de la banca online, actualmente especializado en Nextjs y React. Apasionado de la tecnología y la programación, me gusta aprender cosas nuevas y compartir conocimientos con la comunidad. ',
     'home.breadcrumb': 'Código',

--- a/src/intl/messages/gl.ts
+++ b/src/intl/messages/gl.ts
@@ -19,7 +19,7 @@ const gl = {
     'settings.seo.description':
         'Páxina web de configuración de preferencias de usuario para a súa experiencia na web, permite cambiar o idioma, o tema e a rexión',
     'settings.title': 'Preferencias do sistema',
-    'settings.desc': 'Software Architect, aplicacións web, microinformática e redes',
+    'settings.desc': 'Software Architect · Next.js e React',
     'settings.lang': 'Idioma e Rexión',
     'settings.langAlt': 'Icono de Idioma e Rexión',
     'settings.lang.preferred': 'Idiomas preferidos:',

--- a/src/intl/messages/gl.ts
+++ b/src/intl/messages/gl.ts
@@ -10,7 +10,7 @@ const gl = {
     'blog.readtime': '{readTime, plural, one {# minuto de tempo de lectura} other {# minutos de tempo de lectura}}',
     'blog.breadcrumb': 'Notas',
     language: 'Galego',
-    'home.seo.title': 'Xabier Lameiro | Software Architect, técnico en microinformática e redes',
+    'home.seo.title': 'Xabier Lameiro | Software Architect · Next.js e React',
     'home.breadcrumb': 'Código',
     'home.seo.description':
         'Software Architect con máis de 8 anos de experiencia traballando no sector da banca online, actualmente especializado en Nextjs e React. Apasionado da tecnoloxía e a programación, gustame aprender cousas novas e compartir coñecemento coa comunidade. ',


### PR DESCRIPTION
Five SEO fixes on the blog, verified against the built HTML.

**The SERP title was corrupt.** `npm-token`'s frontmatter carried an MDX escape (`$\{NPM_TOKEN}`) that YAML never processes, so the backslash leaked verbatim into `<title>`, `og:title` and `twitter:title`. Search Console, last 90 days: the query `failed to replace env in config` sits at position 4.4 with 93 impressions and **zero clicks**. A visibly broken title is the most likely cause of a 0% CTR at that position. Fixed in `en` and `gl`; the `$\{...}` occurrences in the MDX body stay, where the escape is required and correctly rendered.

**Identity links pointed at a stale vanity URL.** `socialNetworks` feeds `Person.sameAs` in the JSON-LD and named `linkedin.com/in/xlameiro`, which now 301s to `/in/xabierlameiro`. `sameAs` is how the entity is consolidated, so it should name the canonical profile directly rather than lean on a redirect.

**The home title led with a vocational qualification.** "Software Architect, microcomputing and networks Technician" is 75 characters, so the part that matters was truncated in the SERP, and it disagreed with both the GitHub bio and `Person.jobTitle`. Now "Software Architect · Next.js & React" at 52 characters. `settings.desc` aligned to match.

**The memory-leak post claimed three open Next.js issues.** All three closed as completed on 25–27 July — #95094 by PR 96161 and #94919 by PR 96173, both first in `16.3.0-canary.97`; #94890 by PR 96229. Every fix shipped in 16.3.0, the very version the post named as still affected. Reframed rather than patched: the version check leads, each leak names the PR that fixed it, and the independent measurements posted on #94890 and #95094 while they were open are linked from the intro. The diagnostic method stays in full — it applies to the next leak, which will not arrive with an issue number attached.

Sitemap `lastmod` refreshed for the three updated posts.

**Verification:** 338 tests pass, `tsc --noEmit` clean, `next build` exits 0. Built HTML confirms the title renders `${NPM_TOKEN}`, no escape remains anywhere in the output, and all 132 LinkedIn references resolve to the canonical handle.

After merge and deploy, request reindexing of `/blog/error/npm-token-solution-error` in Search Console — that is what converts the title fix into clicks.
