### PR TITLE
test(seo): add a throwaway route for the indexability guard to watch

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -236,4 +236,8 @@
     <loc>https://xabierlameiro.com/gl/blog/error/erro-non-detectado-react-minificado</loc>
     <lastmod>2026-08-06</lastmod>
   </url>
+  <url>
+    <loc>https://xabierlameiro.com/guard-probe</loc>
+    <lastmod>2026-09-02</lastmod>
+  </url>
 </urlset>

--- a/src/pages/guard-probe.tsx
+++ b/src/pages/guard-probe.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import SEO from '@/components/SEO';
+
+/**
+ * A page that exists to be broken on purpose, once.
+ *
+ * The indexability guard has never proved itself against this site: every run
+ * since it was deployed has found nothing wrong, which is good for the site and
+ * useless as evidence. Its acceptance criterion is a deliberate `noindex` on a
+ * route nobody minds, confirming that exactly one notification arrives naming
+ * the commit that caused it — and that criterion has gone unmet since the
+ * change was written.
+ *
+ * So this route ships indexable, gets watched, then gets a `noindex` in a
+ * second commit. If the guard is real, it says so and names that commit.
+ *
+ * **Delete this page once the guard has spoken.** It carries no content, and a
+ * page that exists only to be watched is worth exactly one experiment.
+ */
+const GuardProbe = () => (
+    <>
+        <SEO
+            meta={{
+                title: 'Guard probe',
+                description:
+                    'Temporary page used once to verify the indexability guard reports a deliberate regression.',
+            }}
+        />
+
+        <main>
+            <h1>Guard probe</h1>
+            <p>
+                This page exists to verify that the indexability guard notices when a deploy makes a page
+                non-indexable. It has no other purpose and will be removed.
+            </p>
+        </main>
+    </>
+);
+
+export default GuardProbe;


### PR DESCRIPTION
The indexability guard has watched this site since July and found nothing
wrong. Good for the site, useless as evidence: its acceptance criterion is a
deliberate regression on a route nobody minds, confirming exactly one
notification arrives naming the commit that caused it. That has never been run.

This is step one of two. The route ships **indexable** and enters the sitemap,
so the guard starts watching it and records a healthy baseline. A second PR
makes it `noindex`, and the guard should then name that commit.

Both the page and its sitemap entry come out afterwards. It carries no content
and ranks for nothing.

> This PR was created with AI assistance.