### PR TITLE
test(seo): make the probe route noindex, on purpose

### DIFF
--- a/src/pages/guard-probe.tsx
+++ b/src/pages/guard-probe.tsx
@@ -24,6 +24,10 @@ const GuardProbe = () => (
                 title: 'Guard probe',
                 description:
                     'Temporary page used once to verify the indexability guard reports a deliberate regression.',
+                // The deliberate regression. This page was indexable when the
+                // guard recorded its baseline; this commit is the one it
+                // should name.
+                noindex: true,
             }}
         />
 


### PR DESCRIPTION
Step two of two. #201 added `/guard-probe` and the guard recorded it as
healthy — baseline established at `33e3ab9`, `index,follow,max-image-preview:large`
on all three locales.

This commit makes it `noindex`. The guard should detect the regression on its
next run and send a notification naming **this** commit as the cause.

If nothing arrives, that is the more useful result: it means the guard has been
reporting nothing because it cannot see anything, not because there is nothing
to see.

Both this and the route come out afterwards.

> This PR was created with AI assistance.