### PR TITLE
feat(seo): link the Person entity to its Wikidata item via sameAs

### DIFF
--- a/src/constants/site.ts
+++ b/src/constants/site.ts
@@ -6,6 +6,11 @@ export const defaultLocale = 'en';
 export const author = 'Xabier Lameiro';
 export const authorAlternateName = 'Xabier Lameiro Cardama';
 export const socialNetworks = [
+    // The Wikidata item (Q141178217) carries the full legal name as its label, which this site only
+    // ever states as `alternateName`. Listing it here makes the link reciprocal — the item points
+    // back at this domain through P856 (official website) — and a reciprocal link is what lets a
+    // search engine merge the two records into one entity instead of treating them as two people.
+    'https://www.wikidata.org/wiki/Q141178217',
     'https://www.linkedin.com/in/xabierlameiro',
     'https://github.com/xabierlameiro',
     'https://www.reddit.com/user/xlameiro',


### PR DESCRIPTION
## What

Adds `https://www.wikidata.org/wiki/Q141178217` to `socialNetworks`, which feeds `sameAs` on the Person JSON-LD in `_document.tsx`.

## Why

A Wikidata item for this person was created today (`Q141178217`). It already points back at this domain through `P856` (official website). Search engines merge two records into one Knowledge Graph entity when the link is **reciprocal**, so declaring it here closes the loop.

Second reason: the item's label is `Xabier Lameiro Cardama`. This site deliberately keeps `Xabier Lameiro` as the one canonical name form (SDD-004 A1) and states the full legal name only as `alternateName`. Right now, searching the exact string "Xabier Lameiro Cardama" on google.es does **not** return xabierlameiro.com in the top 10 — a third-party page ranks first. The Wikidata item gives that name form a corroborating source outside this domain without touching the SDD-004 decision.

## Checks

- `npm run typecheck` — pass
- `npm test` — 140 suites, 678 tests, all pass
- `npx eslint src/constants/site.ts` — clean
- `npx prettier --check` — clean

## Note, unrelated to this change

`npm run lint` reports ~10.3k errors, **all** of them from `.claude/worktrees/gracious-kirch-3aadfc/`. That path is in `.git/info/exclude` so git ignores it, but eslint still walks it. Outside that directory the lint is clean. Worth adding to `.eslintignore`/`ignores` separately.