### PR TITLE
test(e2e): assert home titles from the message catalogues instead of copied literals

### DIFF
--- a/e2e/landing-page.test.ts
+++ b/e2e/landing-page.test.ts
@@ -1,4 +1,5 @@
 import { socialLinks } from '@/constants/site';
+import en from '../src/intl/messages/en';
 import { expect, test } from './fixtures';
 
 /**
@@ -22,8 +23,16 @@ test.describe('Landing page', () => {
         await page.goto('/');
     });
 
+    /*
+     * Asserted against the message catalogue rather than a copied literal. The previous version
+     * inlined the title text, so when #184 rewrote it for the SERP the assertion kept checking a
+     * string the site no longer served and the suite went red on master — a test failing for the one
+     * reason a test should never fail, that the copy it duplicated moved on without it. Reading the
+     * value from the same place the page reads it keeps the check ("the home renders its SEO title")
+     * while removing the duplication that made it brittle.
+     */
     test('should navigate to landing page', async ({ page }) => {
-        await expect(page).toHaveTitle(/Software Architect, microcomputing and networks Technician/);
+        await expect(page).toHaveTitle(en['home.seo.title']);
     });
 
     /**

--- a/e2e/routes.test.ts
+++ b/e2e/routes.test.ts
@@ -1,3 +1,6 @@
+import en from '../src/intl/messages/en';
+import es from '../src/intl/messages/es';
+import gl from '../src/intl/messages/gl';
 import { expect, test } from './fixtures';
 
 /**
@@ -194,10 +197,17 @@ test.describe('RSS feeds', () => {
 test.describe('Locales', () => {
     test.describe.configure({ mode: 'parallel' });
 
+    /*
+     * Taken from the three catalogues rather than copied out of them. As literals these went stale
+     * the moment #184 rewrote the SERP titles, and the suite failed on master for a change that was
+     * intentional. The point of the check is that the three prefixes serve three *different*
+     * languages, which the catalogues express directly — and they cannot drift from the page,
+     * because the page renders these same values.
+     */
     const HOME_TITLE = {
-        '/': /microcomputing and networks Technician/,
-        '/es': /técnico en microinformática y redes/,
-        '/gl': /técnico en microinformática e redes/,
+        '/': en['home.seo.title'],
+        '/es': es['home.seo.title'],
+        '/gl': gl['home.seo.title'],
     };
 
     for (const [path, title] of Object.entries(HOME_TITLE)) {


### PR DESCRIPTION
Four E2E tests have been failing **on master**, not on any one branch. They surfaced on #186, but that PR only touched the blog route — the failures predate it.

## What broke

`#184` rewrote the home page SERP titles. The assertions had the old text copied into them:

```ts
// e2e/landing-page.test.ts
await expect(page).toHaveTitle(/Software Architect, microcomputing and networks Technician/);

// e2e/routes.test.ts
const HOME_TITLE = {
    '/':   /microcomputing and networks Technician/,
    '/es': /técnico en microinformática y redes/,
    '/gl': /técnico en microinformática e redes/,
};
```

The site now serves `Xabier Lameiro | Software Architect · Next.js & React` (and `· Next.js y React` / `· Next.js e React`). Nothing was wrong with the page — the tests were checking a string that had been deliberately replaced, which is the one reason a test should never fail.

Evidence it is not #186: the new title arrives in `a48e275` (#184), which is an ancestor of that branch, and the two spec files were last touched in `f6ae258`, before it.

## The fix

Read the value from the same place the page reads it:

```ts
await expect(page).toHaveTitle(en['home.seo.title']);
```

and for the locale sweep, the three catalogues directly. Each test keeps exactly what it was for — the home renders its SEO title, and the three prefixes serve three different languages — but the copy can now be rewritten without the suite going red.

Imports are relative rather than aliased: there is no `@/intl/*` mapping in `tsconfig.json`, and `src/intl/translations.ts` and its unit test already import these catalogues relatively, so this follows the existing convention rather than adding a path alias for two test files.

## Verification

Run against a production build (`npm run build && npm start`), which is what the Playwright `webServer` does in CI:

- The 4 previously failing tests: **pass**
- Full E2E suite: **86/86 pass**
- `npx jest`: 70 suites, 339 tests pass
- `npm run lint`: clean
- `npm run typecheck`: clean

## Not addressed here

The `Linting` job also fails, and it is unrelated to both this PR and #186. Its `Linter` and `Type check` steps pass; what fails is `Security audit (production dependencies)`, on two advisories in transitive dependencies:

- **1138114** — js-yaml quadratic CPU in `!!omap` resolution, pulled in by `gray-matter` (`js-yaml@3.15.0`)
- **1138813** — nanoid indefinite loop with a zero `size`, pulled in by `next` → `postcss` (`nanoid@3.3.16`)

`scripts/audit-gate.ts` wants either a fix or a dated `ALLOWLIST` entry justifying why each is unreachable. That is a security judgement about this project's exposure, so it is deliberately left for a human rather than silently allowlisted here.
