### PR TITLE
fix(blog): restore tag navigation broken by the canonical link change

### DIFF
--- a/src/components/Blog/PostList/PostList.stories.tsx
+++ b/src/components/Blog/PostList/PostList.stories.tsx
@@ -21,13 +21,13 @@ export const Primary = Template.bind({});
 
 Primary.args = {
     slug: 'post-1',
+    category: 'blog',
     posts: [
         {
             meta: {
                 title: 'The first post',
                 excerpt: 'Resume of the first post',
                 slug: 'post-1',
-                category: 'react',
             },
         },
         {
@@ -35,7 +35,6 @@ Primary.args = {
                 title: 'The second post',
                 excerpt: 'Resume of the second post',
                 slug: 'post-2',
-                category: 'nextjs',
             },
         },
     ],

--- a/src/components/Blog/PostList/__test__/post.test.tsx
+++ b/src/components/Blog/PostList/__test__/post.test.tsx
@@ -14,11 +14,10 @@ describe('PostList', () => {
                     title: 'title',
                     excerpt: 'excerpt',
                     slug: 'slug',
-                    category: 'react',
                 },
             },
         ];
-        render(<PostList posts={posts} slug="slug" />);
+        render(<PostList posts={posts} slug="slug" category="category" />);
         expect(screen.getByTestId('post-list')).toBeInTheDocument();
     });
 
@@ -29,46 +28,46 @@ describe('PostList', () => {
                     title: 'title',
                     excerpt: 'excerpt',
                     slug: 'slug',
-                    category: 'react',
                 },
             },
         ];
-        render(<PostList posts={posts} slug="slug" />);
+        render(<PostList posts={posts} slug="slug" category="category" />);
         expect(screen.getByTestId('post-list')).toBeInTheDocument();
         expect(screen.getByTestId('post-list').children[0].className).toBe('selected');
     });
 
-    // Each href must come from the post's own category, not from whatever segment the current URL
-    // used. Building them from the route param turned every tag listing into a set of faceted
-    // duplicates that out-linked the canonical, which is what made Google index the facet instead.
-    it('should link each post to its own category, not to the browsed one', () => {
+    /*
+     * The regression #186 shipped, pinned so it cannot come back: every link has to stay inside the
+     * segment being browsed. When they were rebuilt from each post's own category, clicking a post
+     * inside a tag listing jumped to /blog/<that post's category>/… and the sidebar deselected the
+     * tag, which made walking a tag impossible.
+     */
+    it('should keep the browsed segment in every link so the tag stays selected', () => {
         const posts = [
             {
                 meta: {
                     title: 'Publish the coverage report',
                     excerpt: 'excerpt',
                     slug: 'publish-report-testing-react',
-                    category: 'react',
                 },
             },
             {
                 meta: {
-                    title: 'Find a memory leak',
+                    title: 'Deploying my storybook',
                     excerpt: 'excerpt',
-                    slug: 'nextjs-memory-leak-in-production',
-                    category: 'nextjs',
+                    slug: 'deploying-my-storybook-is-very-simple',
                 },
             },
         ];
-        render(<PostList posts={posts} slug="publish-report-testing-react" />);
+        render(<PostList posts={posts} slug="publish-report-testing-react" category="ci" />);
 
         expect(screen.getByTitle('Publish the coverage report')).toHaveAttribute(
             'href',
-            '/blog/react/publish-report-testing-react'
+            '/blog/ci/publish-report-testing-react',
         );
-        expect(screen.getByTitle('Find a memory leak')).toHaveAttribute(
+        expect(screen.getByTitle('Deploying my storybook')).toHaveAttribute(
             'href',
-            '/blog/nextjs/nextjs-memory-leak-in-production'
+            '/blog/ci/deploying-my-storybook-is-very-simple',
         );
     });
 });

--- a/src/components/Blog/PostList/index.tsx
+++ b/src/components/Blog/PostList/index.tsx
@@ -6,40 +6,46 @@ type PostListItem = {
         title: string;
         excerpt: string;
         slug: string;
-        /**
-         * The post's own primary category. The href is built from this rather than from the route's
-         * `category` param on purpose: on a tag URL the param is the tag, so linking through it
-         * produced a faceted duplicate for every post in the list, out-linking the canonical the page
-         * declares. Google picked one of those facets over the canonical (SDD-009 rules out a 301
-         * here, and a canonical must not be paired with noindex), so the links agree with the
-         * canonical instead.
-         */
-        category: string;
     };
 };
 
 type Props = {
     posts?: PostListItem[];
     slug?: string | string[];
+    /**
+     * The taxonomy segment currently being browsed — a category on a canonical URL, a tag on a
+     * faceted one. Links are built from it so the segment survives a click, which is what keeps the
+     * sidebar highlighting the tag you opened.
+     *
+     * #186 built these from each post's own category instead, to stop the tag listing minting a
+     * faceted duplicate per post. It did stop that, and it also broke the feature: clicking a post
+     * inside a tag listing moved the selection to that post's *category*, so the tag you were
+     * browsing deselected itself and there was no way to walk a tag. Reverted — the duplicate URLs
+     * were the price of this menu working, and the real fix is to stop carrying taxonomy in the path
+     * at all rather than to make the links disagree with the page you are on.
+     */
+    category?: string | string[];
 };
 /**
  * @example
- *     <PostList posts={posts} slug={slug} />;
+ *     <PostList posts={posts} slug={slug} category={category} />;
  *
  * @param {object[]} posts - The list of posts
  * @param {string} slug - The slug is used to highlight the selected post
+ * @param {string} category - The taxonomy segment being browsed, preserved in every link
  * @returns {JSX.Element}
  */
