### PR TITLE
fix(seo): redirect wrong-locale post URLs and link listings to canonical categories

### DIFF
--- a/src/components/Blog/PostList/PostList.stories.tsx
+++ b/src/components/Blog/PostList/PostList.stories.tsx
@@ -21,13 +21,13 @@ export const Primary = Template.bind({});
 
 Primary.args = {
     slug: 'post-1',
-    category: 'blog',
     posts: [
         {
             meta: {
                 title: 'The first post',
                 excerpt: 'Resume of the first post',
                 slug: 'post-1',
+                category: 'react',
             },
         },
         {
@@ -35,6 +35,7 @@ Primary.args = {
                 title: 'The second post',
                 excerpt: 'Resume of the second post',
                 slug: 'post-2',
+                category: 'nextjs',
             },
         },
     ],

--- a/src/components/Blog/PostList/__test__/post.test.tsx
+++ b/src/components/Blog/PostList/__test__/post.test.tsx
@@ -14,10 +14,11 @@ describe('PostList', () => {
                     title: 'title',
                     excerpt: 'excerpt',
                     slug: 'slug',
+                    category: 'react',
                 },
             },
         ];
-        render(<PostList posts={posts} slug="slug" category="category" />);
+        render(<PostList posts={posts} slug="slug" />);
         expect(screen.getByTestId('post-list')).toBeInTheDocument();
     });
 
@@ -28,11 +29,46 @@ describe('PostList', () => {
                     title: 'title',
                     excerpt: 'excerpt',
                     slug: 'slug',
+                    category: 'react',
                 },
             },
         ];
-        render(<PostList posts={posts} slug="slug" category="category" />);
+        render(<PostList posts={posts} slug="slug" />);
         expect(screen.getByTestId('post-list')).toBeInTheDocument();
         expect(screen.getByTestId('post-list').children[0].className).toBe('selected');
+    });
+
+    // Each href must come from the post's own category, not from whatever segment the current URL
+    // used. Building them from the route param turned every tag listing into a set of faceted
+    // duplicates that out-linked the canonical, which is what made Google index the facet instead.
+    it('should link each post to its own category, not to the browsed one', () => {
+        const posts = [
+            {
+                meta: {
+                    title: 'Publish the coverage report',
+                    excerpt: 'excerpt',
+                    slug: 'publish-report-testing-react',
+                    category: 'react',
+                },
+            },
+            {
+                meta: {
+                    title: 'Find a memory leak',
+                    excerpt: 'excerpt',
+                    slug: 'nextjs-memory-leak-in-production',
+                    category: 'nextjs',
+                },
+            },
+        ];
+        render(<PostList posts={posts} slug="publish-report-testing-react" />);
+
+        expect(screen.getByTitle('Publish the coverage report')).toHaveAttribute(
+            'href',
+            '/blog/react/publish-report-testing-react'
+        );
+        expect(screen.getByTitle('Find a memory leak')).toHaveAttribute(
+            'href',
+            '/blog/nextjs/nextjs-memory-leak-in-production'
+        );
     });
 });

--- a/src/components/Blog/PostList/index.tsx
+++ b/src/components/Blog/PostList/index.tsx
@@ -1,53 +1,50 @@
 import styles from './post.module.css';
 import Link from 'next/link';
 
+type PostListItem = {
+    meta: {
+        title: string;
+        excerpt: string;
+        slug: string;
+        /**
+         * The post's own primary category. The href is built from this rather than from the route's
+         * `category` param on purpose: on a tag URL the param is the tag, so linking through it
+         * produced a faceted duplicate for every post in the list, out-linking the canonical the page
+         * declares. Google picked one of those facets over the canonical (SDD-009 rules out a 301
+         * here, and a canonical must not be paired with noindex), so the links agree with the
+         * canonical instead.
+         */
+        category: string;
+    };
+};
+
 type Props = {
-    posts?: {
-        meta: {
-            title: string;
-            excerpt: string;
-            slug: string;
-        };
-    }[];
+    posts?: PostListItem[];
     slug?: string | string[];
-    category?: string | string[];
 };
 /**
  * @example
- *     <PostList posts={posts} slug={slug} category={category} />;
+ *     <PostList posts={posts} slug={slug} />;
  *
  * @param {object[]} posts - The list of posts
  * @param {string} slug - The slug is used to highlight the selected post
- * @param {string} category - The category is used to highlight the selected post
  * @returns {JSX.Element}
  */
