### PR TITLE
fix(lint): stop eslint and jest from walking Claude Code worktrees

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,12 @@ export default tseslint.config(
             // produced ~9,000 errors as soon as the suite had been run locally.
             'playwright-report/**',
             'test-results/**',
+            // Claude Code worktrees. Same failure mode as playwright-report above, from the other
+            // direction: the path sits in .git/info/exclude, so git ignores it, but flat config
+            // reads neither .gitignore nor git's exclude files — `eslint .` walked a second full
+            // checkout of this repo and reported ~10,300 errors. CI never saw it, because the
+            // directory is never committed, so local and CI disagreed on whether the lint passed.
+            '.claude/**',
         ],
     },
     js.configs.recommended,
@@ -126,5 +132,5 @@ export default tseslint.config(
         rules: {
             'sonarjs/slow-regex': 'off',
         },
-    }
+    },
 );

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,10 @@ const customJestConfig = {
         'src/components/Blog/index.tsx',
         'migration/',
     ],
-    testPathIgnorePatterns: ['e2e', 'migration'],
+    // '<rootDir>/.claude/' keeps Claude Code worktrees out of the run. Without it jest discovered
+    // 140 suites where the repo has 70: every test ran twice, once per checkout. Same root cause as
+    // the '.claude/**' entry in eslint.config.mjs.
+    testPathIgnorePatterns: ['e2e', 'migration', '<rootDir>/.claude/'],
     coverageDirectory: 'public/coverage',
     // SDD-L01. Coverage was collected and published for a long time without any threshold, so
     // nothing stopped it sliding. These numbers are the floor MEASURED on 2026-07-26 after the


### PR DESCRIPTION
## Problem

`.claude/worktrees/gracious-kirch-3aadfc/` is a second, complete git worktree of this repo. It is listed in `.git/info/exclude`, so **git** ignores it — but eslint flat config and jest both read neither `.gitignore` nor git's exclude files, and walked it as source.

- `npm run lint` → **10,328 errors**, every single one from that path. Outside it, zero.
- `npx jest --listTests` → **140 suites** for a repo that has 70. Every test ran twice.

CI never saw either, because the directory is never committed. So CI was green while the local lint was unusable — the two disagreed on whether the code passes, which is the actual damage.

## Fix

One ignore entry each, mirroring the `playwright-report/**` precedent already in `eslint.config.mjs` (added for exactly this failure mode).

## After

| | before | after |
|---|---|---|
| `npm run lint` | 10,328 errors | clean |
| jest suites | 140 | 70 |
| suite time | 11.9s | 5.0s |

`npm run typecheck` clean. `npm run coverage` passes, thresholds unchanged — the duplicate checkout was never counted toward coverage, only toward runtime.

## One line that is not mine

Prettier added a trailing comma at the end of `eslint.config.mjs`. That file already failed `prettier --check` on `master` before this branch; running `--write` on it fixed the pre-existing issue as a side effect. Say the word and I split it out.