-const PostList = ({ posts, slug }: Props) => {
+const PostList = ({ posts, slug, category }: Props) => {
     if (!posts) return null;
 
     if (slug && typeof slug == 'object') slug = slug[0];
+    if (category && typeof category == 'object') category = category[0];
 
     return (
         <ul data-testid="post-list" className={styles.list}>
             {posts.map((item: PostListItem, index: number) => (
                 <li key={index} className={slug == item.meta.slug ? styles.selected : ''}>
-                    <Link href={`/blog/${item.meta.category}/${item.meta.slug}`} title={item.meta.title}>
+                    <Link href={`/blog/${category}/${item.meta.slug}`} title={item.meta.title}>
                         <div className={styles.title}>{item.meta.title}</div>
                         <div className={styles.excerpt}>{item.meta.excerpt}</div>
                     </Link>

--- a/src/pages/blog/[category]/[slug].tsx
+++ b/src/pages/blog/[category]/[slug].tsx
@@ -59,8 +59,6 @@ type Props = {
             title: string;
             excerpt: string;
             slug: string;
-            /** The post's own primary category, so its link is the canonical URL rather than the facet. */
-            category: string;
         };
     }[];
 };
@@ -122,7 +120,7 @@ const PostPage = ({ post, tags, categories, posts }: Props) => {
                         >
                             <AsidePanel />
                             <div className={styles.postLinks}>
-                                <PostList posts={posts} slug={slug} />
+                                <PostList posts={posts} slug={slug} category={category} />
                             </div>
                             {/* SDD-L05: these two rendered with no handleClick, so the only visible
                                 affordance for the side panels did nothing and the real gesture was
@@ -248,28 +246,8 @@ export const getStaticProps = async (data: {
     // 29,180 characters `posts` occupied were `content` nobody reads — 82%, shipped to every visitor
     // and growing linearly with the number of posts in a category. The `Props` type above already
     // declared only these three, so the type was honest and the payload was not.
-    /*
-     * `category` here is the *requested* segment, which for a tag URL is the tag, not the post's
-     * category. PostList used to build every href from it, so browsing inside a tag minted a facet
-     * URL for each post in the list — and those links sit in the sidebar of every page, which made
-     * them the most-linked version of each post on the whole site. That is the signal Google weighs
-     * against rel=canonical, and on /blog/testing/publish-report-testing-react it won: Search Console
-     * reports Google picking the facet over the canonical the page itself declares.
-     *
-     * Google's guidance for this is rel=canonical plus *consistent* signals, and explicitly not
-     * noindex (which must not be combined with a canonical, since it can carry over to the target)
-     * and not a 301 here (SDD-009 — that bounced tag clicks out of the blog). So the fix is to stop
-     * contradicting our own canonical: each post carries its own category and PostList links to that.
-     * The facet URL still resolves 200 with the tag-filtered list, so entering a tag still works; what
-     * goes away is minting a new facet URL on every click through that list.
-     */
     const posts = findPostsByCategoryOrTag(locale, category).map(({ meta }) => ({
-        meta: {
-            title: meta.title,
-            excerpt: meta.excerpt,
-            slug: meta.slug,
-            category: meta.category.toLowerCase(),
-        },
+        meta: { title: meta.title, excerpt: meta.excerpt, slug: meta.slug },
     }));
 
     return {


### PR DESCRIPTION
**Fixes a regression I shipped in #186.** The tag menu is broken on master right now.

## The bug

Click a tag → its posts list correctly. Click one of those posts → the sidebar deselects the tag and highlights that post's **category** instead. There is no way to walk a tag any more.

#186 rebuilt the post-list links from each post's own category rather than from the segment being browsed, so that a tag listing would stop minting a faceted duplicate per post. It did stop that. It also made every link inside a tag listing point out of the tag.

Reverted, with a regression test pinning it:

```ts
render(<PostList posts={posts} slug="publish-report-testing-react" category="ci" />);
expect(screen.getByTitle('Publish the coverage report'))
    .toHaveAttribute('href', '/blog/ci/publish-report-testing-react');
```

**The locale 301s from #186 are untouched.** That part was independent, correct, and is the half of that PR that actually worked.

## Why the revert is the right move rather than another attempt

Putting the taxonomy in the path is the root cause, and it makes every available lever a dead end:

- **301 facet → canonical** breaks tag navigation (SDD-009 already recorded this).
- **`noindex` on facets** is [explicitly discouraged by Google](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls) for choosing a canonical within one site, and [must not be paired with `rel=canonical`](https://developers.google.com/search/docs/crawling-indexing/canonicalization-troubleshooting).
- **Making internal links disagree with the page they sit on** — what #186 did — breaks the feature, as this PR demonstrates.
- **`robots.txt`** cannot help: `/blog/<tag>/<slug>` is the same shape as `/blog/<category>/<slug>`, so no pattern excludes one without the other.

That last point is the actual insight. [Google's faceted-navigation guidance](https://developers.google.com/crawling/docs/faceted-navigation) is written around facets as **query parameters** — it recommends `disallow: /*?*color=` style rules — precisely because a parameter can be excluded and a path segment cannot.

So the fix is not a cleverer directive on these URLs. It is to stop generating them: keep the post at its canonical path and carry the browsed tag in a query parameter, which leaves one crawlable path per post and makes a 301 on the legacy facets safe, since navigation would no longer depend on them. That is a design change and does not belong in a hotfix — tracked separately.

Worth noting the scale here: GSC lists 13 URLs under "Alternate page with proper canonical tag", which is [normal and not an error](https://reddit.com/r/TechSEO/comments/1kr0map/alternate_page_with_proper_canonical_tag/), and Google overrode the canonical on exactly one live URL. This was never urgent enough to justify breaking the menu.

## Not a duplicate-content problem: the three languages

For the record, since it came up: three languages at three URLs is not duplicate content and needs no fixing. Google [recommends exactly that](https://developers.google.com/search/docs/specialty/international/localized-versions) — a distinct URL per language, `hreflang` between them, self-referencing canonical on each. This repo already does it. The two issues were being conflated; only the tag-in-the-path one is real.

## Verification

- `npx jest`: 70 suites, 339 tests pass (includes the new regression test)
- `npm run lint`, `npm run typecheck`: clean
- Manually, in the browser: from `/blog/ci/npm-token-solution-error`, clicking "Deploying my storybook" keeps the URL at `/blog/ci/deploying-my-storybook-is-very-simple`, keeps **`ci` selected** in the sidebar, highlights the clicked post, and leaves the canonical correctly pointing at `/blog/react/deploying-my-storybook-is-very-simple`.