-const PostList = ({ posts, slug, category }: Props) => {
+const PostList = ({ posts, slug }: Props) => {
     if (!posts) return null;
 
     if (slug && typeof slug == 'object') slug = slug[0];
-    if (category && typeof category == 'object') category = category[0];
 
     return (
         <ul data-testid="post-list" className={styles.list}>
-            {posts.map(
-                (
-                    item: {
-                        meta: {
-                            title: string;
-                            excerpt: string;
-                            slug: string;
-                        };
-                    },
-                    index: number
-                ) => (
-                    <li key={index} className={slug == item.meta.slug ? styles.selected : ''}>
-                        <Link href={`/blog/${category}/${item.meta.slug}`} title={item.meta.title}>
-                            <div className={styles.title}>{item.meta.title}</div>
-                            <div className={styles.excerpt}>{item.meta.excerpt}</div>
-                        </Link>
-                    </li>
-                )
-            )}
+            {posts.map((item: PostListItem, index: number) => (
+                <li key={index} className={slug == item.meta.slug ? styles.selected : ''}>
+                    <Link href={`/blog/${item.meta.category}/${item.meta.slug}`} title={item.meta.title}>
+                        <div className={styles.title}>{item.meta.title}</div>
+                        <div className={styles.excerpt}>{item.meta.excerpt}</div>
+                    </Link>
+                </li>
+            ))}
         </ul>
     );
 };

--- a/src/pages/blog/[category]/[slug].tsx
+++ b/src/pages/blog/[category]/[slug].tsx
@@ -14,7 +14,7 @@ import { AsidePanel, ArticlePanel, NavList, PostList } from '@/components/Blog';
 import usePostComponents from '@/components/Blog/PostByline';
 import Loading from '@/components/RenderManager/Loading';
 import styles from '@/styles/blog.module.css';
-import { clx } from '@/helpers';
+import { clx, getLang } from '@/helpers';
 import dynamic from 'next/dynamic';
 import useWindowResize from '@/hooks/useWindowResize';
 import SEO from '@/components/SEO';
@@ -59,6 +59,8 @@ type Props = {
             title: string;
             excerpt: string;
             slug: string;
+            /** The post's own primary category, so its link is the canonical URL rather than the facet. */
+            category: string;
         };
     }[];
 };
