### PR TITLE
docs(blog): move the 16.3.0 update under the quick answer and point to #97776

### DIFF
--- a/data/blog/nextjs-memory-leak/nextjs-memory-leak.en.mdx
+++ b/data/blog/nextjs-memory-leak/nextjs-memory-leak.en.mdx
@@ -5,7 +5,7 @@ author: 'Xabier Lameiro'
 category: 'Nextjs'
 tags: ['memory-leak', 'node', 'performance']
 locale: 'en'
-updated: '2026-08-06'
+updated: '2026-09-05'
 excerpt: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory · OOMKilled (exit code 137) · 504 FUNCTION_INVOCATION_TIMEOUT'
 description: 'The three Next.js memory leaks I measured and helped confirm, all fixed in 16.3.0: which one you have, how to prove it, and why serverless hides them as 504s.'
 image: '/posts/nextjs-memory-leak.png'
@@ -34,6 +34,8 @@ faq:
 <GoogleAdsense />
 
 ## Quick answer
+
+**Update, September 2026.** All three issues below are closed and the fixes shipped in Next.js 16.3.0 (#95094 and #94919 landed in `16.3.0-canary.97` on 25 July, #94890 two days later). The measurements were taken while they were still open, against the versions cited in the reports (Next 15.5.11–16.3.0-canary.50, Node 20/22/24), and they stay here because the method outlives the bugs. If you're on 16.3.x and still growing, you're on a different one: the open `use cache` retention is tracked in [vercel/next.js#97776](https://github.com/vercel/next.js/issues/97776) and its fix isn't in any stable release yet. To find out which route is growing and what holds the memory, run `npx next-leak .` ([source and limits](https://github.com/xabierlameiro/next-leak)).
 
 If your self-hosted Next.js server grows until it dies with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` — or the container gets `OOMKilled` (exit code 137) — don't start by auditing your own code. **Check your Next.js version first.** Between 15.5 and 16.2 there were three documented memory leaks in the framework itself, and all three are fixed in **16.3.0**:
 
@@ -175,5 +177,3 @@ My checklist after this trip:
 2. **Correlate before you blame.** Heap tracking unique URLs → leak 1. Heap tracking traffic and aborts → leak 2. Steps with middleware → leak 3. One specific route driving the curve → almost certainly your code.
 3. **`--max-old-space-size` fixes nothing** — size the heap to your container so you don't die early, but a monotonic slope will eventually hit any limit.
 4. **On serverless, profile time instead of memory.** If you're seeing 504s, hunt for quadratic or repeated per-request work; my whole case is in the previous section.
-
-**Update, August 2026.** All three issues are now closed and the fixes shipped in Next.js 16.3.0 — #95094 and #94919 landed in `16.3.0-canary.97` on 25 July, #94890 two days later. The measurements below were taken while they were still open, against the versions cited in the reports (Next 15.5.11–16.3.0-canary.50, Node 20/22/24). They stay here because the method outlives the bugs: the next leak will not have an issue number waiting for you, and the way you find it is the same.

--- a/data/blog/nextjs-memory-leak/nextjs-memory-leak.es.mdx
+++ b/data/blog/nextjs-memory-leak/nextjs-memory-leak.es.mdx
@@ -5,7 +5,7 @@ author: 'Xabier Lameiro'
 category: 'Nextjs'
 tags: ['memory-leak', 'node', 'performance']
 locale: 'es'
-updated: '2026-08-06'
+updated: '2026-09-05'
 excerpt: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory · OOMKilled (exit code 137) · 504 FUNCTION_INVOCATION_TIMEOUT'
 description: 'Las tres fugas de memoria de Next.js que medí y ayudé a confirmar, ya corregidas en 16.3.0: cuál tienes, cómo demostrarlo y por qué en serverless se disfrazan de 504.'
 image: '/posts/nextjs-memory-leak.png'
@@ -34,6 +34,8 @@ faq:
 <GoogleAdsense />
 
 ## Respuesta rápida
+
+**Actualización, septiembre de 2026.** Los tres issues de abajo están cerrados y los arreglos salieron en Next.js 16.3.0 (la #95094 y la #94919 entraron en `16.3.0-canary.97` el 25 de julio; la #94890, dos días después). Las medidas se tomaron con las fugas aún abiertas, contra las versiones de los informes (Next 15.5.11–16.3.0-canary.50, Node 20/22/24), y se quedan porque el método sobrevive a los bugs. Si estás en 16.3.x y sigues creciendo, tienes otra: la retención abierta de `use cache` se sigue en [vercel/next.js#97776](https://github.com/vercel/next.js/issues/97776) y su arreglo aún no está en ninguna versión estable. Para saber qué ruta crece y qué retiene la memoria, ejecuta `npx next-leak .` ([código y límites](https://github.com/xabierlameiro/next-leak)).
 
 Si tu servidor Next.js autoalojado crece en memoria hasta morir con `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` — o el contenedor cae con `OOMKilled` (exit code 137) — no empieces auditando tu código. **Mira antes tu versión de Next.js.** Entre la 15.5 y la 16.2 hubo tres fugas de memoria documentadas en el propio framework, y las tres están corregidas en la **16.3.0**:
 
@@ -175,5 +177,3 @@ Mi checklist después de este viaje:
 2. **Correlaciona antes de culpar.** Heap que sigue a las URLs únicas → fuga 1. Heap que sigue al tráfico y a los aborts → fuga 2. Escalones con middleware → fuga 3. Una ruta concreta que dispara la curva → casi seguro tu código.
 3. **`--max-old-space-size` no arregla nada** — dimensiona el heap a tu contenedor para no morir antes de tiempo, pero una pendiente monótona acabará chocando contra cualquier límite.
 4. **En serverless, perfila tiempo en vez de memoria.** Si ves 504, busca el trabajo cuadrático o repetido por request; mi caso entero está en el punto anterior.
-
-**Actualización, agosto de 2026.** Los tres issues están cerrados y los arreglos salieron en Next.js 16.3.0 — la #95094 y la #94919 entraron en `16.3.0-canary.97` el 25 de julio; la #94890, dos días después. Las medidas de aquí abajo se tomaron con las fugas aún abiertas, contra las versiones de los informes (Next 15.5.11–16.3.0-canary.50, Node 20/22/24). Se quedan porque el método sobrevive a los bugs: la próxima fuga no traerá un número de issue esperándote, y la forma de encontrarla es la misma.

--- a/data/blog/nextjs-memory-leak/nextjs-memory-leak.gl.mdx
+++ b/data/blog/nextjs-memory-leak/nextjs-memory-leak.gl.mdx
@@ -5,7 +5,7 @@ author: 'Xabier Lameiro'
 category: 'Nextjs'
 tags: ['memory-leak', 'node', 'performance']
 locale: 'gl'
-updated: '2026-08-06'
+updated: '2026-09-05'
 excerpt: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory · OOMKilled (exit code 137) · 504 FUNCTION_INVOCATION_TIMEOUT'
 description: 'As tres fugas de memoria de Next.js que medín e axudei a confirmar, xa corrixidas na 16.3.0: cal tes, como demostralo e por que en serverless se disfrazan dun 504.'
 image: '/posts/nextjs-memory-leak.png'
@@ -34,6 +34,8 @@ faq:
 <GoogleAdsense />
 
 ## Resposta rápida
+
+**Actualización, setembro de 2026.** Os tres issues de abaixo están pechados e os arranxos saíron en Next.js 16.3.0 (a #95094 e a #94919 entraron en `16.3.0-canary.97` o 25 de xullo; a #94890, dous días despois). As medidas tomáronse coas fugas aínda abertas, contra as versións dos informes (Next 15.5.11–16.3.0-canary.50, Node 20/22/24), e quedan porque o método sobrevive aos bugs. Se estás en 16.3.x e segues crecendo, tes outra: a retención aberta de `use cache` séguese en [vercel/next.js#97776](https://github.com/vercel/next.js/issues/97776) e o seu arranxo aínda non está en ningunha versión estable. Para saber que ruta crece e que retén a memoria, executa `npx next-leak .` ([código e límites](https://github.com/xabierlameiro/next-leak)).
 
 Se o teu servidor Next.js autoaloxado medra en memoria ata morrer con `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` — ou o contedor cae con `OOMKilled` (exit code 137) — non empeces auditando o teu código. **Mira antes a túa versión de Next.js.** Entre a 15.5 e a 16.2 houbo tres fugas de memoria documentadas no propio framework, e as tres están corrixidas na **16.3.0**:
 
@@ -175,5 +177,3 @@ A miña checklist despois desta viaxe:
 2. **Correlaciona antes de culpar.** Heap que segue as URLs únicas → fuga 1. Heap que segue o tráfico e os aborts → fuga 2. Chanzos con middleware → fuga 3. Unha ruta concreta que dispara a curva → case seguro o teu código.
 3. **`--max-old-space-size` non arranxa nada** — dimensiona o heap ao teu contedor para non morrer antes de tempo, pero unha pendente monótona acabará chocando contra calquera límite.
 4. **En serverless, perfila tempo en vez de memoria.** Se ves 504, busca o traballo cuadrático ou repetido por request; o meu caso enteiro está no punto anterior.
-
-**Actualización, agosto de 2026.** Os tres issues están pechados e os arranxos saíron en Next.js 16.3.0 — a #95094 e a #94919 entraron en `16.3.0-canary.97` o 25 de xullo; a #94890, dous días despois. As medidas de aquí abaixo tomáronse coas fugas aínda abertas, contra as versións dos informes (Next 15.5.11–16.3.0-canary.50, Node 20/22/24). Quedan porque o método sobrevive aos bugs: a próxima fuga non traerá un número de issue agardando por ti, e a forma de atopala é a mesma.


### PR DESCRIPTION
## Why

React Status #484 links `nextjs-memory-leak-in-production`. Readers land on "Quick answer", which still describes the three issues as open; the "fixed in 16.3.0" note sat at the very end of the post and the CLI was only mentioned in "How I measured this".

## What

- Move the update paragraph to the top of "Quick answer" in `en`, `es` and `gl`.
- Rewrite it as of September 2026: the three issues are fixed in 16.3.0; if you are on 16.3.x and still growing, the open `use cache` retention is vercel/next.js#97776 and its fix is in no stable release yet; `npx next-leak .` tells you which route grows and what holds the memory.
- `updated` frontmatter → 2026-09-05.

No other content changes.

## Verified

- `npm test`, `npm run typecheck`, `npm run build` on the branch (see PR comment for the run).