@@ -120,7 +122,7 @@ const PostPage = ({ post, tags, categories, posts }: Props) => {
                         >
                             <AsidePanel />
                             <div className={styles.postLinks}>
-                                <PostList posts={posts} slug={slug} category={category} />
+                                <PostList posts={posts} slug={slug} />
                             </div>
                             {/* SDD-L05: these two rendered with no handleClick, so the only visible
                                 affordance for the side panels did nothing and the real gesture was
@@ -162,6 +164,48 @@ const PostPage = ({ post, tags, categories, posts }: Props) => {
     );
 };
 
+/**
+ * @description A 301 to the post's own canonical URL, for a slug requested under the wrong locale.
+ *
+ * SDD-L04 made `findPostBySlug` filter by locale, so a Spanish slug no longer answers under the
+ * English prefix — it throws, and the page 404s. Right about the URL being wrong, wrong about what to
+ * do next: those URLs had been indexed for months, so the 404 discards the equity they accumulated
+ * and leaves Search Console reporting "No se ha encontrado" on pages still taking real traffic
+ * (/blog/yarn/npm-token-solucion-erro: 43 impressions in 28 days into a dead end). The article did
+ * not disappear, it lives one prefix over.
+ *
+ * So the slug is looked up again without the locale filter, and if it exists elsewhere the request is
+ * redirected instead of dropped. The destination is built from the post's own frontmatter — never
+ * from the request — so it is always the canonical URL, the same one `resolveSeoUrls` emits and the
+ * sitemap submits. A slug that exists in no locale still 404s.
+ *
+ * Caveat worth knowing: two posts can legitimately share a slug across locales (the es and gl
+ * `integracion-continua-con-github-actions-workflow` are spelled identically), and a locale-less
+ * lookup returns whichever comes first in the corpus. Both are translations of the same article, so
+ * either destination is a real page and the redirect is stable per build — it just is not meaningful
+ * to ask which of the two is "the" target.
+ */
+const redirectToPostLocale = (params: { params: { category: string; slug: string } }) => {
+    let post;
+    try {
+        post = getPostBySlug(params);
+    } catch {
+        return null;
+    }
+
+    const { locale: postLocale, category, slug } = post.meta ?? {};
+    if (!postLocale || !category || !slug) return null;
+
+    return {
+        redirect: {
+            destination: `${getLang(postLocale)}/blog/${category.toLowerCase()}/${slug}`,
+            permanent: true,
+        },
+        // Same cadence as a rendered post: the mapping only changes when the content does.
+        revalidate: 86400,
+    } as const;
+};
+
 export const getStaticProps = async (data: {
     params: {
         category: string;
@@ -179,25 +223,11 @@ export const getStaticProps = async (data: {
     try {
         post = getPostBySlug(data, locale);
     } catch {
-        // Retry a missing slug within a minute (e.g. a just-added post), without hammering.
-        return {
-            notFound: true as const,
-            revalidate: 60,
-        };
-    }
+        // Wrong locale rather than unknown slug? Send it to the real article instead of a dead end.
+        const localeRedirect = redirectToPostLocale(data);
+        if (localeRedirect) return localeRedirect;
 
-    /**
-     * SDD-L04. `findPostBySlug` matches on slug or filename only, with no locale filter, and
-     * `fallback: 'blocking'` renders anything unprerendered with a 200. So a Spanish slug answered
-     * under the English prefix — and `resolveSeoUrls` built the canonical from the *router* locale, so
-     * the page self-canonicalised at whatever prefix was asked for. Search Console confirmed the
-     * result: the same Spanish article indexed twice, at /blog/... and /es/blog/..., each claiming
-     * itself canonical. Surface was 45 posts x 3 prefixes.
-     *
-     * Note this is deliberately narrower than it looks. Faceted *category* URLs stay valid (see the
-     * comment below); only a mismatched **locale** 404s.
-     */
-    if (post.meta?.locale && post.meta.locale !== locale) {
+        // Retry a missing slug within a minute (e.g. a just-added post), without hammering.
         return {
             notFound: true as const,
             revalidate: 60,
@@ -218,8 +248,28 @@ export const getStaticProps = async (data: {
     // 29,180 characters `posts` occupied were `content` nobody reads — 82%, shipped to every visitor
     // and growing linearly with the number of posts in a category. The `Props` type above already
     // declared only these three, so the type was honest and the payload was not.
+    /*
+     * `category` here is the *requested* segment, which for a tag URL is the tag, not the post's
+     * category. PostList used to build every href from it, so browsing inside a tag minted a facet
+     * URL for each post in the list — and those links sit in the sidebar of every page, which made
+     * them the most-linked version of each post on the whole site. That is the signal Google weighs
+     * against rel=canonical, and on /blog/testing/publish-report-testing-react it won: Search Console
+     * reports Google picking the facet over the canonical the page itself declares.
+     *
+     * Google's guidance for this is rel=canonical plus *consistent* signals, and explicitly not
+     * noindex (which must not be combined with a canonical, since it can carry over to the target)
+     * and not a 301 here (SDD-009 — that bounced tag clicks out of the blog). So the fix is to stop
+     * contradicting our own canonical: each post carries its own category and PostList links to that.
+     * The facet URL still resolves 200 with the tag-filtered list, so entering a tag still works; what
+     * goes away is minting a new facet URL on every click through that list.
+     */
     const posts = findPostsByCategoryOrTag(locale, category).map(({ meta }) => ({
-        meta: { title: meta.title, excerpt: meta.excerpt, slug: meta.slug },
+        meta: {
+            title: meta.title,
+            excerpt: meta.excerpt,
+            slug: meta.slug,
+            category: meta.category.toLowerCase(),
+        },
     }));
 
     return {


### PR DESCRIPTION
Search Console was reporting two separate problems on the blog. Both come from the same place — the `[category]/[slug]` route treating the requested URL as authoritative — so they are fixed together.

## 1. Wrong-locale post URLs 404'd instead of redirecting

SDD-L04 made `findPostBySlug` filter by locale, so a Galician slug no longer answers under the English prefix. Correct about the URL being wrong, wrong about what to do next: those URLs had been indexed for months, so the 404 discards the equity they accumulated. `/blog/yarn/npm-token-solucion-erro` was taking **43 impressions in 28 days** into a dead end.

The article did not disappear, it lives one prefix over. Now the slug is looked up again without the locale filter and, if it exists elsewhere, the request is redirected to that post's canonical URL. Unknown slugs still 404.

Worth flagging for review: **the existing locale guard inside `getStaticProps` was dead code.** The `catch` above it calls `getPostBySlug(data, locale)`, which already filters by locale and throws, so the 404 was returned before the guard was ever reached. That is why the redirect had to move into the `catch`.

Measured against a clean dev server:

| URL | Before | After |
| --- | --- | --- |
| `/blog/yarn/npm-token-solucion-erro` | 404 | 308 → `/gl/blog/error/npm-token-solucion-erro` |
| `/blog/react/desplegar-storybook-facilmente` | 404 | 308 → `/es/blog/react/desplegar-storybook-facilmente` |
| `/blog/memory-leak/fuga-de-memoria-nextjs-en-producion` | 404 | 308 → `/gl/blog/nextjs/…` |
| `/blog/ssr/erro-non-detectado-react-minificado` | 404 | 308 → `/gl/blog/error/…` |
| `/blog/nope/does-not-exist-at-all` | 404 | 404 |

All four destinations return 200. `/es/blog/yarn/npm-token-solucion-erro` was checked too, to rule out a double locale prefix — it redirects cleanly to `/gl/…`. 308 rather than 301 because `permanent: true`; Google consolidates both identically, as already noted in `next.config.ts`.

This also resolves two of the three posts where Google had picked its own canonical: both were Galician slugs under the English root, and they now transfer signal instead of dying in a 404.

## 2. Internal links contradicted the canonical the page declares

Search Console showed Google indexing `/blog/testing/publish-report-testing-react` over the `/blog/react/…` canonical that page itself declares.

`PostList` built every href as `` `/blog/${category}/${slug}` `` from the **route** param. On a tag URL that param is the tag, so a tag listing minted a faceted duplicate for each post in it — and that listing sits in the sidebar of every page. The facets ended up more internally linked than the canonical, which is the signal Google was weighing.

Each post now carries its own category and links to that.

### Why not a 301, and why not noindex

Both obvious fixes were ruled out before writing any code:

- **301 facet → canonical** is documented in `[slug].tsx` as having already broken tag navigation once (SDD-009). The faceted URL is the only way into a tag.
- **`noindex` on facets** is explicitly discouraged by Google for this exact case — ["Google doesn't recommend using noindex to prevent selection of a canonical page within a single site"](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls) — and [must not be paired with `rel=canonical`](https://developers.google.com/search/docs/crawling-indexing/canonicalization-troubleshooting), since the directive can carry over to the target.

What Google does ask for is `rel=canonical` plus *consistent* signals, which is what this does.

### Deliberately left in place

The tag sidebar (`getAllTags` in `fileReader.ts`) still links `/blog/<tag>/<slug>` from every page. That is one link per tag instead of N per listing, so the pressure drops a lot but not to zero. It stays because it is the **only** entry point to tag browsing — pointing it at the canonical would remove the feature. If Google still prefers the facet after a recrawl, the next lever is the 301, and it costs tag navigation. That is a product call, not a technical one.

No promise that this flips the canonical on `/blog/testing/publish-report-testing-react`: it removes the contradiction that caused it, but the decision is Google's and shows up over weeks.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npx jest` — 70 suites, 339 tests passing
- `NEXT_PUBLIC_DOMAIN=https://xabierlameiro.com npm run build` — clean
- Redirect and 404 behaviour probed against a dev server with a cleared ISR cache (the table above; an earlier run read `x-nextjs-cache: HIT` and had to be redone)
- Tag navigation confirmed in the browser on `/blog/ci/npm-token-solution-error`: the tag stays highlighted, its 4 posts still list, and every href is now `/blog/nextjs/…`, `/blog/error/…`, `/blog/react/…` rather than `/blog/ci/…`

## Note for the reviewer

The build regenerates `public/sitemap.xml`, `public/feed*.xml` and `public/llms*.txt`. Those were restored so this diff stays surgical. Doing so surfaced an unrelated pre-existing issue: the committed sitemap lists `contador-de-estrelas-de-github` (one "l") while the real Galician slug has two. Production rebuilds the file, so it is repo hygiene rather than a live bug — tracked separately.
